### PR TITLE
Fix proof for Proposition 8.13(->)

### DIFF
--- a/src/hott/1-paths.md
+++ b/src/hott/1-paths.md
@@ -478,3 +478,40 @@ This is a literate `rzk` file:
   : a0 = a13    
   := 13ary-concat A a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13  
       p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 
+```
+
+## Products
+
+```rzk
+#def path-product
+  (A B : U)
+  (a a' : A)
+  (b b' : B)
+  (e_A : a = a')
+  (e_B : b = b')
+  : (a, b) =_{prod A B} (a', b')
+  := transport A (\x -> (a, b) =_{prod A B} (x, b')) a a' e_A
+      (transport B (\y -> (a, b) =_{prod A B} (a, y)) b b' e_B refl)
+
+#def first-path-product
+  (A B : U)
+  (x y : prod A B)
+  (e : x =_{prod A B} y)
+  : first x = first y
+  := ap (prod A B) A x y (\z -> first z) e
+
+#def second-path-product
+  (A B : U)
+  (x y : prod A B)
+  (e : x =_{prod A B} y)
+  : second x = second y
+  := ap (prod A B) B x y (\z -> second z) e
+
+#def first-path-sigma
+  (A : U)
+  (B : A -> U)
+  (x y : ∑ (a : A), B a)
+  (e : x =_{∑ (a : A), B a} y)
+  : first x = first y
+  := ap (∑ (a : A), B a) A x y (\z -> first z) e
+```

--- a/src/hott/4-contractible.md
+++ b/src/hott/4-contractible.md
@@ -127,4 +127,41 @@ A type equivalent to a contractible type is contractible.
         Biscontr
 ```   
 
+## Contractible products
 
+```rzk
+#def isContr-product
+  (A B : U)
+  (AisContr : isContr A)
+  (BisContr : isContr B)
+  : isContr (prod A B)
+  := ((first AisContr, first BisContr), \p ->
+    path-product A B
+      (first AisContr) (first p)
+      (first BisContr) (second p)
+      (second AisContr (first p))
+      (second BisContr (second p))
+      )
+
+#def first-isContr-product
+  (A B : U)
+  (AxBisContr : isContr (prod A B))
+  : isContr A
+  := (first (first AxBisContr), \a ->
+    first-path-product A B
+      (first AxBisContr)
+      (a, second (first AxBisContr))
+      (second AxBisContr (a, second (first AxBisContr))))
+
+#def first-isContr-sigma
+  (A : U)
+  (B : A -> U)
+  (b : (a : A) -> B a)
+  (ABisContr : isContr (∑ (a : A), B a))
+  : isContr A
+  := (first (first ABisContr), \a -> 
+        first-path-sigma A B
+          (first ABisContr)
+          (a, b a)
+          (second ABisContr (a, b a)))
+```

--- a/src/hott/5-sigma.md
+++ b/src/hott/5-sigma.md
@@ -181,5 +181,19 @@ Products distribute inside a Sigma type:
     : Eq (prod A (∑ (b : B), C b)) (∑ (b : B), prod A (C b))
     := (\(a, (b, c)) -> (b, (a, c)), 
             ((\(b, (a, c)) -> (a, (b, c)), \z -> refl), 
-            (\(b, (a, c)) -> (a, (b, c)), \z -> refl)))        
+            (\(b, (a, c)) -> (a, (b, c)), \z -> refl))) 
+```
+
+## Associativity
+
+```rzk
+#def assoc
+    (A : U)
+    (B : A -> U)
+    (C : (a : A) -> B a -> U)
+    : Eq (∑ (a : A), ∑ (b : B a), C a b)
+         (∑ (ab : ∑ (a : A), B a), C (first ab) (second ab))
+    := (\(a, (b, c)) -> ((a, b), c),
+        ((\((a, b), c) -> (a, (b, c)), \_ -> refl),
+         (\((a, b), c) -> (a, (b, c)), \_ -> refl)))
 ```

--- a/src/simplicial-hott/8-covariant.md
+++ b/src/simplicial-hott/8-covariant.md
@@ -489,15 +489,26 @@ The proof of the claimed converse result given in the original source is circula
 #def representable-isCovFam-isSegal
 	(A : U)
 	(repiscovfam : (a : A) -> isCovFam A (\x -> hom A a x))
-	(AisSegal : isSegal A)
 	: isSegal A
-	:= \x y z f g -> isEquiv-toContr-isContr
-			(∑ (h : hom A x z), (hom2 A x y z f g h))
+	:= \x y z f g -> first-isContr-sigma
+		(∑ (h : hom A x z), hom2 A x y z f g h)
+		(\hk -> ∑ (v : hom A x z), hom2 A x x z (id-arr A x) v (first hk))
+		(\hk -> (first hk, \(t, s) -> first hk s))
+		(isEquiv-toContr-isContr
+			(∑ (hk : ∑ (h : hom A x z), hom2 A x y z f g h), ∑ (v : hom A x z), hom2 A x x z (id-arr A x) v (first hk))
 			(representable-dhomFrom A x y z g f)
 			(sym_Eq (representable-dhomFrom A x y z g f)
-				(∑ (h : hom A x z), (hom2 A x y z f g h))
-				(isSegal-representable-dhomFrom-hom2 A AisSegal x y z g f))
-			(repiscovfam x y z g f)
+				(∑ (hk : ∑ (h : hom A x z), hom2 A x y z f g h), ∑ (v : hom A x z), hom2 A x x z (id-arr A x) v (first hk))
+				(compose_Eq
+					(representable-dhomFrom A x y z g f)
+					(∑ (h : hom A x z), (prod (hom2 A x y z f g h) (∑ (v : hom A x z), hom2 A x x z (id-arr A x) v h)))
+					(∑ (hk : ∑ (h : hom A x z), hom2 A x y z f g h), ∑ (v : hom A x z), hom2 A x x z (id-arr A x) v (first hk))
+					(representable-dhomFrom-hom2-dist A x y z g f)
+					(assoc
+						(hom A x z)
+						(\h -> hom2 A x y z f g h)
+						(\h _ -> ∑ (v : hom A x z), hom2 A x x z (id-arr A x) v h))))
+			(repiscovfam x y z g f))
 ```
 
 ## Covariant lifts, transport, and uniqueness


### PR DESCRIPTION
This PR fixes `representable-isCovFam-isSegal` formalisation to not rely on `AisSegal`.
The idea is straightforward:

1. We first follow the same equivalences as in `(->)` direction to get from covariance condition to a contractible type of form `∑ (a : A), prod (B a) (C a)` where `C a` is inhabited for all `a`. More precisely, this type:
<img width="985" alt="Screenshot 2023-05-11 at 00 05 53" src="https://github.com/emilyriehl/yoneda/assets/686582/b6bdd597-27fe-4cea-973f-ad521cc87f22">

2. We use associativity to get to a contractible type `∑ (ab : ∑ (a : A), B a), C (first ab)`.

3. Now, since the type is contractible and `C (first ab)` is inhabited for all `ab`, we show that `∑ (a : A), B a` is also contractible. But this is exactly the Segal condition we are trying to prove!

NOTE: some cleanup required, e.g. I did not do any documentation.