### PR TITLE
Switch to Material theme for MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,8 @@
 site_name: 'yoneda'
+repo_url: https://github.com/emilyriehl/yoneda
+repo_name: emilyriehl/yoneda
+edit_uri: edit/master/src
+
 docs_dir: src
 nav:
   - General:
@@ -61,14 +65,14 @@ theme:
   palette:
     # Palette toggle for light mode
     - media: '(prefers-color-scheme: light)'
-      primary: blue
+      primary: indigo
       scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
     - media: '(prefers-color-scheme: dark)'
-      primary: blue
+      primary: indigo
       scheme: slate
       toggle:
         icon: material/brightness-4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,14 +23,61 @@ nav:
       - Discrete Types: simplicial-hott/07-discrete.rzk.md
       - Covariantly Functorial Type Families: simplicial-hott/08-covariant.rzk.md
       - The Yoneda Lemma: simplicial-hott/09-yoneda.rzk.md
+      - Rezk Types: simplicial-hott/10-rezk-types.rzk.md
       - Cocartesian Families: simplicial-hott/12-cocartesian.rzk.md
 
 markdown_extensions:
+  - admonition
+  - footnotes
+  - pymdownx.details
   - mdx_math
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 theme:
-  name: readthedocs
-  highlights: false # we override default highlights in custom_theme/
-  custom_dir: custom_theme/
-extra_css:
-  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+  features:
+    - content.code.copy
+    - content.action.edit
+    - navigation.footer
+    - navigation.sections
+    - navigation.path
+  palette:
+    # Palette toggle for light mode
+    - media: '(prefers-color-scheme: light)'
+      primary: blue
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: '(prefers-color-scheme: dark)'
+      primary: blue
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+extra_javascript:
+  - javascript/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+plugins:
+  - search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+mkdocs-material
 python-markdown-math
+pygments-rzk


### PR DESCRIPTION
This pull request switches generated documentation to Material theme for MkDocs. The motivation is that it offers many more features and is more customizable compared to ReadTheDocs theme (currently used). Feedback is welcome!

- [x] Switch to a different theme
- [x] Dark/light themes with a switch
- [x] Page's table of contents on the right (can be customized, moved to the left, leaving more space for page's content)
- [x] Switch to [`pygments-rzk`](https://github.com/fizruk/pygments-rzk) for highlighting.
  - Syntax highlighting is temporarily worse, but will be fixed and maintained
  - The same syntax highlighting can be used with LaTeX (via `minted` package)
- [x] Support a lot of extensions, including titles for code blocks (e.g. to reference definitions/theorems in papers). See [Reference for Material](https://squidfunk.github.io/mkdocs-material/reference/) for different markup features.
- [x] Permalinks for sections
- [x] GitHub repository link and info
- [x] Edit buttons to go directly to editing on GitHub

Before:

<img width="1792" alt="Screenshot 2023-07-01 at 01 31 19" src="https://github.com/emilyriehl/yoneda/assets/686582/7798bc15-176b-4c67-b55a-f99ab47e9f52">

After:

<img width="1792" alt="Screenshot 2023-07-01 at 01 30 27" src="https://github.com/emilyriehl/yoneda/assets/686582/a3132983-f56b-4bf9-8f1d-bad8081c6d6f">
