### PR TITLE
Dependent yoneda

### DIFF
--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -235,8 +235,8 @@ witnesses of the equivalence).
 #def equiv-horn-restriction
   (A : U)
   : Equiv
-    ( {t : 2 * 2 | Δ² t} -> A)
-    ( Σ ( k : {t : 2 * 2 | Λ t} -> A) ,
+    ( Δ² -> A)
+    ( Σ ( k : Λ -> A) ,
         ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
             ( hom2 A
               ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
@@ -244,12 +244,12 @@ witnesses of the equivalence).
               ( h))))
   :=
     ( \ k ->
-      ( \{t : 2 * 2 | Λ t} -> k t ,
+      ( \ {t : 2 * 2 | Λ t} -> k t ,
         ( \ (t : 2) -> k (t , t) ,
-          \{t : 2 * 2 | Δ² t} -> k t)) ,
-      ( ( \ khh -> \{t : 2 * 2 | Δ² t} -> (second (second khh)) t ,
+          \ {t : 2 * 2 | Δ² t} -> k t)) ,
+      ( ( \ khh -> \  {t : 2 * 2 | Δ² t} -> (second (second khh)) t ,
           \ k -> refl_{k}) ,
-        ( \ khh -> \{t : 2 * 2 | Δ² t} -> (second (second khh)) t ,
+        ( \ khh -> \  {t : 2 * 2 | Δ² t} -> (second (second khh)) t ,
           \ k -> refl_{k})))
 ```
 
@@ -257,20 +257,20 @@ witnesses of the equivalence).
 #def Segal-equiv-horn-restriction
   (A : U)
   (is-segal-A : is-segal A)
-  : Equiv ({t : 2 * 2 | Δ² t} -> A) ({t : 2 * 2 | Λ t} -> A)
+  : Equiv (Δ² -> A) (Λ -> A)
   :=
     comp-equiv
-      ( { t : 2 * 2 | Δ² t} -> A)
-      ( Σ ( k : {t : 2 * 2 | Λ t} -> A) ,
+      ( Δ² -> A)
+      ( Σ ( k : Λ -> A) ,
           ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
                 ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
                 ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
                 ( h))))
-      ( {t : 2 * 2 | Λ t} -> A)
+      ( Λ -> A)
       ( equiv-horn-restriction A)
       ( total-space-projection
-        ( {t : 2 * 2 | Λ t} -> A )
+        ( Λ -> A )
         ( \ k ->
           Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
             ( hom2 A
@@ -278,7 +278,7 @@ witnesses of the equivalence).
               ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
               ( h))) ,
       ( is-equiv-projection-contractible-fibers
-          ( {t : 2 * 2 | Λ t} -> A)
+          ( Λ -> A)
           ( \ k ->
             Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
@@ -319,7 +319,7 @@ Types that are local at the horn inclusion are Segal types:
   :=
     \ x y z f g ->
     contractible-fibers-is-equiv-projection
-      (  {t : 2 * 2 | Λ t} -> A )
+      (  Λ -> A )
       ( \ k ->
         Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
           ( hom2 A
@@ -329,7 +329,7 @@ Types that are local at the horn inclusion are Segal types:
             ( h)))
       ( second
         ( comp-equiv
-          ( Σ ( k :  {t : 2 * 2 | Λ t} -> A ) ,
+          ( Σ ( k : Λ -> A ) ,
             Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
                 ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
@@ -376,18 +376,18 @@ all $x$ then $(x : X) → A x$ is a Segal type.
   (fiberwise-is-segal-A : (x : X) -> is-local-horn-inclusion (A x))
   : is-local-horn-inclusion ((x : X) -> A x)
   := triple-compose-is-equiv
-       ({t : 2 * 2 | Δ² t} -> ((x : X) -> A x) )
-       ((x : X) -> {t : 2 * 2 | Δ² t} -> A x )
-       ((x : X) -> {t : 2 * 2 | Λ t} -> A x )
-       ({t : 2 * 2 | Λ t} -> ((x : X) -> A x) )
-        (\ g -> \ x -> \{t : 2 * 2 | Δ² t} -> g t x) -- first equivalence
+       (Δ² -> ((x : X) -> A x) )
+       ((x : X) -> Δ² -> A x )
+       ((x : X) -> Λ -> A x )
+       (Λ -> ((x : X) -> A x) )
+        (\ g -> \ x -> \ {t : 2 * 2 | Δ² t} -> g t x) -- first equivalence
             (second (flip-ext-fun
               (2 * 2)
               Δ² (\{t : 2 * 2 | Δ² t} -> BOT)
               X
-              (\{t : 2 * 2 | Δ² t} -> A)
-              (\{t : 2 * 2 | BOT} -> recBOT)))
-        (\ h -> \ x -> \{t : 2 * 2 | Λ t} -> h x t) -- second equivalence
+              (\ {t : 2 * 2 | Δ² t} -> A)
+              (\ {t : 2 * 2 | BOT} -> recBOT)))
+        (\ h -> \ x -> \ {t : 2 * 2 | Λ t} -> h x t) -- second equivalence
           (second (function-equiv-fibered-equiv
               funext
               X
@@ -397,10 +397,10 @@ all $x$ then $(x : X) → A x$ is a Segal type.
         (\ h -> \{t : 2 * 2 | Λ t} -> \ x -> (h x) t) -- third equivalence
           (second(flip-ext-fun-inv
             (2 * 2)
-            Λ (\{t : 2 * 2 | Λ t} -> BOT)
+            Λ (\ {t : 2 * 2 | Λ t} -> BOT)
             X
-            (\{t : 2 * 2 | Λ t} -> A)
-            (\{t : 2 * 2 | BOT} -> recBOT)))
+            (\ {t : 2 * 2 | Λ t} -> A)
+            (\ {t : 2 * 2 | BOT} -> recBOT)))
 ```
 
 If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $x$

--- a/src/simplicial-hott/12-cocartesian.rzk.md
+++ b/src/simplicial-hott/12-cocartesian.rzk.md
@@ -99,14 +99,14 @@ is-rezk (P b)) (e : P b) (e' : P b') (f : dhom B b b' u P e e') (fiscocart :
 isCocartArr B b b' u P e e' f) : is-contr (CocartLift B b b' u P e) := ( (e' , f
 , fiscocart) , \ d -> \ g ->
 
-## Initial objects
+## Final objects
 
 ```rzk
-#def is-initial
-    (A : U)
-    (a : A)
-    : U
-    := (x : A) -> is-contr (hom A a x)
+#def is-final
+  (A : U)
+  (a : A)
+  : U
+  := (x : A) -> is-contr (hom A x a)
 ```
 
 In a Segal type, initial objects are isomorphic.
@@ -137,16 +137,6 @@ In a Segal type, initial objects are isomorphic.
               ( first (binitial a))
               ( first (ainitial b)))
             ( id-arr A b))))
-```
-
-## Final objects
-
-```rzk
-#def is-final
-  (A : U)
-  (a : A)
-  : U
-  := (x : A) -> is-contr (hom A x a)
 ```
 
 In a Segal type, final objects are isomorphic.


### PR DESCRIPTION
This adds a proof of the dependent Yoneda lemma and the lemmas that precede it. For this I needed to move the definition of initial objects into the Yoneda file. Later, I'll add the dual result and move final objects in there as well.

One naming question: I have a mild preference for the more grammatical 

```rzk
A-is-segal : is-segal A
```
rather than

```rzk
is-segal-A : is-segal A
```
because I think it means the proofs are slightly nicer to read. But if someone has feelings either way I'd like to hear about them.
