### PR TITLE
Change fizruk to rzk-lang where appropriate

### DIFF
--- a/.github/workflows/rzk.yml
+++ b/.github/workflows/rzk.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check all files
-        uses: fizruk/rzk-action@v1
+        uses: rzk-lang/rzk-action@v1
         with:
           rzk-version: latest
           # rzk-version: v0.4.1.1   # example of a specific version

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ the aim of proving the Yoneda lemma for ∞-categories following the paper
 "[Could ∞-category theory be taught to undergraduates?](https://www.ams.org/journals/notices/202305/noti2692/noti2692.html)"
 [2].
 
-The formalizations are implemented using [`rzk`](https://github.com/fizruk/rzk),
-an experimental proof assistant for a variant of type theory with shapes
-developed by [Nikolai Kudasov](https://fizruk.github.io/). Formalizations were
-contributed by [Fredrik Bakke](https://github.com/fredrik-bakke),
+The formalizations are implemented using
+[`rzk`](https://github.com/rzk-lang/rzk), an experimental proof assistant for a
+variant of type theory with shapes developed by
+[Nikolai Kudasov](https://fizruk.github.io/). Formalizations were contributed by
+[Fredrik Bakke](https://github.com/fredrik-bakke),
 [Nikolai Kudasov](https://fizruk.github.io/),
 [Emily Riehl](https://emilyriehl.github.io/), and
 [Jonathan Weinberger](https://sites.google.com/view/jonathanweinberger). The
@@ -40,11 +41,12 @@ non-univalent 1-categories in HoTT.
 
 ## Checking the Formalisations Locally
 
-Install the [`rzk`](https://github.com/fizruk/rzk) proof assistant. Then run the
-following command from the root of this repository:
+Install the
+[`rzk`](https://rzk-lang.github.io/rzk/latest/getting-started/install/) proof
+assistant. Then run the following command from the root of this repository:
 
 ```sh
-stack exec rzk typecheck src/hott/* src/simplicial-hott/*
+rzk typecheck src/hott/* src/simplicial-hott/*
 ```
 
 # References

--- a/src/index.md
+++ b/src/index.md
@@ -7,10 +7,11 @@ the aim of proving the Yoneda lemma for ∞-categories following the paper
 "[Could ∞-category theory be taught to undergraduates?](https://www.ams.org/journals/notices/202305/noti2692/noti2692.html)"
 [2].
 
-The formalizations are implemented using [`rzk`](https://github.com/fizruk/rzk),
-an experimental proof assistant for a variant of type theory with shapes
-developed by [Nikolai Kudasov](https://fizruk.github.io/). Formalizations were
-contributed by [Fredrik Bakke](https://github.com/fredrik-bakke),
+The formalizations are implemented using
+[`rzk`](https://github.com/rzk-lang/rzk), an experimental proof assistant for a
+variant of type theory with shapes developed by
+[Nikolai Kudasov](https://fizruk.github.io/). Formalizations were contributed by
+[Fredrik Bakke](https://github.com/fredrik-bakke),
 [Nikolai Kudasov](https://fizruk.github.io/),
 [Emily Riehl](https://emilyriehl.github.io/), and
 [Jonathan Weinberger](https://sites.google.com/view/jonathanweinberger). Our
@@ -35,12 +36,13 @@ non-univalent 1-categories in HoTT.
 
 ## Checking the Formalisations Locally
 
-Install the [`rzk`](https://github.com/fizruk/rzk) proof assistant. Then run the
-following command from the root of
-[our repository](https://github.com/emilyriehl/):
+Install the
+[`rzk`](https://rzk-lang.github.io/rzk/latest/getting-started/install/) proof
+assistant. Then run the following command from the root of
+[our repository](https://github.com/emilyriehl/yoneda):
 
 ```sh
-stack exec rzk typecheck src/hott/* src/simplicial-hott/*
+rzk typecheck src/hott/* src/simplicial-hott/*
 ```
 
 ## References

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -136,7 +136,7 @@ This is a literate `rzk` file:
 
 ```rzk title="RS17, Theorem 4.4"
 -- Reformulated via tope disjunction instead of inclusion.
--- See https://github.com/fizruk/rzk/issues/8
+-- See https://github.com/rzk-lang/rzk/issues/8
 #def cofibration-composition'
   ( I : CUBE)
   ( χ ψ ϕ : I -> TOPE)


### PR DESCRIPTION
The `rzk` proof assistant and other satellite tools (such as VS Code extension, highlighters, GitHub Actions) now reside under https://github.com/rzk-lang organisation. This PR updates references correspondingly.

I also update instructions for running `rzk` and the link to installation instructions for `rzk`. Please, see updated instructions at https://rzk-lang.github.io/rzk/develop/getting-started/install/ (soon will be updated for the latest released version as well).