### PR TITLE
Unicode syntax

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -17,7 +17,7 @@ The general format of a definition is as follows:
   ( p : x = y)
   ( q : y = z)
   : (x = z)
-  := idJ (A , y , \ z' q' -> (x = z') , p , z , q)
+  := idJ (A , y , \ z' q' → (x = z') , p , z , q)
 ```
 
 - We start with the name, and place every assumption on a new line.
@@ -46,35 +46,35 @@ example about Segal types:
   ( is-local-horn-inclusion-A : is-local-horn-inclusion A)
   : isSegal A
   :=
-    \ x y z f g ->
+    \ x y z f g →
     projection-equiv-contractible-fibers
-      ( < {t : 2 * 2 | Λ t} -> A >)
-      ( \ k ->
-        Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+      ( Λ → A)
+      ( \ k →
+        Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
           ( hom2 A
-            ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-            ( \ t -> k (t , 0_2))
-            ( \ t -> k (1_2 , t))
+            ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+            ( \ t → k (t , 0₂))
+            ( \ t → k (1₂ , t))
             ( h)))
       ( second
         ( comp-equiv
-          ( Σ ( k : < {t : 2 * 2 | Λ t} -> A >) ,
-            Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+          ( Σ ( k : Λ → A ) ,
+            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
               ( hom2 A
-                ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t -> k (t , 0_2))
-                ( \ t -> k (1_2 , t))
+                ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                ( \ t → k (t , 0₂))
+                ( \ t → k (1₂ , t))
                 ( h)))
-          ( < {t : 2 * 2 | Δ² t} -> A >)
-          ( < {t : 2 * 2 | Λ t} -> A >)
+          ( Δ² → A)
+          ( Λ  → A)
           ( inv-equiv
-            ( < {t : 2 * 2 | Δ² t} -> A >)
-            ( Σ ( k : < {t : 2 * 2 | Λ t} -> A >) ,
-              Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+            ( Δ² → A)
+            ( Σ ( k : Λ → A) ,
+              Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
                 ( hom2 A
-                  ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                  ( \ t -> k (t , 0_2))
-                  ( \ t -> k (1_2 , t))
+                  ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                  ( \ t → k (t , 0₂))
+                  ( \ t → k (1₂ , t))
                   ( h)))
             ( equiv-horn-restriction A))
           ( horn-restriction A , is-local-horn-inclusion-A)))
@@ -84,7 +84,7 @@ example about Segal types:
 The root here is the function `projection-equiv-contractible-fibers`. It takes
 four arguments, each starting on a fresh line and is indented an extra level
 from the root. The first argument fits neatly on one line, but the second one is
-too large. In these cases, we add a line break right after the `->`-symbol
+too large. In these cases, we add a line break right after the `→`-symbol
 following the lambda-abstraction, which is the earliest branching point in this
 case. The next node is again `Σ`, with two arguments. The first one fits on a
 line, but the second does not, so we add a line break between them. This process

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -133,6 +133,32 @@ two-space indentation level increases.
   that if you find yourself appealing to this convention frequently, that is a
   sign that your code should be refactored.
 
+- We use Unicode symbols sparingly and only when they align with established
+  mathematical practice.
+
+## Use of Unicode characters
+
+In the defined names we use Unicode symbols sparingly and only when they align
+with established mathematical practice.
+
+For the builtin syntactic features of `rzk` we use the following Unicode
+symbols:
+
+- `->` should be always replaced with `→` (`\to`)
+- `|->` should be always replaced with `↦` (`\mapsto`)
+- `===` should be always replaced with `≡` (`\equiv`)
+- `<=` should be always replaced with `≤` (`\<=`)
+- `/\` should be always replaced with `∧` (`\and`)
+- `\/` should be always replaced with `∨` (`\or`)
+- `0_2` should be always replaced with `0₂` (`0\2`)
+- `1_2` should be always replaced with `1₂` (`1\2`)
+- `I * J` should be always replaced with `I × J` (`\x` or `\times`)
+
+We use ASCII versions for `TOP` and `BOT` since `⊤` and `⊥` do not read better
+in the code. Same for `first` and `second` (`π₁` and `π₂` are not very
+readable). For the latter a lot of uses for projections should go away by using
+pattern matching (and `let`/`where` in the future).
+
 ## Use of Comments
 
 > We do not explicitly ban code comments, but our other conventions should

--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -31,7 +31,7 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 #def iff
   ( A B : U)
   : U
-  := product (A -> B) (B -> A)
+  := product (A → B) (B → A)
 ```
 
 ## Basic function definitions
@@ -42,26 +42,26 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 #variables A B C D : U
 
 #def composition
-  ( g : B -> C)
-  ( f : A -> B)
-  : A -> C
-  := \ z -> g (f z)
+  ( g : B → C)
+  ( f : A → B)
+  : A → C
+  := \ z → g (f z)
 
 #def triple-composition
-  ( h : C -> D)
-  ( g : B -> C)
-  ( f : A -> B)
-  : A -> D
-  := \ z -> h (g (f z))
+  ( h : C → D)
+  ( g : B → C)
+  ( f : A → B)
+  : A → D
+  := \ z → h (g (f z))
 
 #def identity
-  : A -> A
-  := \ a -> a
+  : A → A
+  := \ a → a
 
 #def constant
   ( b : B)
-  : A -> B
-  := \ a -> b
+  : A → B
+  := \ a → b
 
 #end basic-functions
 ```
@@ -73,8 +73,8 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 ```rzk
 #def reindex
   ( A B : U)
-  ( f : B -> A)
-  ( C : A -> U)
-  : B -> U
-  := \ b -> C (f b)
+  ( f : B → A)
+  ( C : A → U)
+  : B → U
+  := \ b → C (f b)
 ```

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -21,7 +21,7 @@ This is a literate `rzk` file:
 #def rev
   ( p : x = y)
   : y = x
-  := idJ (A , x , (\ y' p' -> y' = x) , refl , y , p)
+  := idJ (A , x , (\ y' p' → y' = x) , refl , y , p)
 ```
 
 ### Path concatenation
@@ -34,7 +34,7 @@ our main definition.
   ( p : x = y)
   ( q : y = z)
   : (x = z)
-  := idJ (A , y , \ z' q' -> (x = z') , p , z , q)
+  := idJ (A , y , \ z' q' → (x = z') , p , z , q)
 ```
 
 We also introduce a version defined by induction on the first path variable, for
@@ -43,8 +43,8 @@ situations where it is easier to induct on the first path.
 ```rzk
 #def concat'
   ( p : x = y)
-  : (y = z) -> (x = z)
-  := idJ (A , x , \ y' p' -> (y' = z) -> (x = z) , \ q' -> q' , y , p)
+  : (y = z) → (x = z)
+  := idJ (A , x , \ y' p' → (y' = z) → (x = z) , \ q' → q' , y , p)
 
 #end path-algebra
 ```
@@ -60,7 +60,7 @@ situations where it is easier to induct on the first path.
 #def rev-rev
   ( p : x = y)
   : (rev A y x (rev A x y p)) = p
-  := idJ (A , x , \ y' p' -> (rev A y' x (rev A x y' p')) = p' , refl , y , p)
+  := idJ (A , x , \ y' p' → (rev A y' x (rev A x y' p')) = p' , refl , y , p)
 ```
 
 ### Left unit law for path concatenation
@@ -72,7 +72,7 @@ choice of definition.
 #def left-unit-concat
   ( p : x = y)
   : (concat A x x y refl p) = p
-  := idJ (A , x , \ y' p' -> (concat A x x y' refl p') = p' , refl , y , p)
+  := idJ (A , x , \ y' p' → (concat A x x y' refl p') = p' , refl , y , p)
 ```
 
 ### Associativity of path concatenation
@@ -88,7 +88,7 @@ choice of definition.
     idJ
     ( ( A) ,
       ( y) ,
-      ( \ z' r' ->
+      ( \ z' r' →
         concat A w y z' (concat A w x y p q) r' =
         concat A w x z' p (concat A x y z' q r')) ,
       ( refl) ,
@@ -105,7 +105,7 @@ choice of definition.
     idJ
     ( A ,
       y ,
-      \ z' r' ->
+      \ z' r' →
         concat A w x z' p (concat A x y z' q r') =
         concat A w y z' (concat A w x y p q) r' ,
       refl ,
@@ -119,7 +119,7 @@ choice of definition.
     idJ
     ( A ,
       x ,
-      \ y' p' -> concat A x y' x p' (rev A x y' p') = refl ,
+      \ y' p' → concat A x y' x p' (rev A x y' p') = refl ,
       refl ,
       y ,
       p)
@@ -131,7 +131,7 @@ choice of definition.
     idJ
     ( A ,
       x ,
-      \ y' p' -> concat A y' x y' (rev A x y' p') p' = refl ,
+      \ y' p' → concat A y' x y' (rev A x y' p') p' = refl ,
       refl ,
       y ,
       p)
@@ -164,13 +164,13 @@ Concatenation of two paths with common domain; defined using `concat` and `rev`.
 #def right-cancel-concat
   ( p q : x = y)
   ( r : y = z)
-  : ((concat A x y z p r) = (concat A x y z q r)) -> (p = q)
+  : ((concat A x y z p r) = (concat A x y z q r)) → (p = q)
   :=
     idJ
     ( A ,
       y ,
-      \ z' r' -> ((concat A x y z' p r') = (concat A x y z' q r')) -> (p = q) ,
-      \ H -> H ,
+      \ z' r' → ((concat A x y z' p r') = (concat A x y z' q r')) → (p = q) ,
+      \ H → H ,
       z ,
       r)
 
@@ -196,7 +196,7 @@ of the path algebra coherences defined above.
     idJ
     ( A ,
       y ,
-      \ z' q' ->
+      \ z' q' →
         (rev A x z' (concat A x y z' p q')) =
         (concat A z' y x (rev A y z' q') (rev A x y p)) ,
       rev
@@ -220,7 +220,7 @@ of the path algebra coherences defined above.
     idJ
     ( A ,
       y ,
-      \ z' r' -> (concat A x y z' p r') = (concat A x y z' q r') ,
+      \ z' r' → (concat A x y z' p r') = (concat A x y z' q r') ,
       H ,
       z ,
       r)
@@ -233,20 +233,20 @@ Prewhiskering paths of paths is much harder.
 ```rzk
 #def concat-homotopy
   ( p : x = y)
-  : ( q : y = z) ->
-    ( r : y = z) ->
-    ( H : q = r) ->
+  : ( q : y = z) →
+    ( r : y = z) →
+    ( H : q = r) →
     ( concat A x y z p q) = (concat A x y z p r)
   :=
     idJ
     ( A ,
       x ,
-      \ y' p' ->
-      (q : y' = z) ->
-      (r : y' = z) ->
-      (H : q = r) ->
+      \ y' p' →
+      (q : y' = z) →
+      (r : y' = z) →
+      (H : q = r) →
       (concat A x y' z p' q) = (concat A x y' z p' r) ,
-      \ q r H ->
+      \ q r H →
         concat
           ( x = z)
           ( concat A x x z refl q)
@@ -263,16 +263,16 @@ Prewhiskering paths of paths is much harder.
 ```rzk
 #def concat-concat'
   ( p : x = y)
-  : ( q : y = z) ->
+  : ( q : y = z) →
     ( concat A x y z p q) = (concat' A x y z p q)
   :=
     idJ
     ( A ,
       x ,
-      \ y' p' ->
-        (q' : y' =_{A} z) ->
+      \ y' p' →
+        (q' : y' =_{A} z) →
         (concat A x y' z p' q') =_{x =_{A} z} concat' A x y' z p' q' ,
-      \ q' -> left-unit-concat A x z q' ,
+      \ q' → left-unit-concat A x z q' ,
       y ,
       p)
 
@@ -291,18 +291,18 @@ Prewhiskering paths of paths is much harder.
 #def alt-triangle-rotation
   ( p : x = z)
   ( q : x = y)
-  : ( r : y = z) ->
-    ( H : p = concat' A x y z q r) ->
+  : ( r : y = z) →
+    ( H : p = concat' A x y z q r) →
     ( concat' A y x z (rev A x y q) p) = r
   :=
     idJ
     ( A ,
       x ,
-      \ y' q' ->
-        (r' : y' =_{A} z) ->
-        (H' : p = concat' A x y' z q' r') ->
+      \ y' q' →
+        (r' : y' =_{A} z) →
+        (H' : p = concat' A x y' z q' r') →
         (concat' A y' x z (rev A x y' q') p) = r' ,
-      \ r' H' -> H' ,
+      \ r' H' → H' ,
       y ,
       q)
 ```
@@ -345,22 +345,22 @@ The following needs to be outside the previous section because of the usage of
 #def ap
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   : (f x = f y)
-  := idJ (A , x , \ y' -> \ p' -> (f x = f y') , refl , y , p)
+  := idJ (A , x , \ y' → \ p' → (f x = f y') , refl , y , p)
 
 #def ap-rev
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   : (ap A B y x f (rev A x y p)) = (rev B (f x) (f y) (ap A B x y f p))
   :=
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
         ap A B y' x f (rev A x y' p') = rev B (f x) (f y') (ap A B x y' f p') ,
       refl ,
       y ,
@@ -369,7 +369,7 @@ The following needs to be outside the previous section because of the usage of
 #def ap-concat
   ( A B : U)
   ( x y z : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   ( q : y = z)
   : ( ap A B x z f (concat A x y z p q)) =
@@ -378,7 +378,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       y ,
-      \ z' q' ->
+      \ z' q' →
         (ap A B x z' f (concat A x y z' p q')) =
         (concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q')) ,
       refl ,
@@ -388,14 +388,14 @@ The following needs to be outside the previous section because of the usage of
 #def rev-ap-rev
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   : (rev B (f y) (f x) (ap A B y x f (rev A x y p))) = (ap A B x y f p)
   :=
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
         (rev B (f y') (f x) (ap A B y' x f (rev A x y' p'))) =
         (ap A B x y' f p') ,
       refl ,
@@ -406,7 +406,7 @@ The following needs to be outside the previous section because of the usage of
 #def concat-ap-rev-ap-id
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   : ( concat
       ( B) (f y) (f x) (f y)
@@ -417,7 +417,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
       ( concat
         ( B) (f y') (f x) (f y')
         ( ap A B y' x f (rev A x y' p')) (ap A B x y' f p')) =
@@ -431,13 +431,13 @@ The following needs to be outside the previous section because of the usage of
   ( x y : A)
   ( p : x = y)
   : (ap A A x y (identity A) p) = p
-    := idJ (A , x , \ y' p' -> (ap A A x y' (\ z -> z) p') = p' , refl , y , p)
+    := idJ (A , x , \ y' p' → (ap A A x y' (\ z → z) p') = p' , refl , y , p)
 
 -- application of a function to homotopic paths yields homotopic paths
 #def ap-htpy
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p q : x = y)
   ( H : p = q)
   : (ap A B x y f p) = (ap A B x y f q)
@@ -445,7 +445,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( x = y ,
       p ,
-      \ q' H' -> (ap A B x y f p) = (ap A B x y f q') ,
+      \ q' H' → (ap A B x y f p) = (ap A B x y f q') ,
       refl ,
       q ,
       H)
@@ -453,8 +453,8 @@ The following needs to be outside the previous section because of the usage of
 #def ap-comp
   ( A B C : U)
   ( x y : A)
-  ( f : A -> B)
-  ( g : B -> C)
+  ( f : A → B)
+  ( g : B → C)
   ( p : x = y)
   : ( ap A C x y (composition A B C g f) p) =
     ( ap B C (f x) (f y) g (ap A B x y f p))
@@ -462,8 +462,8 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       x ,
-      \ y' p' ->
-      ( ap A C x y' (\ z -> g (f z)) p') =
+      \ y' p' →
+      ( ap A C x y' (\ z → g (f z)) p') =
       ( ap B C (f x) (f y') g (ap A B x y' f p')) ,
       refl ,
       y ,
@@ -472,15 +472,15 @@ The following needs to be outside the previous section because of the usage of
 #def rev-ap-comp
   ( A B C : U)
   ( x y : A)
-  ( f : A -> B)
-  ( g : B -> C)
+  ( f : A → B)
+  ( g : B → C)
   ( p : x = y)
   : ( ap B C (f x) (f y) g (ap A B x y f p)) =
     ( ap A C x y (composition A B C g f) p)
   :=
     rev
       ( g (f x) = g (f y))
-      ( ap A C x y (\ z -> g (f z)) p)
+      ( ap A C x y (\ z → g (f z)) p)
       ( ap B C (f x) (f y) g (ap A B x y f p))
       ( ap-comp A B C x y f g p)
 ```
@@ -491,7 +491,7 @@ The following needs to be outside the previous section because of the usage of
 #section transport
 
 #variable A : U
-#variable B : A -> U
+#variable B : A → U
 
 -- transport in a type family along a path in the base
 #def transport
@@ -499,7 +499,7 @@ The following needs to be outside the previous section because of the usage of
   ( p : x = y)
   ( u : B x)
   : B y
-  := idJ (A , x , \ y' p' -> B y' , u , y , p)
+  := idJ (A , x , \ y' p' → B y' , u , y , p)
 
 -- The lift of a base path to a path from a term in the total space to its transport.
 #def transport-lift
@@ -511,7 +511,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       x ,
-      \ y' p' -> (x , u) =_{Σ (z : A) , B z} (y' , transport x y' p' u) ,
+      \ y' p' → (x , u) =_{Σ (z : A) , B z} (y' , transport x y' p' u) ,
       refl ,
       y ,
       p)
@@ -528,7 +528,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       y ,
-      \ z' q' ->
+      \ z' q' →
       ( transport x z' (concat A x y z' p q') u) =
       ( transport y z' q' (transport x y p u)) ,
       refl ,
@@ -546,7 +546,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       y ,
-      \ z' q' ->
+      \ z' q' →
       ( transport y z' q' (transport x y p u)) =
       ( transport x z' (concat A x y z' p q') u) ,
       refl ,
@@ -564,7 +564,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( x = y ,
       p ,
-      \ q' H' -> (transport x y p u) = (transport x y q' u) ,
+      \ q' H' → (transport x y p u) = (transport x y q' u) ,
       refl ,
       q ,
       H)
@@ -572,8 +572,8 @@ The following needs to be outside the previous section because of the usage of
 #def transport-loop
   ( a : A)
   ( b : B a)
-  : (a = a) -> B a
-  := \ p -> (transport a a p b)
+  : (a = a) → B a
+  := \ p → (transport a a p b)
 
 #end transport
 ```
@@ -583,16 +583,16 @@ The following needs to be outside the previous section because of the usage of
 ```rzk
 #def apd
   ( A : U)
-  ( B : A -> U)
+  ( B : A → U)
   ( x y : A)
-  ( f : (z : A) -> B z)
+  ( f : (z : A) → B z)
   ( p : x = y)
   : (transport A B x y p (f x)) = f y
   :=
     idJ
     ( A ,
       x ,
-      (\ y' p' -> (transport A B x y' p' (f x)) = f y') ,
+      (\ y' p' → (transport A B x y' p' (f x)) = f y') ,
       refl ,
       y ,
       p)
@@ -703,7 +703,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       x ,
-      \ y' p' -> triple-concat A y' x x y' (rev A x y' p') refl p' = refl ,
+      \ y' p' → triple-concat A y' x x y' (rev A x y' p') refl p' = refl ,
       refl ,
       y ,
       p)
@@ -711,14 +711,14 @@ The following needs to be outside the previous section because of the usage of
 #def ap-rev-refl-id-triple-concat
   ( A B : U)
   ( x y : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : x = y)
   : (ap A B y y f (triple-concat A y x x y (rev A x y p) refl p)) = refl
   :=
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
         ap A B y' y' f (triple-concat A y' x x y' (rev A x y' p') refl p') =
         refl ,
       refl ,
@@ -728,7 +728,7 @@ The following needs to be outside the previous section because of the usage of
 #def ap-triple-concat
   ( A B : U)
   ( w x y z : A)
-  ( f : A -> B)
+  ( f : A → B)
   ( p : w = x)
   ( q : x = y)
   ( r : y = z)
@@ -746,7 +746,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( A ,
       y ,
-      \ z' r' ->
+      \ z' r' →
       ap A B w z' f (triple-concat A w x y z' p q r') =
       triple-concat
         B
@@ -783,7 +783,7 @@ The following needs to be outside the previous section because of the usage of
     idJ
     ( x = y ,
       q ,
-      \ r' H' ->
+      \ r' H' →
       triple-concat A w x y z p q s = triple-concat A w x y z p r' s ,
       refl ,
       r ,

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -15,24 +15,24 @@ This is a literate `rzk` file:
 
 -- The type of homotopies between parallel functions.
 #def homotopy
-  (f g : A -> B)
+  (f g : A → B)
   : U
-  := (a : A) -> (f a = g a)
+  := (a : A) → (f a = g a)
 
 -- The reversal of a homotopy
 #def homotopy-rev
-  (f g : A -> B)
+  (f g : A → B)
   (H : homotopy f g)
   : homotopy g f
-  := \ a -> rev B (f a) (g a) (H a)
+  := \ a → rev B (f a) (g a) (H a)
 
 -- Homotopy composition is defined in diagrammatic order like concat but unlike composition.
 #def homotopy-composition
-  (f g h : A -> B)
+  (f g h : A → B)
   (H : homotopy f g)
   (K : homotopy g h)
   : homotopy f h
-  := \ a -> concat B (f a) (g a) (h a) (H a) (K a)
+  := \ a → concat B (f a) (g a) (h a) (H a) (K a)
 
 #end homotopies
 ```
@@ -45,27 +45,27 @@ This is a literate `rzk` file:
 #variables A B C : U
 
 #def homotopy-postwhisker
-  (f g : A -> B)
+  (f g : A → B)
   (H : homotopy A B f g)
-  (h : B -> C)
+  (h : B → C)
   : homotopy A C (composition A B C h f) (composition A B C h g)
-  := \ a -> ap B C (f a) (g a) h (H a)
+  := \ a → ap B C (f a) (g a) h (H a)
 
 #def homotopy-prewhisker
-  (f g : B -> C)
+  (f g : B → C)
   (H : homotopy B C f g)
-  (h : A -> B)
+  (h : A → B)
   : homotopy A C (composition A B C f h) (composition A B C g h)
-  := \ a -> H (h a)
+  := \ a → H (h a)
 
 #end homotopy-whiskering
 
 #def homotopy-whisker
   (A B C D : U)
-  (h k : B -> C)
+  (h k : B → C)
   (H : homotopy B C h k)
-  (f : A -> B)
-  (g : C -> D)
+  (f : A → B)
+  (g : C → D)
   : homotopy
       A
       D
@@ -88,7 +88,7 @@ This is a literate `rzk` file:
 -- The naturality square associated to a homotopy and a path.
 #def nat-htpy
   (A B : U)
-  (f g : A -> B)
+  (f g : A → B)
   (H : homotopy A B f g)
   (x y : A)
   (p : x = y)
@@ -98,7 +98,7 @@ This is a literate `rzk` file:
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
         (concat B (f x) (f y') (g y') (ap A B x y' f p') (H y')) =
         (concat B (f x) (g x) (g y') (H x) (ap A B x y' g p')) ,
       left-unit-concat B (f x) (g x) (H x) ,
@@ -108,7 +108,7 @@ This is a literate `rzk` file:
 -- Naturality in another form
 #def triple-concat-nat-htpy
   (A B : U)
-  (f g : A -> B)
+  (f g : A → B)
   (H : homotopy A B f g)
   (x y : A)
   (p : x = y)
@@ -120,7 +120,7 @@ This is a literate `rzk` file:
     idJ
     ( A ,
       x ,
-      \ y' p' ->
+      \ y' p' →
         triple-concat
           ( B)
           ( g x)
@@ -142,7 +142,7 @@ This is a literate `rzk` file:
 #section cocone-naturality
 
 #variable A : U
-#variable f : A -> A
+#variable f : A → A
 #variable H : homotopy A A f (identity A)
 #variable a : A
 
@@ -206,9 +206,9 @@ This is a literate `rzk` file:
 -- Conjugation between higher homotopies
 #def triple-concat-higher-homotopy
   (A B : U)
-  (f g : A -> B)
+  (f g : A → B)
   (H K : homotopy A B f g)
-  (α : (a : A) -> H a = K a)
+  (α : (a : A) → H a = K a)
   (x y : A)
   (p : f x = f y)
   : triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (H x)) p (H y) =
@@ -217,7 +217,7 @@ This is a literate `rzk` file:
     idJ
     ( f y = g y ,
       H y ,
-      \ Ky α' ->
+      \ Ky α' →
         triple-concat
           ( B) (g x) (f x) (f y) (g y)
           ( rev B (f x) (g x) (H x)) (p) (H y) =
@@ -239,7 +239,7 @@ This is a literate `rzk` file:
           ( g x = f x)
           ( H x)
           ( K x)
-          ( \ G -> rev B (f x) (g x) G) (α x)) ,
+          ( \ G → rev B (f x) (g x) G) (α x)) ,
       K y ,
       α y)
 ```

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -14,18 +14,18 @@ This is a literate `rzk` file:
 #variables A B : U
 
 #def has-section
-  ( f : A -> B)
+  ( f : A → B)
   : U
-  := Σ (s : B -> A) , (homotopy B B (composition B A B f s) (identity B))
+  := Σ (s : B → A) , (homotopy B B (composition B A B f s) (identity B))
 
 #def has-retraction
-  ( f : A -> B)
+  ( f : A → B)
   : U
-  := Σ (r : B -> A) , (homotopy A A (composition A B A r f) (identity A))
+  := Σ (r : B → A) , (homotopy A A (composition A B A r f) (identity A))
 
 -- equivalences are bi-invertible maps
 #def is-equiv
-  ( f : A -> B)
+  ( f : A → B)
   : U
   := product (has-retraction f) (has-section f)
 
@@ -38,15 +38,15 @@ This is a literate `rzk` file:
 #section equivalence-data
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable is-equiv-f : is-equiv A B f
 
 #def is-equiv-section uses (f)
-  : B -> A
+  : B → A
   := first (second is-equiv-f)
 
 #def is-equiv-retraction uses (f)
-  : B -> A
+  : B → A
   := first (first is-equiv-f)
 
 -- the homotopy between the section and retraction of an equivalence
@@ -80,10 +80,10 @@ This is a literate `rzk` file:
 -- the following type of more coherent equivalences is not a proposition
 #def has-inverse
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   : U
   :=
-    Σ ( g : B -> A) ,
+    Σ ( g : B → A) ,
       ( product
         ( homotopy A A (composition A B A g f) (identity A))
         -- The retracting homotopy
@@ -97,7 +97,7 @@ This is a literate `rzk` file:
 -- invertible maps are equivalences
 #def is-equiv-has-inverse
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : is-equiv A B f
   :=
@@ -107,7 +107,7 @@ This is a literate `rzk` file:
 -- equivalences are invertible
 #def has-inverse-is-equiv
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   : has-inverse A B f
   :=
@@ -131,32 +131,32 @@ This is a literate `rzk` file:
 #section has-inverse-data
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable has-inverse-f : has-inverse A B f
 
 -- The inverse of a map with an inverse
 #def has-inverse-inverse uses (f)
-  : B -> A
+  : B → A
   := first (has-inverse-f)
 
 -- Some iterated composites associated to a pair of invertible maps.
 #def has-inverse-retraction-composite uses (B has-inverse-f)
-  : A -> A
+  : A → A
   := composition A B A has-inverse-inverse f
 
 #def has-inverse-section-composite uses (A has-inverse-f)
-  : B -> B
+  : B → B
   := composition B A B f has-inverse-inverse
 
 -- This composite is parallel to f; we won't need the dual notion.
 #def has-inverse-triple-composite uses (has-inverse-f)
-  : A -> B
+  : A → B
   := triple-composition A B A B f has-inverse-inverse f
 
 -- This composite is also parallel to f; again we won't need the dual notion.
 #def has-inverse-quintuple-composite uses (has-inverse-f)
-  : A -> B
-  := \ a -> f (has-inverse-inverse (f (has-inverse-inverse (f a))))
+  : A → B
+  := \ a → f (has-inverse-inverse (f (has-inverse-inverse (f a))))
 #end has-inverse-data
 ```
 
@@ -168,7 +168,7 @@ The type of equivalences between types uses is-equiv rather than has-inverse.
 #def Equiv
   ( A B : U)
   : U
-  := Σ (f : A -> B) , (is-equiv A B f)
+  := Σ (f : A → B) , (is-equiv A B f)
 ```
 
 The data of an equivalence is not symmetric so we promote an equivalence to an
@@ -196,10 +196,10 @@ Composition of equivalences in diagrammatic order.
   ( B≃C : Equiv B C)
   : Equiv A C
   :=
-    ( \ a -> (first B≃C) ((first A≃B) a) , -- the composite equivalence
-      ( ( \ c ->
+    ( \ a → (first B≃C) ((first A≃B) a) , -- the composite equivalence
+      ( ( \ c →
           ( first (first (second A≃B))) ((first (first (second (B≃C)))) c) ,
-          ( \ a ->
+          ( \ a →
             concat A
               ( (first (first (second A≃B)))
                 ((first (first (second B≃C)))
@@ -213,10 +213,10 @@ Composition of equivalences in diagrammatic order.
                 ( first (first (second A≃B)))
                 ( (second (first (second B≃C))) ((first A≃B) a)))
               ( (second (first (second A≃B))) a))) ,
-                ( \ c ->
+                ( \ c →
                   ( first (second (second A≃B)))
                   ( (first (second (second (B≃C)))) c) ,
-          ( \ c ->
+          ( \ c →
             concat C
               ( (first B≃C) ((first A≃B) ((first (second (second A≃B)))
                 ((first (second (second B≃C))) c))))
@@ -234,16 +234,16 @@ Composition of equivalences in diagrammatic order.
 -- now we compose the functions that are equivalences
 #def compose-is-equiv
   ( A B C : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  ( g : B -> C)
+  ( g : B → C)
   ( is-equiv-g : is-equiv B C g)
   : is-equiv A C (composition A B C g f)
   :=
     ( ( composition C B A
       ( is-equiv-retraction A B f is-equiv-f)
       ( is-equiv-retraction B C g is-equiv-g) ,
-      ( \ a ->
+      ( \ a →
         concat A
           ( (is-equiv-retraction A B f is-equiv-f)
             ((is-equiv-retraction B C g is-equiv-g) (g (f a))))
@@ -258,7 +258,7 @@ Composition of equivalences in diagrammatic order.
       ( composition C B A
         ( is-equiv-section A B f is-equiv-f)
         ( is-equiv-section B C g is-equiv-g) ,
-        ( \ c ->
+        ( \ c →
           concat C
             ( g (f ((first (second is-equiv-f)) ((first (second is-equiv-g)) c))))
             ( g ((first (second is-equiv-g)) c))
@@ -298,11 +298,11 @@ Composition of equivalences in diagrammatic order.
 
 #def triple-compose-is-equiv
   ( A B C D : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  ( g : B -> C)
+  ( g : B → C)
   ( is-equiv-g : is-equiv B C g)
-  ( h : C -> D)
+  ( h : C → D)
   ( is-equiv-h : is-equiv C D h)
   : is-equiv A D (triple-composition A B C D h g f)
   :=
@@ -320,13 +320,13 @@ If a map is homotopic to an equivalence it is an equivalence.
 ```rzk
 #def is-equiv-homotopic-is-equiv
   ( A B : U)
-  ( f g : A -> B)
+  ( f g : A → B)
   ( H : homotopy A B f g)
   ( is-equiv-g : is-equiv A B g)
   : is-equiv A B f
   :=
     ( ( ( first (first is-equiv-g)) ,
-        ( \ a ->
+        ( \ a →
           concat A
             ( (first (first is-equiv-g)) (f a))
             ( (first (first is-equiv-g)) (g a))
@@ -334,7 +334,7 @@ If a map is homotopic to an equivalence it is an equivalence.
             ( ap B A (f a) (g a) (first (first is-equiv-g)) (H a))
             ( (second (first is-equiv-g)) a))) ,
       ( ( first (second is-equiv-g)) ,
-        ( \ b ->
+        ( \ b →
           concat B
             ( f ((first (second is-equiv-g)) b))
             ( g ((first (second is-equiv-g)) b))
@@ -344,7 +344,7 @@ If a map is homotopic to an equivalence it is an equivalence.
 
 #def is-equiv-rev-homotopic-is-equiv
   ( A B : U)
-  ( f g : A -> B)
+  ( f g : A → B)
   ( H : homotopy A B f g)
   ( is-equiv-f : is-equiv A B f)
   : is-equiv A B g
@@ -358,16 +358,16 @@ By path induction, an identification between functions defines a homotopy
 ```rzk
 #def htpy-eq
   ( X : U)
-  ( A : X -> U)
-  ( f g : (x : X) -> A x)
+  ( A : X → U)
+  ( f g : (x : X) → A x)
   ( p : f = g)
-  : (x : X) -> (f x = g x)
+  : (x : X) → (f x = g x)
   :=
     idJ
-    ( ( (x : X) -> A x) ,
+    ( ( (x : X) → A x) ,
       ( f) ,
-      ( \ g' p' -> (x : X) -> (f x = g' x)) ,
-      ( \ x -> refl) ,
+      ( \ g' p' → (x : X) → (f x = g' x)) ,
+      ( \ x → refl) ,
       ( g) ,
       ( p))
 ```
@@ -379,11 +379,11 @@ equivalences.
 -- The type that encodes the function extensionality axiom.
 #def FunExt : U
   :=
-    ( X : U) ->
-    ( A : X -> U) ->
-    ( f : (x : X) -> A x) ->
-    ( g : (x : X) -> A x) ->
-    is-equiv (f = g) ((x : X) -> f x = g x) (htpy-eq X A f g)
+    ( X : U) →
+    ( A : X → U) →
+    ( f : (x : X) → A x) →
+    ( g : (x : X) → A x) →
+    is-equiv (f = g) ((x : X) → f x = g x) (htpy-eq X A f g)
 ```
 
 In the formalisations below, some definitions will assume function
@@ -401,45 +401,45 @@ extensionality:
 -- The equivalence provided by function extensionality.
 #def FunExt-equiv uses (funext)
   ( X : U)
-  ( A : X -> U)
-  ( f g : (x : X) -> A x)
-  : Equiv (f = g) ((x : X) -> f x = g x)
+  ( A : X → U)
+  ( f g : (x : X) → A x)
+  : Equiv (f = g) ((x : X) → f x = g x)
   := (htpy-eq X A f g , funext X A f g)
 
 -- In particular, function extensionality implies that homotopies give rise to identifications. This defines eq-htpy to be the retraction to htpy-eq.
 #def eq-htpy uses (funext)
   ( X : U)
-  ( A : X -> U)
-  ( f g : (x : X) -> A x)
-  : ((x : X) -> f x = g x) -> (f = g)
+  ( A : X → U)
+  ( f g : (x : X) → A x)
+  : ((x : X) → f x = g x) → (f = g)
   := first (first (funext X A f g))
 
 -- Using function extensionality, a fiberwise equivalence defines an equivalence of dependent function types
 #def equiv-function-equiv-fibered uses (funext)
   ( X : U)
-  ( A B : X -> U)
-  ( fibequiv : (x : X) -> Equiv (A x) (B x))
-  : Equiv ((x : X) -> A x) ((x : X) -> B x)
+  ( A B : X → U)
+  ( fibequiv : (x : X) → Equiv (A x) (B x))
+  : Equiv ((x : X) → A x) ((x : X) → B x)
   :=
-    ( ( \ a x -> (first (fibequiv x)) (a x)) ,
-      ( ( ( \ b x -> (first (first (second (fibequiv x)))) (b x)) ,
-          ( \ a ->
+    ( ( \ a x → (first (fibequiv x)) (a x)) ,
+      ( ( ( \ b x → (first (first (second (fibequiv x)))) (b x)) ,
+          ( \ a →
             eq-htpy
               X A
-              ( \ x ->
+              ( \ x →
                 (first (first (second (fibequiv x))))
                   ((first (fibequiv x)) (a x)))
               ( a)
-              ( \ x -> (second (first (second (fibequiv x)))) (a x)))) ,
-        ( ( \ b x -> (first (second (second (fibequiv x)))) (b x)) ,
-          ( \ b ->
+              ( \ x → (second (first (second (fibequiv x)))) (a x)))) ,
+        ( ( \ b x → (first (second (second (fibequiv x)))) (b x)) ,
+          ( \ b →
             eq-htpy
               X B
-              ( \ x ->
+              ( \ x →
                 (first (fibequiv x))
                   ((first (second (second (fibequiv x)))) (b x)))
               ( b)
-              ( \ x -> (second (second (second (fibequiv x)))) (b x))))))
+              ( \ x → (second (second (second (fibequiv x)))) (b x))))))
 ```
 
 ## Embeddings
@@ -447,25 +447,25 @@ extensionality:
 ```rzk
 #def is-emb
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   : U
-  := (x : A) -> (y : A) -> is-equiv (x = y) (f x = f y) (ap A B x y f)
+  := (x : A) → (y : A) → is-equiv (x = y) (f x = f y) (ap A B x y f)
 
 #def Emb
   ( A B : U)
   : U
-  := (Σ (f : A -> B) , is-emb A B f)
+  := (Σ (f : A → B) , is-emb A B f)
 
 #def is-emb-is-inhabited-emb
   ( A B : U)
-  ( f : A -> B)
-  ( e : A -> is-emb A B f)
+  ( f : A → B)
+  ( e : A → is-emb A B f)
   : is-emb A B f
-  := \ x y -> e x x y
+  := \ x y → e x x y
 
 #def inv-ap-is-emb
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-emb-f : is-emb A B f)
   ( x y : A)
   ( p : f x = f y)
@@ -479,15 +479,15 @@ extensionality:
 #def has-retraction-rev
   ( A : U)
   ( y : A)
-  : (x : A) -> has-retraction (x = y) (y = x) ((\ p -> ((rev A x y) p)))
+  : (x : A) → has-retraction (x = y) (y = x) ((\ p → ((rev A x y) p)))
   :=
-    \ x ->
+    \ x →
     ( ( rev A y x) ,
-      ( \ p ->
+      ( \ p →
         idJ
         ( A ,
           x ,
-          ( \ y' p' ->
+          ( \ y' p' →
             ( composition
               ( x = y') (y' = x) (x = y') (rev A y' x) (rev A x y') (p'))
             =_{x = y'}
@@ -499,15 +499,15 @@ extensionality:
 #def has-section-rev
   ( A : U)
   ( y : A)
-  : (x : A) -> has-section (x = y) (y = x) ((\ p -> ((rev A x y) p)))
+  : (x : A) → has-section (x = y) (y = x) ((\ p → ((rev A x y) p)))
   :=
-    \ x ->
+    \ x →
     ( ( rev A y x) ,
-      ( \ p ->
+      ( \ p →
         idJ
         ( A ,
           y ,
-          ( \ x' p' ->
+          ( \ x' p' →
             ( composition
               ( y = x') (x' = y) (y = x') (rev A x' y) (rev A y x') (p'))
             =_{y = x'}

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -12,11 +12,11 @@ This is a literate `rzk` file:
 -- We'll require a more coherent notion of equivalence
 #def is-half-adjoint-equiv
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   : U
   :=
     Σ ( has-inverse-f : (has-inverse A B f)) ,
-      ( ( a : A) ->
+      ( ( a : A) →
         ( second (second has-inverse-f) (f a)) =
         ( ap A B ( has-inverse-retraction-composite A B f has-inverse-f a) a
           ( f) ( ( ( first ( second has-inverse-f))) a)))
@@ -25,10 +25,10 @@ This is a literate `rzk` file:
 -- following one:
 #def is-half-adjoint-equiv'
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   : U
   := Σ ( has-inverse-f : (has-inverse A B f)) ,
-       ( ( a : A) ->
+       ( ( a : A) →
          ( second (second has-inverse-f) (f a)) =
            ( ap A B
             ( has-inverse-retraction-composite A B f has-inverse-f a)
@@ -45,7 +45,7 @@ and discard the other.
 ```rzk
 #def has-inverse-kept-htpy
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : homotopy A A
     ( has-inverse-retraction-composite A B f has-inverse-f) (identity A)
@@ -53,7 +53,7 @@ and discard the other.
 
 #def has-inverse-discarded-htpy
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : homotopy B B
     ( has-inverse-section-composite A B f has-inverse-f) (identity B)
@@ -67,7 +67,7 @@ following naturality square.
 #section has-inverse-coherence
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable has-inverse-f : has-inverse A B f
 #variable a : A
 
@@ -92,7 +92,7 @@ following naturality square.
     nat-htpy A B
     ( has-inverse-triple-composite A B f has-inverse-f)
     ( f)
-    ( \ x -> has-inverse-discarded-htpy A B f has-inverse-f (f x))
+    ( \ x → has-inverse-discarded-htpy A B f has-inverse-f (f x))
     ( has-inverse-retraction-composite A B f has-inverse-f a)
     ( a)
     ( has-inverse-kept-htpy A B f has-inverse-f a)
@@ -252,9 +252,9 @@ following naturality square.
 
 -- This will replace the discarded homotopy
 #def has-inverse-corrected-htpy
-  : homotopy B B (has-inverse-section-composite A B f has-inverse-f) (\ b -> b)
+  : homotopy B B (has-inverse-section-composite A B f has-inverse-f) (\ b → b)
   :=
-    \ b ->
+    \ b →
       concat B
         ( (has-inverse-section-composite A B f has-inverse-f) b)
         ( (has-inverse-section-composite A B f has-inverse-f)
@@ -319,7 +319,7 @@ the invertible map by replacing the discarded homotopy with the corrected one.
 ```rzk
 #def corrected-has-inverse-has-inverse
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : has-inverse A B f
   :=
@@ -330,7 +330,7 @@ the invertible map by replacing the discarded homotopy with the corrected one.
 -- Invertible maps are half adjoint equivalences!
 #def is-half-adjoint-equiv-has-inverse
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : is-half-adjoint-equiv A B f
   :=
@@ -340,7 +340,7 @@ the invertible map by replacing the discarded homotopy with the corrected one.
 -- Equivalences are half adjoint equivalences!
 #def is-half-adjoint-equiv-is-equiv
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   : is-half-adjoint-equiv A B f
   :=
@@ -357,7 +357,7 @@ have equivalent identity types.
 #section equiv-identity-types-equiv
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable fisHAE : is-half-adjoint-equiv A B f
 
 #def iff-ap-is-half-adjoint-equiv
@@ -365,7 +365,7 @@ have equivalent identity types.
   : iff (x = y) (f x = f y)
   :=
     (ap A B x y f ,
-      \ q ->
+      \ q →
         triple-concat A
           ( x)
           ( (has-inverse-inverse A B f (first fisHAE)) (f x))
@@ -381,11 +381,11 @@ have equivalent identity types.
   : has-retraction (x = y) (f x = f y) (ap A B x y f)
   :=
     ( second (iff-ap-is-half-adjoint-equiv x y) ,
-      \ p ->
+      \ p →
           idJ
           ( A ,
             x ,
-            \ y' p' ->
+            \ y' p' →
               ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
               p' ,
             ( rev-refl-id-triple-concat A
@@ -564,8 +564,8 @@ have equivalent identity types.
   :=
     triple-concat-higher-homotopy A B
       ( has-inverse-triple-composite A B f (first fisHAE)) f
-      ( \ a -> (((second (second (first fisHAE)))) (f a)))
-      ( \ a ->
+      ( \ a → (((second (second (first fisHAE)))) (f a)))
+      ( \ a →
         ( ap A B (has-inverse-retraction-composite A B f (first fisHAE) a) a f
           ( ((first (second (first fisHAE)))) a)))
       ( second fisHAE)
@@ -723,7 +723,7 @@ have equivalent identity types.
 
 #def is-equiv-ap-is-equiv
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   ( x y : A)
   : is-equiv (x = y) (f x = f y) (ap A B x y f)
@@ -733,7 +733,7 @@ have equivalent identity types.
 
 #def Eq-ap-is-equiv
   ( A B : U)
-  ( f : A -> B)
+  ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   ( x y : A)
   : Equiv (x = y) (f x = f y)

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -19,20 +19,20 @@ This is a literate `rzk` file:
   ( e_A : a = a')
   ( e_B : b = b')
   : ( a , b) =_{product A B} (a' , b')
-  := transport A (\ x -> (a , b) =_{product A B} (x , b')) a a' e_A
-      ( transport B (\ y -> (a , b) =_{product A B} (a , y)) b b' e_B refl)
+  := transport A (\ x → (a , b) =_{product A B} (x , b')) a a' e_A
+      ( transport B (\ y → (a , b) =_{product A B} (a , y)) b b' e_B refl)
 
 #def first-path-product
   ( x y : product A B)
   ( e : x =_{product A B} y)
   : first x = first y
-  := ap (product A B) A x y (\ z -> first z) e
+  := ap (product A B) A x y (\ z → first z) e
 
 #def second-path-product
   ( x y : product A B)
   ( e : x =_{product A B} y)
   : second x = second y
-  := ap (product A B) B x y (\ z -> second z) e
+  := ap (product A B) B x y (\ z → second z) e
 
 #end paths-in-products
 ```
@@ -43,13 +43,13 @@ This is a literate `rzk` file:
 #section paths-in-sigma
 
 #variable A : U
-#variable B : A -> U
+#variable B : A → U
 
 #def first-path-Σ
   ( s t : Σ (a : A) , B a)
   ( e : s = t)
   : first s = first t
-  := ap (Σ (a : A) , B a) A s t (\ z -> first z) e
+  := ap (Σ (a : A) , B a) A s t (\ z → first z) e
 
 #def second-path-Σ
   ( s t : Σ (a : A) , B a)
@@ -60,7 +60,7 @@ This is a literate `rzk` file:
     idJ
     ( ( Σ (a : A) , B a) ,
       ( s) ,
-      ( \ t' e' ->
+      ( \ t' e' →
         ( transport A B
           ( first s) (first t') (first-path-Σ s t' e') (second s)) =
         ( second t')) ,
@@ -91,24 +91,24 @@ This is a literate `rzk` file:
   ( u v : B x)
   ( p : u = v)
   : (x , u) =_{Σ (a : A) , B a} (x , v)
-  := idJ (B x , u , \ v' p' -> (x , u) = (x , v') , refl , v , p)
+  := idJ (B x , u , \ v' p' → (x , u) = (x , v') , refl , v , p)
 
 -- Essentially eq-pair but with explicit arguments.
 #def path-of-pairs-pair-of-paths
   ( x y : A)
   ( p : x = y)
-  : ( u : B x) ->
-    ( v : B y) ->
-    ( (transport A B x y p u) = v) ->
+  : ( u : B x) →
+    ( v : B y) →
+    ( (transport A B x y p u) = v) →
     ( x , u) =_{Σ (z : A) , B z} (y , v)
   :=
     idJ
     ( ( A) ,
       ( x) ,
-      ( \ y' p' -> (u' : B x) -> (v' : B y') ->
-        ((transport A B x y' p' u') = v') ->
+      ( \ y' p' → (u' : B x) → (v' : B y') →
+        ((transport A B x y' p' u') = v') →
         (x , u') =_{Σ (z : A) , B z} (y' , v')) ,
-      ( \ u' v' q' -> (eq-eq-fiber-Σ x u' v' q')) ,
+      ( \ u' v' q' → (eq-eq-fiber-Σ x u' v' q')) ,
       ( y) ,
       ( p))
 
@@ -130,7 +130,7 @@ This is a literate `rzk` file:
     ( Σ (a : A) ,
       B a ,
       s ,
-      \ t' e' -> (eq-pair s t' (pair-eq s t' e')) = e' ,
+      \ t' e' → (eq-pair s t' (pair-eq s t' e')) = e' ,
       refl ,
       t ,
       e)
@@ -142,8 +142,8 @@ This is a literate `rzk` file:
   ( s1 : B s0)
   ( t0 : A)
   ( e0 : s0 = t0)
-  : ( t1 : B t0) ->
-    ( e1 : (transport A B s0 t0 e0 s1) = t1) ->
+  : ( t1 : B t0) →
+    ( e1 : (transport A B s0 t0 e0 s1) = t1) →
     ( ( pair-eq (s0 , s1) (t0 , t1) (eq-pair (s0 , s1) (t0 , t1) (e0 , e1)))
       =_{Eq-Σ (s0 , s1) (t0 , t1)}
       ( e0 , e1))
@@ -151,16 +151,16 @@ This is a literate `rzk` file:
     idJ
     ( A ,
       s0 ,
-      ( \ t0' e0' ->
-        (t1 : B t0') -> (e1 : (transport A B s0 t0' e0' s1) = t1) ->
+      ( \ t0' e0' →
+        (t1 : B t0') → (e1 : (transport A B s0 t0' e0' s1) = t1) →
         ( ( pair-eq (s0 , s1) (t0' , t1) (eq-pair (s0 , s1) (t0' , t1) (e0' , e1)))
           =_{Eq-Σ (s0 , s1) (t0' , t1)}
           ( e0' , e1))) ,
-      ( \ t1 e1 ->
+      ( \ t1 e1 →
         idJ
         ( B s0 ,
           s1 ,
-          \ t1' e1' ->
+          \ t1' e1' →
             ( pair-eq (s0 , s1) (s0 , t1')
               ( eq-pair (s0 , s1) (s0 , t1') (refl , e1')))
               =_{Eq-Σ (s0 , s1) (s0 , t1')} (refl , e1') ,
@@ -195,7 +195,7 @@ This is a literate `rzk` file:
 #section paths-in-sigma-over-product
 
 #variables A B : U
-#variable C : A -> B -> U
+#variable C : A → B → U
 
 #def product-transport
   ( a a' : A)
@@ -208,8 +208,8 @@ This is a literate `rzk` file:
     idJ
     ( B ,
       b ,
-      \ b'' q' -> C a' b'' ,
-      idJ (A , a , \ a'' p' -> C a'' b , c , a' , p) ,
+      \ b'' q' → C a' b'' ,
+      idJ (A , a , \ a'' p' → C a'' b , c , a' , p) ,
       b' ,
       q)
 
@@ -233,7 +233,7 @@ This is a literate `rzk` file:
     idJ
     ( Σ (a : A) , (Σ (b : B) , C a b) ,
       s ,
-      \ t' e' -> (Eq-Σ-over-product s t') ,
+      \ t' e' → (Eq-Σ-over-product s t') ,
       ( refl , (refl , refl)) ,
       t ,
       e)
@@ -247,23 +247,23 @@ This is a literate `rzk` file:
   ( u u' : B)
   ( c : C a u)
   ( p : a = a')
-  : ( q : u = u') ->
-    ( c' : C a' u') ->
-    ( r : product-transport a a' u u' p q c = c') ->
+  : ( q : u = u') →
+    ( c' : C a' u') →
+    ( r : product-transport a a' u u' p q c = c') →
     ( (a, (u, c)) =_{(Σ (x : A), (Σ (y : B) , C x y))} (a', (u', c')))
   :=
     idJ
     ( ( A) ,
       ( a) ,
-      ( \ a'' p' ->
-        (q : u = u') ->
-        (c' : C a'' u') ->
-        (r : product-transport a a'' u u' p' q c = c') ->
+      ( \ a'' p' →
+        (q : u = u') →
+        (c' : C a'' u') →
+        (r : product-transport a a'' u u' p' q c = c') →
         ( (a, (u, c)) =_{(Σ (x : A) , (Σ (y : B), C x y))} (a'', (u', c')))) ,
-      ( \ q c' r ->
-        ( eq-eq-fiber-Σ A (\x -> (Σ (v : B) , C x v)) a
+      ( \ q c' r →
+        ( eq-eq-fiber-Σ A (\x → (Σ (v : B) , C x v)) a
           ( u, c) ( u', c')
-          ( path-of-pairs-pair-of-paths B (\y -> C a y) u u' q c c' r))) ,
+          ( path-of-pairs-pair-of-paths B (\y → C a y) u u' q c c' r))) ,
       ( a') ,
       ( p))
 
@@ -287,7 +287,7 @@ This is a literate `rzk` file:
     idJ
     ( ( Σ (a : A) , (Σ (b : B) , C a b)) ,
       ( s) ,
-      ( \ t' e' -> (eq-triple s t' (triple-eq s t' e')) = e') ,
+      ( \ t' e' → (eq-triple s t' (triple-eq s t' e')) = e') ,
       ( refl) ,
       ( t) ,
       ( e))
@@ -298,9 +298,9 @@ This is a literate `rzk` file:
   ( b b' : B)
   ( c : C a b)
   ( p : a = a')
-  : ( q : b = b') ->
-    ( c' : C a' b') ->
-    ( r : product-transport a a' b b' p q c = c') ->
+  : ( q : b = b') →
+    ( c' : C a' b') →
+    ( r : product-transport a a' b b' p q c = c') →
     ( triple-eq
       ( a , (b , c)) (a' , (b' , c'))
       ( eq-triple (a , (b , c)) (a' , (b' , c')) (p , (q , r)))) =
@@ -309,30 +309,30 @@ This is a literate `rzk` file:
     idJ
     ( ( A) ,
       ( a) ,
-      ( \ a'' p' ->
-        ( q : b = b') ->
-        ( c' : C a'' b') ->
-        ( r : product-transport a a'' b b' p' q c = c') ->
+      ( \ a'' p' →
+        ( q : b = b') →
+        ( c' : C a'' b') →
+        ( r : product-transport a a'' b b' p' q c = c') →
         ( triple-eq
           ( a , (b , c)) (a'' , (b' , c'))
           ( eq-triple (a , (b , c)) (a'' , (b' , c')) (p' , (q , r)))) =
         ( p' , (q , r))) ,
-      \ q ->
+      \ q →
         idJ
         ( ( B) ,
           ( b) ,
-          ( \ b'' q' ->
-            ( c' : C a b'') ->
-            ( r : product-transport a a b b'' refl q' c = c') ->
+          ( \ b'' q' →
+            ( c' : C a b'') →
+            ( r : product-transport a a b b'' refl q' c = c') →
             ( triple-eq
               ( a , (b , c)) (a , (b'' , c'))
               ( eq-triple (a , (b , c)) (a , (b'' , c')) (refl , (q' , r)))) =
               ( refl , (q' , r))) ,
-          ( \ c' r ->
+          ( \ c' r →
             idJ
             ( ( C a b) ,
               ( c) ,
-              ( \ c'' r' ->
+              ( \ c'' r' →
                 triple-eq
                   ( a , (b , c)) (a , (b , c''))
                   ( eq-triple
@@ -377,9 +377,9 @@ This is a literate `rzk` file:
   ( A B : U)
   : Equiv (product A B) (product B A)
   :=
-    ( \ (a , b) -> (b , a) ,
-      ( ( \ (b , a) -> (a , b) ,\ p -> refl) ,
-        ( \ (b , a) -> (a , b) ,\ p -> refl)))
+    ( \ (a , b) → (b , a) ,
+      ( ( \ (b , a) → (a , b) ,\ p → refl) ,
+        ( \ (b , a) → (a , b) ,\ p → refl)))
 ```
 
 ## Fubini
@@ -390,14 +390,14 @@ unimportant.
 ```rzk
 #def fubini-Σ
   ( A B : U)
-  ( C : A -> B -> U)
+  ( C : A → B → U)
   : Equiv ( Σ (x : A) , Σ (y : B) , C x y) (Σ (y : B) , Σ (x : A) , C x y)
   :=
-    ( \ t -> (first (second t) , (first t , second (second t))) ,
-      ( ( \ t -> (first (second t) , (first t , second (second t))) ,
-          \ t -> refl) ,
-        ( \ t -> (first (second t) , (first t , second (second t))) ,
-          \ t -> refl)))
+    ( \ t → (first (second t) , (first t , second (second t))) ,
+      ( ( \ t → (first (second t) , (first t , second (second t))) ,
+          \ t → refl) ,
+        ( \ t → (first (second t) , (first t , second (second t))) ,
+          \ t → refl)))
 ```
 
 Products distribute inside Sigma types:
@@ -405,12 +405,12 @@ Products distribute inside Sigma types:
 ```rzk
 #def distributive-product-Σ
   ( A B : U)
-  ( C : B -> U)
+  ( C : B → U)
   : Equiv (product A (Σ (b : B) , C b)) (Σ (b : B) , product A (C b))
   :=
-    ( \ (a , (b , c)) -> (b , (a , c)) ,
-      ( ( \ (b , (a , c)) -> (a , (b , c)) , \ z -> refl) ,
-        ( \ (b , (a , c)) -> (a , (b , c)) , \ z -> refl)))
+    ( \ (a , (b , c)) → (b , (a , c)) ,
+      ( ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl) ,
+        ( \ (b , (a , c)) → (a , (b , c)) , \ z → refl)))
 ```
 
 ## Associativity
@@ -418,15 +418,15 @@ Products distribute inside Sigma types:
 ```rzk
 #def associative-Σ
   (A : U)
-  (B : A -> U)
-  (C : (a : A) -> B a -> U)
+  (B : A → U)
+  (C : (a : A) → B a → U)
   : Equiv
       ( Σ (a : A) , Σ (b : B a) , C a b)
       ( Σ (ab : Σ (a : A) , B a) , C (first ab) (second ab))
   :=
-    ( \ (a , (b , c)) -> ((a , b) , c) ,
-      ( ( \ ((a , b) , c) -> (a , (b , c)) , \ _ -> refl) ,
-        ( \ ((a , b) , c) -> (a , (b , c)) , \ _ -> refl)))
+    ( \ (a , (b , c)) → ((a , b) , c) ,
+      ( ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl) ,
+        ( \ ((a , b) , c) → (a , (b , c)) , \ _ → refl)))
 ```
 
 ## Currying
@@ -436,15 +436,15 @@ This is the dependent version of the currying equivalence.
 ```rzk
 #def equiv-dependent-curry
   (A : U)
-  (B : A -> U)
-  (C : (a : A) -> B a -> U)
+  (B : A → U)
+  (C : (a : A) → B a → U)
   : Equiv
-      ((p : Σ (a : A), B a) -> C (first p) (second p))
-      ((a : A) -> (b : B a) -> C a b)
+      ((p : Σ (a : A), B a) → C (first p) (second p))
+      ((a : A) → (b : B a) → C a b)
   :=
-    ( ( \ s a b -> s (a, b)),
-      ( ( ( \ f (a, b) -> f a b,
-            \ f -> refl ),
-          ( \ f (a, b) -> f a b,
-            \ s -> refl ))))
+    ( ( \ s a b → s (a, b)),
+      ( ( ( \ f (a, b) → f a b,
+            \ f → refl ),
+          ( \ f (a, b) → f a b,
+            \ s → refl ))))
 ```

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -11,7 +11,7 @@ This is a literate `rzk` file:
 ```rzk
 -- contractible types
 #def is-contr (A : U) : U
-  := Σ (x : A) , ((y : A) -> x = y)
+  := Σ (x : A) , ((y : A) → x = y)
 ```
 
 ## Contractible type data
@@ -28,13 +28,13 @@ This is a literate `rzk` file:
 
 -- The path from the contraction center to any point.
 #def contracting-htpy
-  : ( z : A) -> contraction-center = z
+  : ( z : A) → contraction-center = z
   := second is-contr-A
 
 #def contracting-htpy-realigned uses (is-contr-A)
-  : ( z : A) -> contraction-center = z
+  : ( z : A) → contraction-center = z
   :=
-    \ z ->
+    \ z →
       ( concat A contraction-center contraction-center z
           (rev A contraction-center contraction-center
             ( contracting-htpy contraction-center))
@@ -63,7 +63,7 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
 
 ```rzk
 #def ind-unit
-  ( C : Unit -> U)
+  ( C : Unit → U)
   ( C-unit : C unit)
   ( x : Unit)
   : C x
@@ -77,7 +77,7 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
 -- Terminal projection as a constant map
 #def terminal-map
   ( A : U)
-  : A -> Unit
+  : A → Unit
   := constant A Unit unit
 ```
 
@@ -88,13 +88,13 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
   ( x y : Unit)
   : has-retraction (x = y) Unit (terminal-map (x = y))
   :=
-    ( \ a -> refl ,
-      \ p -> idJ (Unit , x , \ y' p' -> refl =_{x = y'} p' , refl , y , p))
+    ( \ a → refl ,
+      \ p → idJ (Unit , x , \ y' p' → refl =_{x = y'} p' , refl , y , p))
 
 #def terminal-map-of-path-types-of-Unit-has-sec
   ( x y : Unit)
   : has-section (x = y) Unit (terminal-map (x = y))
-  := ( \ a -> refl , \ a -> refl)
+  := ( \ a → refl , \ a → refl)
 
 #def terminal-map-of-path-types-of-Unit-is-equiv
   ( x y : Unit)
@@ -120,13 +120,13 @@ A type is contractible if and only if its terminal map is an equivalence.
   : has-retraction A Unit (terminal-map A)
   :=
     ( constant Unit A (contraction-center A is-contr-A) ,
-      \ y -> (contracting-htpy A is-contr-A) y)
+      \ y → (contracting-htpy A is-contr-A) y)
 
 #def contr-implies-terminal-map-is-equiv-sec
   ( A : U)
   ( is-contr-A : is-contr A)
   : has-section A Unit (terminal-map A)
-  := ( constant Unit A (contraction-center A is-contr-A) , \ z -> refl)
+  := ( constant Unit A (contraction-center A is-contr-A) , \ z → refl)
 
 #def contr-implies-terminal-map-is-equiv
   ( A : U)
@@ -176,10 +176,10 @@ A type is contractible if and only if its terminal map is an equivalence.
   ( f : Equiv A B)
   : ( iff (is-contr A) (is-contr B))
   :=
-    ( \ is-contr-A ->
+    ( \ is-contr-A →
       ( equiv-with-contractible-domain-implies-contractible-codomain
         A B f is-contr-A) ,
-      \ is-contr-B ->
+      \ is-contr-B →
       ( equiv-with-contractible-codomain-implies-contractible-domain
         A B f is-contr-B))
 
@@ -201,7 +201,7 @@ A retract of contractible types is contractible.
 #def is-retract-of
   ( A B : U)
   : U
-  := Σ ( s : A -> B) , has-retraction A B s
+  := Σ ( s : A → B) , has-retraction A B s
 
 #section retraction-data
 
@@ -209,11 +209,11 @@ A retract of contractible types is contractible.
 #variable AretractB : is-retract-of A B
 
 #def is-retract-of-section
-  : A -> B
+  : A → B
   := first AretractB
 
 #def is-retract-of-retraction
-  : B -> A
+  : B → A
   := first (second AretractB)
 
 #def is-retract-of-homotopy
@@ -261,13 +261,13 @@ A function between contractible types is an equivalence
   ( A B : U)
   ( is-contr-A : is-contr A)
   ( is-contr-B : is-contr B)
-  ( f : A -> B)
+  ( f : A → B)
   : is-equiv A B f
   :=
-    ( ( \ b -> contraction-center A is-contr-A ,
-        \ a -> contracting-htpy A is-contr-A a) ,
-      ( \ b -> contraction-center A is-contr-A ,
-        \ b -> contractible-connecting-htpy B is-contr-B
+    ( ( \ b → contraction-center A is-contr-A ,
+        \ a → contracting-htpy A is-contr-A a) ,
+      ( \ b → contraction-center A is-contr-A ,
+        \ b → contractible-connecting-htpy B is-contr-B
                 (f (contraction-center A is-contr-A)) b))
 ```
 
@@ -303,13 +303,13 @@ For example, we prove that based path spaces are contractible.
   ( a x y : A)         -- The basepoint and two other points.
   ( p : a = x)         -- An element of the based path space.
   ( q : x = y)         -- A path in the base.
-  : ( transport A (\ z -> (a = z)) x y q p) = (concat A a x y p q)
+  : ( transport A (\ z → (a = z)) x y q p) = (concat A a x y p q)
   :=
     idJ
     ( A ,
       x ,
-      \ y' q' ->
-        ( transport A (\ z -> (a = z)) x y' q' p) = (concat A a x y' p q') ,
+      \ y' q' →
+        ( transport A (\ z → (a = z)) x y' q' p) = (concat A a x y' p q') ,
       refl ,
       y ,
       q)
@@ -329,10 +329,10 @@ For example, we prove that based path spaces are contractible.
   : (based-paths-center A a) = p
   :=
     path-of-pairs-pair-of-paths
-      A ( \ z -> a = z) a (first p) (second p) (refl) (second p)
+      A ( \ z → a = z) a (first p) (second p) (refl) (second p)
         (concat
           ( a = (first p))
-          ( transport A (\ z -> (a = z)) a (first p) (second p) (refl))
+          ( transport A (\ z → (a = z)) a (first p) (second p) (refl))
           ( concat A a a (first p) (refl) (second p))
           ( second p)
           ( concat-as-based-transport A a a (first p) (refl) (second p))
@@ -356,7 +356,7 @@ For example, we prove that based path spaces are contractible.
   : is-contr (product A B)
   :=
     ( (first is-contr-A , first is-contr-B) ,
-      \ p -> path-product A B
+      \ p → path-product A B
               ( first is-contr-A) (first p)
               ( first is-contr-B) (second p)
               ( second is-contr-A (first p))
@@ -368,20 +368,20 @@ For example, we prove that based path spaces are contractible.
   : is-contr A
   :=
     ( first (first AxB-is-contr) ,
-      \ a -> first-path-product A B
+      \ a → first-path-product A B
               ( first AxB-is-contr)
               ( a , second (first AxB-is-contr))
               ( second AxB-is-contr (a , second (first AxB-is-contr))))
 
 #def is-contr-base-is-contr-Σ
   ( A : U)
-  ( B : A -> U)
-  ( b : (a : A) -> B a)
+  ( B : A → U)
+  ( b : (a : A) → B a)
   ( is-contr-AB : is-contr (Σ (a : A) , B a))
   : is-contr A
   :=
     ( first (first is-contr-AB) ,
-      \ a -> first-path-Σ A B
+      \ a → first-path-Σ A B
               ( first is-contr-AB)
               ( a , b a)
               ( second is-contr-AB (a , b a)))
@@ -395,42 +395,42 @@ A type is contractible if and only if it has singleton induction.
 #def ev-pt
   ( A : U)
   ( a : A)
-  ( B : A -> U)
-  : ((x : A) -> B x) -> B a
-  := \ f -> f a
+  ( B : A → U)
+  : ((x : A) → B x) → B a
+  := \ f → f a
 
 #def has-singleton-induction-pointed
   ( A : U)
   ( a : A)
-  ( B : A -> U)
+  ( B : A → U)
   : U
-  := has-section ((x : A) -> B x) (B a) (ev-pt A a B)
+  := has-section ((x : A) → B x) (B a) (ev-pt A a B)
 
 #def has-singleton-induction-pointed-structure
   ( A : U)
   ( a : A)
   : U
-  := ( B : A -> U) -> has-section ((x : A) -> B x) (B a) (ev-pt A a B)
+  := ( B : A → U) → has-section ((x : A) → B x) (B a) (ev-pt A a B)
 
 #def has-singleton-induction
   ( A : U)
   : U
-  := Σ ( a : A) , (B : A -> U) -> (has-singleton-induction-pointed A a B)
+  := Σ ( a : A) , (B : A → U) → (has-singleton-induction-pointed A a B)
 
 #def ind-sing
   ( A : U)
   ( a : A)
-  ( B : A -> U)
+  ( B : A → U)
   (singleton-ind-A : has-singleton-induction-pointed A a B)
-  : (B a) -> ((x : A) -> B x)
+  : (B a) → ((x : A) → B x)
   := ( first singleton-ind-A)
 
 #def comp-sing
   ( A : U)
   ( a : A)
-  ( B : A -> U)
+  ( B : A → U)
   ( singleton-ind-A : has-singleton-induction-pointed A a B)
-  : ( homotopy (B a) (B a) (composition (B a) ((x : A) -> B x) (B a) (ev-pt A a B) (ind-sing A a B singleton-ind-A)) (identity (B a)))
+  : ( homotopy (B a) (B a) (composition (B a) ((x : A) → B x) (B a) (ev-pt A a B) (ind-sing A a B singleton-ind-A)) (identity (B a)))
   := (second singleton-ind-A)
 
 #def contr-implies-singleton-induction-ind
@@ -439,12 +439,12 @@ A type is contractible if and only if it has singleton induction.
   : (has-singleton-induction A)
   :=
     ( ( contraction-center A is-contr-A) ,
-      \ B ->
-        ( ( \ b x ->
+      \ B →
+        ( ( \ b x →
                 ( transport A B
                   ( contraction-center A is-contr-A) x
                   ( contracting-htpy-realigned A is-contr-A x) b)) ,
-          ( \ b ->
+          ( \ b →
                 ( ap
                   ( (contraction-center A is-contr-A) =
                     (contraction-center A is-contr-A))
@@ -452,14 +452,14 @@ A type is contractible if and only if it has singleton induction.
                   ( contracting-htpy-realigned A is-contr-A
                     ( contraction-center A is-contr-A))
                   refl_{(contraction-center A is-contr-A)}
-                  ( \ p ->
+                  ( \ p →
                     ( transport-loop A B (contraction-center A is-contr-A) b p))
                   ( contracting-htpy-realigned-path A is-contr-A)))))
 
 #def contr-implies-singleton-induction-pointed
   ( A : U)
   ( is-contr-A : is-contr A)
-  ( B : A -> U)
+  ( B : A → U)
   : has-singleton-induction-pointed A (contraction-center A is-contr-A) B
   := ( second (contr-implies-singleton-induction-ind A is-contr-A)) B
 
@@ -468,5 +468,5 @@ A type is contractible if and only if it has singleton induction.
   ( a : A)
   ( f : has-singleton-induction-pointed-structure A a)
   : ( is-contr A)
-  := ( a , (first (f ( \ x -> a = x))) (refl_{a}))
+  := ( a , (first (f ( \ x → a = x))) (refl_{a}))
 ```

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -14,7 +14,7 @@ The homotopy fiber of a map is the following type:
 -- The fiber of a map
 #def fib
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (b : B)
   : U
   := Σ (a : A) , (f a) = b
@@ -22,19 +22,19 @@ The homotopy fiber of a map is the following type:
 -- We calculate the transport of (a , q) : fib b along p : a = a'
 #def transport-in-fiber
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (b : B)
   (a a' : A)
   (u : (f a) = b)
   (p : a = a')
-  : (transport A ( \ x -> (f x) = b) a a' p u) =
+  : (transport A ( \ x → (f x) = b) a a' p u) =
     (concat B (f a') (f a) b (ap A B a' a f (rev A a a' p)) u)
   :=
     idJ
     ( A ,
       a ,
-      \ a'' p' ->
-        (transport A (\ x -> (f x) = b) a a'' p' u) =
+      \ a'' p' →
+        (transport A (\ x → (f x) = b) a a'' p' u) =
         (concat B (f a'') (f a) b (ap A B a'' a f (rev A a a'' p')) u) ,
       ( rev ((f a) = b) (concat B (f a) (f a) b refl u) u
         ( left-unit-concat B (f a) b u)) ,
@@ -50,9 +50,9 @@ A map is contractible just when its fibers are contractible.
 -- Contractible maps
 #def is-contr-map
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   : U
-  := (b : B) -> is-contr (fib A B f b)
+  := (b : B) → is-contr (fib A B f b)
 ```
 
 Contractible maps are equivalences:
@@ -61,19 +61,19 @@ Contractible maps are equivalences:
 #section is-contr-map-is-equiv
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable is-contr-f : is-contr-map A B f
 
 -- The inverse to a contractible map
 #def is-contr-map-inverse
-  : B -> A
-  := \ b -> first (contraction-center (fib A B f b) (is-contr-f b))
+  : B → A
+  := \ b → first (contraction-center (fib A B f b) (is-contr-f b))
 
 #def has-section-is-contr-map
   : has-section A B f
   :=
     ( is-contr-map-inverse ,
-      \ b -> second (contraction-center (fib A B f b) (is-contr-f b)))
+      \ b → second (contraction-center (fib A B f b) (is-contr-f b)))
 
 #def is-contr-map-data-in-fiber uses (is-contr-f)
   (a : A)
@@ -93,10 +93,10 @@ Contractible maps are equivalences:
   : has-retraction A B f
   :=
     ( is-contr-map-inverse ,
-      \ a -> ( ap (fib A B f (f a)) A
+      \ a → ( ap (fib A B f (f a)) A
                 ( is-contr-map-data-in-fiber a)
                 ( (a , refl))
-                ( \ u -> first u)
+                ( \ u → first u)
                 ( is-contr-map-path-in-fiber a)))
 
 #def is-equiv-is-contr-map uses (is-contr-f)
@@ -114,7 +114,7 @@ We now show that half adjoint equivalences are contractible maps.
 -- If f is a half adjoint equivalence, its fibers are inhabited.
 #def is-surj-is-half-adjoint-equiv
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (fisHAE : is-half-adjoint-equiv A B f) -- first fisHAE : has-inverse A B f
   (b : B)
   : fib A B f b
@@ -130,7 +130,7 @@ this homotopy is straightforward.
 #section half-adjoint-equivalence-fiber-data
 
 #variables A B : U
-#variable f : A -> B
+#variable f : A → B
 #variable fisHAE : is-half-adjoint-equiv A B f
 #variable b : B
 #variable z : fib A B f b
@@ -148,7 +148,7 @@ this homotopy is straightforward.
 
 -- Specializing the above to isHAE-fib-base-path
 #def isHAE-fib-base-path-transport
-  : transport A (\ x -> (f x) = b)
+  : transport A (\ x → (f x) = b)
       ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
       ( isHAE-fib-base-path )
       ( (second (second (first fisHAE))) b) =
@@ -950,13 +950,13 @@ this homotopy is straightforward.
   := left-unit-concat B (f (first z)) b (second z)
 
 #def isHAE-fib-base-path-transport-path
-  : transport A ( \ x -> (f x) = b)
+  : transport A ( \ x → (f x) = b)
     ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
     ( isHAE-fib-base-path )
     ( (second (second (first fisHAE))) b) = second z
   :=
     alternating-12ary-concat ( (f (first z)) = b)
-    ( transport A ( \ x -> (f x) = b)
+    ( transport A ( \ x → (f x) = b)
       ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
       ( isHAE-fib-base-path )
       ( (second (second (first fisHAE))) b))
@@ -1157,7 +1157,7 @@ Finally, we may define the contracting homotopy:
   : (is-surj-is-half-adjoint-equiv A B f fisHAE b) = z
   :=
     path-of-pairs-pair-of-paths A
-    ( \ x -> (f x) = b)
+    ( \ x → (f x) = b)
     ( (has-inverse-inverse A B f (first fisHAE)) b)
     ( first z)
     ( isHAE-fib-base-path)
@@ -1173,12 +1173,12 @@ Half adjoint equivalences define contractible maps:
 ```rzk
 #def is-contr-map-is-half-adjoint-equiv
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (fisHAE : is-half-adjoint-equiv A B f)
   : is-contr-map A B f
-  := \ b ->
+  := \ b →
         ( is-surj-is-half-adjoint-equiv A B f fisHAE b ,
-          \ z -> isHAE-fib-contracting-homotopy A B f fisHAE b z)
+          \ z → isHAE-fib-contracting-homotopy A B f fisHAE b z)
 ```
 
 ## Equivalences are contractible maps
@@ -1186,18 +1186,18 @@ Half adjoint equivalences define contractible maps:
 ```rzk
 #def is-contr-map-is-equiv
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (is-equiv-f : is-equiv A B f)
   : is-contr-map A B f
-  := \ b ->
+  := \ b →
         ( is-surj-is-half-adjoint-equiv A B f
           ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b ,
-          \ z -> isHAE-fib-contracting-homotopy A B f
+          \ z → isHAE-fib-contracting-homotopy A B f
             ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b z)
 
 #def is-contr-map-iff-is-equiv
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   : iff (is-contr-map A B f) (is-equiv A B f)
   := (is-equiv-is-contr-map A B f , is-contr-map-is-equiv A B f)
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -14,43 +14,43 @@ maps.
 ```rzk
 #def total-map-family-of-maps
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
-  : (Σ (x : A) , B x) -> (Σ (x : A) , C x)      -- the induced map on total spaces
-  := \ z -> (first z , f (first z) (second z))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  : (Σ (x : A) , B x) → (Σ (x : A) , C x)      -- the induced map on total spaces
+  := \ z → (first z , f (first z) (second z))
 
 #def total-map-to-fiber
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
   (w : (Σ (x : A) , C x))
-  : fib (B (first w)) (C (first w)) (f (first w)) (second w) ->
+  : fib (B (first w)) (C (first w)) (f (first w)) (second w) →
     ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
   :=
-    \ (b , p) ->
+    \ (b , p) →
       ( (first w , b) ,
         eq-eq-fiber-Σ A C (first w) (f (first w) b) (second w) p)
 
 #def total-map-from-fiber
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
   (w : (Σ (x : A) , C x))
   : (fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
-    -> fib (B (first w)) (C (first w)) (f (first w)) (second w)
+    → fib (B (first w)) (C (first w)) (f (first w)) (second w)
   :=
-    \ (z , p) ->
+    \ (z , p) →
       idJ
       ( (Σ (x : A) , C x) ,
         ((total-map-family-of-maps A B C f) z) ,
-        \ w' p' -> fib (B (first w')) (C (first w')) (f (first w')) (second w') , ((second z) , refl) ,
+        \ w' p' → fib (B (first w')) (C (first w')) (f (first w')) (second w') , ((second z) , refl) ,
         w ,
         p)
 
 #def total-map-to-fiber-retraction
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : has-retraction
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -58,11 +58,11 @@ maps.
     ( total-map-to-fiber A B C f w)
   :=
     ( total-map-from-fiber A B C f w ,
-      \ (b , p) ->
+      \ (b , p) →
         idJ
         ( (C (first w)) ,
           (f (first w) b) ,
-          \ w1 p' ->
+          \ w1 p' →
             ((total-map-from-fiber A B C f ((first w , w1)))
               ((total-map-to-fiber A B C f (first w , w1)) (b , p')))
             =_{(fib (B (first w)) (C (first w)) (f (first w)) (w1))}
@@ -73,8 +73,8 @@ maps.
 
 #def total-map-to-fiber-section
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
   (w : (Σ (x : A) , C x))
   : has-section
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -82,11 +82,11 @@ maps.
     ( total-map-to-fiber A B C f w)
   :=
     ( total-map-from-fiber A B C f w ,
-      \ (z , p) ->
+      \ (z , p) →
         idJ
         ( (Σ (x : A) , C x) ,
           ((first z , f (first z) (second z))) ,
-          \ w' p' ->
+          \ w' p' →
             ( (total-map-to-fiber A B C f w')
               ( (total-map-from-fiber A B C f w') (z , p'))) =
             ( z , p') ,
@@ -96,8 +96,8 @@ maps.
 
 #def total-map-to-fiber-is-equiv
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
   (w : (Σ (x : A) , C x))
   : is-equiv
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -110,8 +110,8 @@ maps.
 
 #def total-map-fiber-equiv
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))             -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))             -- a family of maps
   (w : (Σ (x : A) , C x))
   : Equiv
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -128,46 +128,46 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
 ```rzk
 #def invertible-family-total-inverse
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
-  (invfamily : (a : A) -> has-inverse (B a) (C a) (f a))
-  : (Σ (x : A) , C x) -> (Σ (x : A) , B x)
-  := \ (a , c) -> (a , (has-inverse-inverse (B a) (C a) (f a) (invfamily a)) c)
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
+  (invfamily : (a : A) → has-inverse (B a) (C a) (f a))
+  : (Σ (x : A) , C x) → (Σ (x : A) , B x)
+  := \ (a , c) → (a , (has-inverse-inverse (B a) (C a) (f a) (invfamily a)) c)
 
 #def invertible-family-total-retraction
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
-  (invfamily : (a : A) -> has-inverse (B a) (C a) (f a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
+  (invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-retraction
     ( Σ (x : A) , B x)
     ( Σ (x : A) , C x)
     ( total-map-family-of-maps A B C f)
   :=
     ( invertible-family-total-inverse A B C f invfamily ,
-      \ (a , b) ->
+      \ (a , b) →
         (eq-eq-fiber-Σ A B a
           ( (has-inverse-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
           ( (first (second (invfamily a))) b)))
 
 #def invertible-family-total-section
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
-  (invfamily : (a : A) -> has-inverse (B a) (C a) (f a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
+  (invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-section (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f)
   :=
     ( invertible-family-total-inverse A B C f invfamily ,
-      \ (a , c) ->
+      \ (a , c) →
         ( eq-eq-fiber-Σ A C a
           ( f a ((has-inverse-inverse (B a) (C a) (f a) (invfamily a)) c)) c
           ( (second (second (invfamily a))) c)))
 
 #def invertible-family-total-invertible
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
-  (invfamily : (a : A) -> has-inverse (B a) (C a) (f a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
+  (invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : has-inverse
     ( Σ (x : A) , B x)
     ( Σ (x : A) , C x)
@@ -179,27 +179,27 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
 
 #def family-of-equiv-total-equiv
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
-  (familyequiv : (a : A) -> is-equiv (B a) (C a) (f a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
+  (familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
   : is-equiv
     ( Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f)
   :=
     is-equiv-has-inverse
     ( Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f)
     ( invertible-family-total-invertible A B C f
-      ( \ a -> has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a)))
+      ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a)))
 
 #def total-equiv-family-equiv
   ( A : U)
-  ( B C : A -> U)
-  ( familyeq : (a : A) -> Equiv (B a) (C a))
+  ( B C : A → U)
+  ( familyeq : (a : A) → Equiv (B a) (C a))
   : Equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
   :=
-    ( total-map-family-of-maps A B C (\ a -> first (familyeq a)) ,
+    ( total-map-family-of-maps A B C (\ a → first (familyeq a)) ,
       family-of-equiv-total-equiv A B C
-        ( \ a -> first (familyeq a))
-        ( \ a -> second (familyeq a)))
+        ( \ a → first (familyeq a))
+        ( \ a → second (familyeq a)))
 ```
 
 The one-way result: that a family of equivalence gives an invertible map (and
@@ -208,13 +208,13 @@ thus an equivalence) on total spaces.
 ```rzk
 #def total-has-inverse-family-equiv
   ( A : U)
-  ( B C : A -> U)
-  ( f : (a : A) -> (B a) -> (C a))
-  ( familyequiv : (a : A) -> is-equiv (B a) (C a) (f a))
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))
+  ( familyequiv : (a : A) → is-equiv (B a) (C a) (f a))
   : has-inverse (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f)
   :=
     invertible-family-total-invertible A B C f
-    ( \ a -> has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a))
+    ( \ a → has-inverse-is-equiv (B a) (C a) (f a) (familyequiv a))
 ```
 
 For the converse, we make use of our calculation on fibers. The first
@@ -223,8 +223,8 @@ implication could be proven similarly.
 ```rzk
 #def total-contr-map-family-of-contr-maps
   ( A : U)
-  ( B C : A -> U)
-  ( f : (a : A) -> (B a) -> (C a))                         -- a family of maps
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))                         -- a family of maps
   ( totalcontrmap :
     is-contr-map
       ( Σ (x : A) , B x)
@@ -233,7 +233,7 @@ implication could be proven similarly.
   ( a : A)
   : is-contr-map (B a) (C a) (f a)
   :=
-    \ c ->
+    \ c →
       is-contr-is-equiv-to-contr
         ( fib (B a) (C a) (f a) c)
         ( fib (Σ (x : A) , B x) (Σ (x : A) , C x)
@@ -243,8 +243,8 @@ implication could be proven similarly.
 
 #def total-equiv-family-of-equiv
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))                         -- a family of maps
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))                         -- a family of maps
   (totalequiv : is-equiv
                 ( Σ (x : A) , B x)
                 ( Σ (x : A) , C x)
@@ -265,10 +265,10 @@ equivalence.
 ```rzk
 #def total-equiv-iff-family-of-equiv
   (A : U)
-  (B C : A -> U)
-  (f : (a : A) -> (B a) -> (C a))
+  (B C : A → U)
+  (f : (a : A) → (B a) → (C a))
   : iff
-      ( (a : A) -> is-equiv (B a) (C a) (f a))
+      ( (a : A) → is-equiv (B a) (C a) (f a))
       ( is-equiv (Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map-family-of-maps A B C f))
   := (family-of-equiv-total-equiv A B C f , total-equiv-family-of-equiv A B C f)
@@ -288,7 +288,7 @@ equivalence.
   ( A : U)
   (a : A)
   : Equiv (Σ (x : A) , x = a) (Σ (x : A) , a = x)
-  := total-equiv-family-equiv A (\ x -> x = a) (\ x -> a = x) (\ x -> equiv-rev A x a)
+  := total-equiv-family-equiv A (\ x → x = a) (\ x → a = x) (\ x → equiv-rev A x a)
 
 -- Codomain based path spaces are contractible
 #def is-contr-codomain-based-paths
@@ -303,16 +303,16 @@ equivalence.
 
 ## Pullback of a type family
 
-A family of types over B pulls back along any function f : A -> B to define a
+A family of types over B pulls back along any function f : A → B to define a
 family of types over A.
 
 ```rzk
 #def pullback
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
-  : A -> U
-  := \ a -> C (f a)
+  (f : A → B)
+  (C : B → U)
+  : A → U
+  := \ a → C (f a)
 ```
 
 The pullback of a family along homotopic maps is equivalent.
@@ -321,18 +321,18 @@ The pullback of a family along homotopic maps is equivalent.
 #section is-equiv-pullback-htpy
 
 #variables A B : U
-#variables f g : A -> B
+#variables f g : A → B
 #variable α : homotopy A B f g
-#variable C : B -> U
+#variable C : B → U
 #variable a : A
 
 #def pullback-homotopy
-  : (pullback A B f C a) -> (pullback A B g C a)
-  := \ c -> transport B C (f a) (g a) (α a) c
+  : (pullback A B f C a) → (pullback A B g C a)
+  := \ c → transport B C (f a) (g a) (α a) c
 
 #def pullback-homotopy-inverse
-  : (pullback A B g C a) -> (pullback A B f C a)
-  := \ c -> transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c
+  : (pullback A B g C a) → (pullback A B f C a)
+  := \ c → transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c
 
 #def pullback-homotopy-has-retraction
   : has-retraction
@@ -341,7 +341,7 @@ The pullback of a family along homotopic maps is equivalent.
     ( pullback-homotopy)
   :=
     ( pullback-homotopy-inverse ,
-      \ c ->
+      \ c →
         concat
         ( pullback A B f C a)
         ( transport B C (g a) (f a)
@@ -361,7 +361,7 @@ The pullback of a family along homotopic maps is equivalent.
     ( pullback-homotopy)
   :=
     ( pullback-homotopy-inverse ,
-      \ c ->
+      \ c →
         concat (pullback A B g C a)
           ( transport B C (f a) (g a) (α a)
             ( transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c))
@@ -388,10 +388,10 @@ space.
 ```rzk
 #def pullback-comparison-map
   ( A B : U)
-  ( f : A -> B)
-  ( C : B -> U)
-  : (Σ (a : A) , (pullback A B f C) a) -> (Σ (b : B) , C b)
-  := \ (a , c) -> (f a , c)
+  ( f : A → B)
+  ( C : B → U)
+  : (Σ (a : A) , (pullback A B f C) a) → (Σ (b : B) , C b)
+  := \ (a , c) → (f a , c)
 ```
 
 Now we show that if a family is pulled back along an equivalence, the total
@@ -402,8 +402,8 @@ map.
 ```rzk
 #def pullback-comparison-fiber
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
   : U
   :=
@@ -412,16 +412,16 @@ map.
 
 #def pullback-comparison-fiber-to-fiber
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
-  : (pullback-comparison-fiber A B f C z) -> (fib A B f (first z))
+  : (pullback-comparison-fiber A B f C z) → (fib A B f (first z))
   :=
-    \ (w , p) ->
+    \ (w , p) →
       idJ
       ( (Σ (b : B) , C b) ,
         (pullback-comparison-map A B f C w) ,
-        \ z' p' ->
+        \ z' p' →
           ( fib A B f (first z')) ,
         (first w , refl) ,
         z ,
@@ -429,36 +429,36 @@ map.
 
 #def from-base-fiber-to-pullback-comparison-fiber
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (b : B)
-  : (fib A B f b) -> (c : C b) -> (pullback-comparison-fiber A B f C (b , c))
+  : (fib A B f b) → (c : C b) → (pullback-comparison-fiber A B f C (b , c))
   :=
-    \ (a , p) ->
+    \ (a , p) →
         idJ
         ( B ,
           f a ,
-          \ b' p' ->
-            (c : C b') -> (pullback-comparison-fiber A B f C ((b' , c))) ,
-          \ c -> ((a , c) , refl) ,
+          \ b' p' →
+            (c : C b') → (pullback-comparison-fiber A B f C ((b' , c))) ,
+          \ c → ((a , c) , refl) ,
           b ,
           p)
 
 #def pullback-comparison-fiber-to-fiber-inv
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
-  : (fib A B f (first z)) -> (pullback-comparison-fiber A B f C z)
+  : (fib A B f (first z)) → (pullback-comparison-fiber A B f C z)
   :=
-    \ (a , p) ->
+    \ (a , p) →
       from-base-fiber-to-pullback-comparison-fiber A B f C
       ( first z) (a , p) (second z)
 
 #def pullback-comparison-fiber-to-fiber-retracting-homotopy
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
   ((w , p) : pullback-comparison-fiber A B f C z)
   : ( (pullback-comparison-fiber-to-fiber-inv A B f C z)
@@ -467,7 +467,7 @@ map.
     idJ
     ( (Σ (b : B) , C b) ,
       (pullback-comparison-map A B f C w) ,
-      \ z' p' ->
+      \ z' p' →
         ((pullback-comparison-fiber-to-fiber-inv A B f C z')
           ((pullback-comparison-fiber-to-fiber A B f C z') (w , p'))) = (w , p') ,
       refl ,
@@ -476,11 +476,11 @@ map.
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy-map
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (b : B)
   ((a , p) : fib A B f b)
-  : (c : C b) ->
+  : (c : C b) →
       ((pullback-comparison-fiber-to-fiber A B f C (b , c))
         ((pullback-comparison-fiber-to-fiber-inv A B f C (b , c)) (a , p))) =
       (a , p)
@@ -488,18 +488,18 @@ map.
     idJ
     ( B ,
       f a ,
-      \ b' p' -> (c : C b') ->
+      \ b' p' → (c : C b') →
         ( (pullback-comparison-fiber-to-fiber A B f C (b' , c))
           ( (pullback-comparison-fiber-to-fiber-inv A B f C (b' , c)) (a , p'))) =
         ( a , p') ,
-      \ c -> refl ,
+      \ c → refl ,
       b ,
       p)
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
   ((a , p) : fib A B f (first z))
   : ((pullback-comparison-fiber-to-fiber A B f C z)
@@ -510,8 +510,8 @@ map.
 
 #def equiv-pullback-comparison-fiber
   (A B : U)
-  (f : A -> B)
-  (C : B -> U)
+  (f : A → B)
+  (C : B → U)
   (z : Σ (b : B) , C b)
   : Equiv (pullback-comparison-fiber A B f C z) (fib A B f (first z))
   :=
@@ -528,9 +528,9 @@ equivalence of total spaces.
 ```rzk
 #def total-equiv-pullback-is-equiv
   (A B : U)
-  (f : A -> B)
+  (f : A → B)
   (is-equiv-f : is-equiv A B f)
-  (C : B -> U)
+  (C : B → U)
   : Equiv (Σ (a : A) , (pullback A B f C) a) (Σ (b : B) , C b)
   :=
     ( pullback-comparison-map A B f C ,
@@ -538,7 +538,7 @@ equivalence of total spaces.
         ( Σ (a : A) , (pullback A B f C) a)
         ( Σ (b : B) , C b)
         ( pullback-comparison-map A B f C)
-        ( \ z ->
+        ( \ z →
           ( is-contr-is-equiv-to-contr
             ( pullback-comparison-fiber A B f C z)
             ( fib A B f (first z))
@@ -553,42 +553,42 @@ equivalence of total spaces.
 
 #variable A : U
 #variable a : A
-#variable B : A -> U
-#variable f : (x : A) -> (a = x) -> B x
+#variable B : A → U
+#variable f : (x : A) → (a = x) → B x
 
 #def fund-id-fam-of-eqs-implies-sum-over-codomain-contr
-  : ((x : A) -> (is-equiv (a = x) (B x) (f x))) -> (is-contr (Σ (x : A) , B x))
+  : ((x : A) → (is-equiv (a = x) (B x) (f x))) → (is-contr (Σ (x : A) , B x))
   :=
-    ( \ familyequiv ->
+    ( \ familyequiv →
       ( equiv-with-contractible-domain-implies-contractible-codomain
         ( Σ (x : A) , a = x) (Σ (x : A) , B x)
-        ( ( total-map-family-of-maps A ( \ x -> (a = x)) B f) ,
+        ( ( total-map-family-of-maps A ( \ x → (a = x)) B f) ,
           ( is-equiv-has-inverse (Σ (x : A) , a = x) (Σ (x : A) , B x)
-            ( total-map-family-of-maps A ( \ x -> (a = x)) B f)
+            ( total-map-family-of-maps A ( \ x → (a = x)) B f)
             ( total-has-inverse-family-equiv A
-              ( \ x -> (a = x)) B f familyequiv)))
+              ( \ x → (a = x)) B f familyequiv)))
         ( is-contr-based-paths A a)))
 
 #def fund-id-sum-over-codomain-contr-implies-fam-of-eqs
-  : (is-contr (Σ (x : A) , B x)) -> ((x : A) -> (is-equiv (a = x) (B x) (f x)))
+  : (is-contr (Σ (x : A) , B x)) → ((x : A) → (is-equiv (a = x) (B x) (f x)))
   :=
-    ( \ is-contr-B ->
-      ( \ x ->
+    ( \ is-contr-B →
+      ( \ x →
         ( total-equiv-family-of-equiv A
-          ( \ x' -> (a = x'))
+          ( \ x' → (a = x'))
           B
           f
           ( is-equiv-are-contr (Σ (x' : A) , (a = x')) (Σ (x' : A) , (B x'))
             ( is-contr-based-paths A a) is-contr-B
-            ( total-map-family-of-maps A ( \ x' -> (a = x')) B f))
+            ( total-map-family-of-maps A ( \ x' → (a = x')) B f))
           x)))
 
 -- This allows us to apply "based path induction"
 -- to a family satisfying the fundamental theorem.
 -- Please suggest a better name.
 #def ind-based-path
-  (familyequiv : (z : A) -> (is-equiv (a = z) (B z) (f z)))
-  (P : (z : A) -> B z -> U)
+  (familyequiv : (z : A) → (is-equiv (a = z) (B z) (f z)))
+  (P : (z : A) → B z → U)
   (p0 : P a (f a refl))
   (u : A)
   (p : B u)
@@ -597,11 +597,11 @@ equivalence of total spaces.
     ind-sing
       ( Σ (v : A) , B v)
       ( a , f a refl)
-      ( \ (u' , p') -> P u' p')
+      ( \ (u' , p') → P u' p')
       ( contr-implies-singleton-induction-pointed
         ( Σ (z : A) , B z)
         ( fund-id-fam-of-eqs-implies-sum-over-codomain-contr familyequiv)
-        ( \ (x', p') -> P x' p'))
+        ( \ (x', p') → P x' p'))
       ( p0)
       (u , p)
 
@@ -613,48 +613,48 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
 ```rzk
 #def emb-is-equiv
   (A B : U)
-  (e : A -> B)
+  (e : A → B)
   (is-equiv-e : is-equiv A B e)
   : (Emb A B)
   :=
     ( e ,
-      \ x y ->
+      \ x y →
           ( fund-id-sum-over-codomain-contr-implies-fam-of-eqs
   -- By the fundamental theorem of identity types, it will suffice to show
   -- contractibility of sigma_{t : A} e x = e t
   -- for the family of maps ap_e, which is of type
-  -- (\t:A) -> (x = t) -> (e x = e t)
+  -- (\t:A) → (x = t) → (e x = e t)
             A
             x
-            ( \ t -> (e x = e t))
-            ( \ t -> (ap A B x t e)) -- the family of maps ap_e
+            ( \ t → (e x = e t))
+            ( \ t → (ap A B x t e)) -- the family of maps ap_e
             ( (is-contr-is-equiv-to-contr
   -- Contractibility of sigma_{t : A} e x = e t will follow since
-  -- total (\ t -> rev B (e x) = (e t)), mapping from sigma_{t : A} e x = e t to
+  -- total (\ t → rev B (e x) = (e t)), mapping from sigma_{t : A} e x = e t to
   -- sigma_{t : A} e t = e x
   -- is an equivalence, and `Σ_{t : A} e t = e x ~ fib (e , e x)` is
   -- contractible since e is an equivalence.
                 (Σ (y' : A) , (e x = e y')) -- source type
                 (Σ (y' : A) , (e y' = e x)) -- target type
                 ((total-map-family-of-maps A
-                  ( \ y' -> (e x) = (e y'))
-                  ( \ y' -> (e y') = (e x))
-                  ( \ y' -> (rev B (e x) (e y')))) , -- a) total map
+                  ( \ y' → (e x) = (e y'))
+                  ( \ y' → (e y') = (e x))
+                  ( \ y' → (rev B (e x) (e y')))) , -- a) total map
 
                 ( -- b) proof that total map is equivalence
                   ( first
                     ( total-equiv-iff-family-of-equiv A
-                    ( \ y' -> (e x) = (e y'))
-                    ( \ y' -> (e y') = (e x))
-                    ( \ y' -> (rev B (e x) (e y')))))
-                  ( \ y' -> (is-equiv-rev B (e x) (e y')))))
+                    ( \ y' → (e x) = (e y'))
+                    ( \ y' → (e y') = (e x))
+                    ( \ y' → (rev B (e x) (e y')))))
+                  ( \ y' → (is-equiv-rev B (e x) (e y')))))
                 ( -- fiber of e at e(x) is contractible
                   (is-contr-map-is-equiv A B e is-equiv-e) (e x))))) (y))
                   -- evaluate at y
 
 #def is-emb-is-equiv
   (A B : U)
-  (e : A -> B)
+  (e : A → B)
   (is-equiv-e : is-equiv A B e)
   : is-emb A B e
   := (second (emb-is-equiv A B e is-equiv-e))
@@ -667,8 +667,8 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
 -- embeddings so that this could go earlier.
 #def RightCancel-is-equiv
   (A B C : U)
-  (f : A -> B)
-  (g : B -> C)
+  (f : A → B)
+  (g : B → C)
   (is-equiv-g : is-equiv B C g)
   (gfisequiv : is-equiv A C (composition A B C g f))
   : is-equiv A B f
@@ -678,7 +678,7 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
         (second (first gfisequiv))) ,
       ( composition B C A
         (is-equiv-section A C (composition A B C g f) gfisequiv) g ,
-        \ b ->
+        \ b →
           inv-ap-is-emb
             B C g
             ( is-emb-is-equiv B C g is-equiv-g)
@@ -688,15 +688,15 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
 
 #def LeftCancel-is-equiv
   (A B C : U)
-  (f : A -> B)
+  (f : A → B)
   (is-equiv-f : is-equiv A B f)
-  (g : B -> C)
+  (g : B → C)
   (gfisequiv : is-equiv A C (composition A B C g f))
   : is-equiv B C g
   :=
     ( ( composition C A B
           f (is-equiv-retraction A C (composition A B C g f) gfisequiv) ,
-        \ b ->
+        \ b →
           triple-concat B
             ( f ((is-equiv-retraction A C (composition A B C g f) gfisequiv)
               (g b)))
@@ -707,16 +707,16 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
             ( ap B B
               ( b)
               ( f ((is-equiv-section A B f is-equiv-f) b))
-              ( \ b0 ->
+              ( \ b0 →
                 ( f ((is-equiv-retraction A C
                       ( composition A B C g f) gfisequiv) (g b0))))
               ( rev B (f ((is-equiv-section A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
             ( ( homotopy-whisker B A A B
-                ( \ a ->
+                ( \ a →
                   ( is-equiv-retraction A C
                     ( composition A B C g f) gfisequiv) (g (f a)))
-                ( \ a -> a)
+                ( \ a → a)
                 ( second (first gfisequiv))
                 ( is-equiv-section A B f is-equiv-f)
                 f) b)
@@ -736,15 +736,15 @@ types over a product type.
 #section fibered-map-over-product
 
 #variables A A' B B' : U
-#variable C : A -> B -> U
-#variable C' : A' -> B' -> U
-#variable f : A -> A'
-#variable g : B -> B'
-#variable h : (a : A) -> (b : B) -> (c : C a b) -> C' (f a) (g b)
+#variable C : A → B → U
+#variable C' : A' → B' → U
+#variable f : A → A'
+#variable g : B → B'
+#variable h : (a : A) → (b : B) → (c : C a b) → C' (f a) (g b)
 
 #def total-map-fibered-map-over-product
-  : (Σ (a : A) , (Σ (b : B) , C a b)) -> (Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-  := \ (a , (b , c)) -> (f a , (g b , h a b c))
+  : (Σ (a : A) , (Σ (b : B) , C a b)) → (Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+  := \ (a , (b , c)) → (f a , (g b , h a b c))
 
 #def pullback-is-equiv-base-is-equiv-total-is-equiv
   (totalisequiv : is-equiv
@@ -755,20 +755,20 @@ types over a product type.
   : is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
-    ( \ (a , (b , c)) -> (a , (g b , h a b c)))
+    ( \ (a , (b , c)) → (a , (g b , h a b c)))
   :=
     RightCancel-is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-    ( \ (a , (b , c)) -> (a , (g b , h a b c)))
-    ( \ (a , (b' , c')) -> (f a , (b' , c')))
+    ( \ (a , (b , c)) → (a , (g b , h a b c)))
+    ( \ (a , (b' , c')) → (f a , (b' , c')))
     ( second (total-equiv-pullback-is-equiv
                 A
                 A'
                 f
                 is-equiv-f
-                ( \ a' -> (Σ (b' : B') , C' a' b'))))
+                ( \ a' → (Σ (b' : B') , C' a' b'))))
     ( totalisequiv)
 
 #def pullback-is-equiv-bases-are-equiv-total-is-equiv
@@ -781,26 +781,26 @@ types over a product type.
   : is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
-    ( \ (a , (b , c)) -> (a , (b , h a b c)))
+    ( \ (a , (b , c)) → (a , (b , h a b c)))
   :=
     RightCancel-is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
-    ( \ (a , (b , c)) -> (a , (b , h a b c)))
-    ( \ (a , (b , c)) -> (a , (g b , c)))
+    ( \ (a , (b , c)) → (a , (b , h a b c)))
+    ( \ (a , (b , c)) → (a , (g b , c)))
     ( family-of-equiv-total-equiv A
-      ( \ a -> (Σ (b : B) , C' (f a) (g b)))
-      ( \ a -> (Σ (b' : B') , C' (f a) b'))
-      ( \ a (b , c) -> (g b , c))
-      ( \ a ->
+      ( \ a → (Σ (b : B) , C' (f a) (g b)))
+      ( \ a → (Σ (b' : B') , C' (f a) b'))
+      ( \ a (b , c) → (g b , c))
+      ( \ a →
         ( second
           ( total-equiv-pullback-is-equiv
               B
               B'
               g
               is-equiv-g
-              ( \ b' -> C' (f a) b')))))
+              ( \ b' → C' (f a) b')))))
     ( pullback-is-equiv-base-is-equiv-total-is-equiv totalisequiv is-equiv-f)
 
 #def fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
@@ -815,14 +815,14 @@ types over a product type.
   : is-equiv (C a0 b0) (C' (f a0) (g b0)) (h a0 b0)
   :=
     total-equiv-family-of-equiv B
-    ( \ b -> C a0 b)
-    ( \ b -> C' (f a0) (g b))
-    ( \ b c -> h a0 b c)
+    ( \ b → C a0 b)
+    ( \ b → C' (f a0) (g b))
+    ( \ b c → h a0 b c)
     ( total-equiv-family-of-equiv
       A
-      ( \ a -> (Σ (b : B) , C a b))
-      ( \ a -> (Σ (b : B) , C' (f a) (g b)))
-      ( \ a (b , c) -> (b , h a b c))
+      ( \ a → (Σ (b : B) , C a b))
+      ( \ a → (Σ (b : B) , C' (f a) (g b)))
+      ( \ a (b , c) → (b , h a b c))
       ( pullback-is-equiv-bases-are-equiv-total-is-equiv
           totalisequiv is-equiv-f is-equiv-g)
       a0)

--- a/src/hott/09-propositions.rzk.md
+++ b/src/hott/09-propositions.rzk.md
@@ -14,11 +14,11 @@ A type is a proposition when its identity types are contractible.
 #def is-prop
   (A : U)
   : U
-  := (a : A) -> (b : A) -> is-contr (a = b)
+  := (a : A) → (b : A) → is-contr (a = b)
 
 #def is-prop-Unit
   : is-prop Unit
-  := \ x y -> (path-types-of-Unit-are-contractible x y)
+  := \ x y → (path-types-of-Unit-are-contractible x y)
 ```
 
 ## Alternative characterizations: definitions
@@ -27,12 +27,12 @@ A type is a proposition when its identity types are contractible.
 #def all-elements-equal
   (A : U)
   : U
-  := (a : A) -> (b : A) -> (a = b)
+  := (a : A) → (b : A) → (a = b)
 
 #def is-contr-is-inhabited
   (A : U)
   : U
-  := A -> is-contr A
+  := A → is-contr A
 
 #def is-emb-terminal-map
   (A : U)
@@ -47,20 +47,20 @@ A type is a proposition when its identity types are contractible.
   (A : U)
   (AisProp : is-prop A)
   : all-elements-equal A
-  := \ a b -> (first (AisProp a b))
+  := \ a b → (first (AisProp a b))
 
 #def is-contr-is-inhabited-all-elements-equal
   (A : U)
   (AhasAllEltsEqual : all-elements-equal A)
   : is-contr-is-inhabited A
-  := \ a -> (a , AhasAllEltsEqual a)
+  := \ a → (a , AhasAllEltsEqual a)
 
 #def terminal-map-is-emb-is-inhabited-is-contr-is-inhabited
   (A : U)
   (c : is-contr-is-inhabited A)
-  : A -> (is-emb-terminal-map A)
+  : A → (is-emb-terminal-map A)
   :=
-    \ x ->
+    \ x →
       ( is-emb-is-equiv A Unit (terminal-map A)
         ( contr-implies-terminal-map-is-equiv A (c x)))
 
@@ -77,7 +77,7 @@ A type is a proposition when its identity types are contractible.
   (f : is-emb-terminal-map A)
   : is-prop A
   :=
-    \ x y ->
+    \ x y →
       ( is-contr-is-equiv-to-contr (x = y) (unit = unit)
         ( (ap A Unit x y (terminal-map A)) , (f x y))
         ( path-types-of-Unit-are-contractible unit unit))

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -12,9 +12,9 @@ is an equivalence if and only if its fibers are contractible.
 ```rzk
 #def total-space-projection
   (A : U)
-  (B : A -> U)
-  : (Σ (x : A) , B x) -> A
-  := \ z -> first z
+  (B : A → U)
+  : (Σ (x : A) , B x) → A
+  := \ z → first z
 ```
 
 ## Contractible fibers
@@ -24,32 +24,32 @@ The following type asserts that the fibers of a type family are contractible.
 ```rzk
 #def contractible-fibers
   (A : U)
-  (B : A -> U)
+  (B : A → U)
   : U
-  := ((x : A) -> is-contr (B x))
+  := ((x : A) → is-contr (B x))
 
 #section contractible-fibers-data
 
 #variable A : U
-#variable B : A -> U
+#variable B : A → U
 #variable ABcontrfib : contractible-fibers A B
 
 -- The center of contraction in a contractible fibers
 #def contractible-fibers-section
-  : (x : A) -> B x
-  := \ x -> contraction-center (B x) (ABcontrfib x)
+  : (x : A) → B x
+  := \ x → contraction-center (B x) (ABcontrfib x)
 
 -- The section of the total space projection built from the contraction centers
 #def contractible-fibers-actual-section uses (ABcontrfib)
-  : (a : A) -> Σ (x : A) , B x
-  := \ a -> (a , contractible-fibers-section a)
+  : (a : A) → Σ (x : A) , B x
+  := \ a → (a , contractible-fibers-section a)
 
 #def contractible-fibers-section-htpy uses (ABcontrfib)
   : homotopy A A
     ( composition A (Σ (x : A) , B x) A
       ( total-space-projection A B) (contractible-fibers-actual-section))
     ( identity A)
-  := \ x -> refl
+  := \ x → refl
 
 #def contractible-fibers-section-is-section uses (ABcontrfib)
   : has-section (Σ (x : A) , B x) A (total-space-projection A B)
@@ -57,9 +57,9 @@ The following type asserts that the fibers of a type family are contractible.
 
 -- This can be used to define the retraction homotopy for the total space projection, called "first" here
 #def contractible-fibers-retraction-htpy
-  : (z : Σ (x : A) , B x) ->
+  : (z : Σ (x : A) , B x) →
       (contractible-fibers-actual-section) (first z) = z
-  := \ z ->
+  := \ z →
       eq-eq-fiber-Σ A B
         ( first z)
         ( (contractible-fibers-section) (first z))
@@ -88,7 +88,7 @@ The following type asserts that the fibers of a type family are contractible.
 -- From a projection equivalence, it's not hard to inhabit fibers
 #def inhabited-fibers-is-equiv-projection
   (A : U)
-  (B : A -> U)
+  (B : A → U)
   (ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
   (a : A)
   : B a
@@ -101,17 +101,17 @@ The following type asserts that the fibers of a type family are contractible.
 -- are contractible; the following proof fails
 -- #def is-equiv-projection-implies-contractible-fibers
 --    (A : U)
---    (B : A -> U)
+--    (B : A → U)
 --    (ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
 --    : contractible-fibers A B
 --    :=
---      \ x -> (second ((first (first ABprojequiv)) x) ,
---      \ u -> second-path-Σ A B ((first (first ABprojequiv)) x) (x , u)
+--      \ x → (second ((first (first ABprojequiv)) x) ,
+--      \ u → second-path-Σ A B ((first (first ABprojequiv)) x) (x , u)
 --             ( (second (first ABprojequiv)) (x , u)) )
 
 #section projection-hae-data
 #variable A : U
-#variable B : A -> U
+#variable B : A → U
 #variable ABprojHAE :
   is-half-adjoint-equiv (Σ (x : A) , B x) A (total-space-projection A B)
 #variable w : (Σ (x : A) , B x)
@@ -189,18 +189,18 @@ The following type asserts that the fibers of a type family are contractible.
 -- Finally we have
 #def contractible-fibers-is-half-adjoint-equiv-projection
   (A : U)
-  (B : A -> U)
+  (B : A → U)
   (ABprojHAE : is-half-adjoint-equiv (Σ (x : A) , B x) A (total-space-projection A B))
   : contractible-fibers A B
   :=
-    \ x ->
+    \ x →
       ( (projection-hae-section A B ABprojHAE x) ,
-        \ u -> (projection-hae-fibered-contracting-htpy A B ABprojHAE (x , u)))
+        \ u → (projection-hae-fibered-contracting-htpy A B ABprojHAE (x , u)))
 
 -- The converse to our first result
 #def contractible-fibers-is-equiv-projection
   (A : U)
-  (B : A -> U)
+  (B : A → U)
   (ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
   : contractible-fibers A B
   :=
@@ -211,11 +211,11 @@ The following type asserts that the fibers of a type family are contractible.
 -- The main theorem
 #def projection-theorem
   (A : U)
-  (B : (a : A) -> U)
+  (B : (a : A) → U)
   : iff
     ( is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
     ( contractible-fibers A B)
   :=
-    ( \ ABprojequiv -> contractible-fibers-is-equiv-projection A B ABprojequiv ,
-      \ ABcontrfib -> is-equiv-projection-contractible-fibers A B ABcontrfib)
+    ( \ ABprojequiv → contractible-fibers-is-equiv-projection A B ABprojequiv ,
+      \ ABcontrfib → is-equiv-projection-contractible-fibers A B ABcontrfib)
 ```

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -14,37 +14,37 @@ This is a literate `rzk` file:
 
 ```rzk
 -- the 1-simplex
-#def Δ¹ : 2 -> TOPE
-  := \ t -> TOP
+#def Δ¹ : 2 → TOPE
+  := \ t → TOP
 
 -- the 2-simplex
-#def Δ² : (2 * 2) -> TOPE
-  := \ (t , s) -> s <= t
+#def Δ² : (2 * 2) → TOPE
+  := \ (t , s) → s <= t
 
 -- the 3-simplex
-#def Δ³ : (2 * 2 * 2) -> TOPE
-  := \ ((t1 , t2) , t3) -> t3 <= t2 /\ t2 <= t1
+#def Δ³ : (2 * 2 * 2) → TOPE
+  := \ ((t1 , t2) , t3) → t3 <= t2 /\ t2 <= t1
 ```
 
 ### Boundaries of simplices
 
 ```rzk
 -- the boundary of a 1-simplex
-#def ∂Δ¹ : Δ¹ -> TOPE
-  := \ t -> (t === 0_2 \/ t === 1_2)
+#def ∂Δ¹ : Δ¹ → TOPE
+  := \ t → (t === 0_2 \/ t === 1_2)
 
 -- the boundary of a 2-simplex
-#def ∂Δ² : Δ² -> TOPE
+#def ∂Δ² : Δ² → TOPE
   :=
-    \ (t, s) ->
+    \ (t, s) →
     ( s === 0_2 \/ t === 1_2 \/ s === t)
 ```
 
 ### The inner horn
 
 ```rzk
-#def Λ : (2 * 2) -> TOPE
-  := \ (t , s) -> (s === 0_2 \/ t === 1_2)
+#def Λ : (2 * 2) → TOPE
+  := \ (t , s) → (s === 0_2 \/ t === 1_2)
 ```
 
 ### Products
@@ -54,29 +54,29 @@ The product of topes defines the product of shapes.
 ```rzk
 #def shape-prod
   (I J : CUBE)
-  (ψ : I -> TOPE)
-  (χ : J -> TOPE)
-  : (I * J) -> TOPE
-  := \ (t , s) -> ψ t /\ χ s
+  (ψ : I → TOPE)
+  (χ : J → TOPE)
+  : (I * J) → TOPE
+  := \ (t , s) → ψ t /\ χ s
 
 -- the square as a product
-#def Δ¹×Δ¹ : (2 * 2) -> TOPE
+#def Δ¹×Δ¹ : (2 * 2) → TOPE
   := shape-prod 2 2 Δ¹ Δ¹
 
 -- the total boundary of the square
-#def ∂□ : (2 * 2) -> TOPE
-  := \ (t ,s) -> ((∂Δ¹ t) /\ (Δ¹ s)) \/ ((Δ¹ t) /\ (∂Δ¹ s))
+#def ∂□ : (2 * 2) → TOPE
+  := \ (t ,s) → ((∂Δ¹ t) /\ (Δ¹ s)) \/ ((Δ¹ t) /\ (∂Δ¹ s))
 
 -- the vertical boundary of the square
-#def ∂Δ¹×Δ¹ : (2 * 2) -> TOPE
+#def ∂Δ¹×Δ¹ : (2 * 2) → TOPE
   := shape-prod 2 2 ∂Δ¹ Δ¹
 
 -- the horizontal boundary of the square
-#def Δ¹×∂Δ¹ : (2 * 2) -> TOPE
+#def Δ¹×∂Δ¹ : (2 * 2) → TOPE
   := shape-prod 2 2 Δ¹ ∂Δ¹
 
 -- the prism from a 2-simplex in an arrow type
-#def Δ²×Δ¹ : (2 * 2 * 2) -> TOPE
+#def Δ²×Δ¹ : (2 * 2 * 2) → TOPE
   := shape-prod (2 * 2) 2 Δ² Δ¹
 ```
 
@@ -86,8 +86,8 @@ The intersection of shapes is defined by conjunction on topes:
 
 ```rzk
 #def shape-intersection
-  (I : CUBE) (ψ χ : I -> TOPE) : I -> TOPE
-  := \ t -> ψ t /\ χ t
+  (I : CUBE) (ψ χ : I → TOPE) : I → TOPE
+  := \ t → ψ t /\ χ t
 ```
 
 ### Unions
@@ -96,6 +96,6 @@ The union of shapes is defined by disjunction on topes:
 
 ```rzk
 #def shapeUnion
-  (I : CUBE) (ψ χ : I -> TOPE) : I -> TOPE
-  := \ t -> ψ t \/ χ t
+  (I : CUBE) (ψ χ : I → TOPE) : I → TOPE
+  := \ t → ψ t \/ χ t
 ```

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -18,11 +18,11 @@ This is a literate `rzk` file:
   := \ t → TOP
 
 -- the 2-simplex
-#def Δ² : (2 * 2) → TOPE
+#def Δ² : (2 × 2) → TOPE
   := \ (t , s) → s ≤ t
 
 -- the 3-simplex
-#def Δ³ : (2 * 2 * 2) → TOPE
+#def Δ³ : (2 × 2 × 2) → TOPE
   := \ ((t1 , t2) , t3) → t3 ≤ t2 ∧ t2 ≤ t1
 ```
 
@@ -43,7 +43,7 @@ This is a literate `rzk` file:
 ### The inner horn
 
 ```rzk
-#def Λ : (2 * 2) → TOPE
+#def Λ : (2 × 2) → TOPE
   := \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂)
 ```
 
@@ -56,28 +56,28 @@ The product of topes defines the product of shapes.
   (I J : CUBE)
   (ψ : I → TOPE)
   (χ : J → TOPE)
-  : (I * J) → TOPE
+  : (I × J) → TOPE
   := \ (t , s) → ψ t ∧ χ s
 
 -- the square as a product
-#def Δ¹×Δ¹ : (2 * 2) → TOPE
+#def Δ¹×Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ Δ¹
 
 -- the total boundary of the square
-#def ∂□ : (2 * 2) → TOPE
+#def ∂□ : (2 × 2) → TOPE
   := \ (t ,s) → ((∂Δ¹ t) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (∂Δ¹ s))
 
 -- the vertical boundary of the square
-#def ∂Δ¹×Δ¹ : (2 * 2) → TOPE
+#def ∂Δ¹×Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 ∂Δ¹ Δ¹
 
 -- the horizontal boundary of the square
-#def Δ¹×∂Δ¹ : (2 * 2) → TOPE
+#def Δ¹×∂Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ ∂Δ¹
 
 -- the prism from a 2-simplex in an arrow type
-#def Δ²×Δ¹ : (2 * 2 * 2) → TOPE
-  := shape-prod (2 * 2) 2 Δ² Δ¹
+#def Δ²×Δ¹ : (2 × 2 × 2) → TOPE
+  := shape-prod (2 × 2) 2 Δ² Δ¹
 ```
 
 ### Intersections

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -31,20 +31,20 @@ This is a literate `rzk` file:
 ```rzk
 -- the boundary of a 1-simplex
 #def ∂Δ¹ : Δ¹ → TOPE
-  := \ t → (t ≡ 0_2 ∨ t ≡ 1_2)
+  := \ t → (t ≡ 0₂ ∨ t ≡ 1₂)
 
 -- the boundary of a 2-simplex
 #def ∂Δ² : Δ² → TOPE
   :=
     \ (t, s) →
-    ( s ≡ 0_2 ∨ t ≡ 1_2 ∨ s ≡ t)
+    ( s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
 ```
 
 ### The inner horn
 
 ```rzk
 #def Λ : (2 * 2) → TOPE
-  := \ (t , s) → (s ≡ 0_2 ∨ t ≡ 1_2)
+  := \ (t , s) → (s ≡ 0₂ ∨ t ≡ 1₂)
 ```
 
 ### Products

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -19,11 +19,11 @@ This is a literate `rzk` file:
 
 -- the 2-simplex
 #def Δ² : (2 * 2) → TOPE
-  := \ (t , s) → s <= t
+  := \ (t , s) → s ≤ t
 
 -- the 3-simplex
 #def Δ³ : (2 * 2 * 2) → TOPE
-  := \ ((t1 , t2) , t3) → t3 <= t2 /\ t2 <= t1
+  := \ ((t1 , t2) , t3) → t3 ≤ t2 ∧ t2 ≤ t1
 ```
 
 ### Boundaries of simplices
@@ -31,20 +31,20 @@ This is a literate `rzk` file:
 ```rzk
 -- the boundary of a 1-simplex
 #def ∂Δ¹ : Δ¹ → TOPE
-  := \ t → (t === 0_2 \/ t === 1_2)
+  := \ t → (t ≡ 0_2 ∨ t ≡ 1_2)
 
 -- the boundary of a 2-simplex
 #def ∂Δ² : Δ² → TOPE
   :=
     \ (t, s) →
-    ( s === 0_2 \/ t === 1_2 \/ s === t)
+    ( s ≡ 0_2 ∨ t ≡ 1_2 ∨ s ≡ t)
 ```
 
 ### The inner horn
 
 ```rzk
 #def Λ : (2 * 2) → TOPE
-  := \ (t , s) → (s === 0_2 \/ t === 1_2)
+  := \ (t , s) → (s ≡ 0_2 ∨ t ≡ 1_2)
 ```
 
 ### Products
@@ -57,7 +57,7 @@ The product of topes defines the product of shapes.
   (ψ : I → TOPE)
   (χ : J → TOPE)
   : (I * J) → TOPE
-  := \ (t , s) → ψ t /\ χ s
+  := \ (t , s) → ψ t ∧ χ s
 
 -- the square as a product
 #def Δ¹×Δ¹ : (2 * 2) → TOPE
@@ -65,7 +65,7 @@ The product of topes defines the product of shapes.
 
 -- the total boundary of the square
 #def ∂□ : (2 * 2) → TOPE
-  := \ (t ,s) → ((∂Δ¹ t) /\ (Δ¹ s)) \/ ((Δ¹ t) /\ (∂Δ¹ s))
+  := \ (t ,s) → ((∂Δ¹ t) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (∂Δ¹ s))
 
 -- the vertical boundary of the square
 #def ∂Δ¹×Δ¹ : (2 * 2) → TOPE
@@ -87,7 +87,7 @@ The intersection of shapes is defined by conjunction on topes:
 ```rzk
 #def shape-intersection
   (I : CUBE) (ψ χ : I → TOPE) : I → TOPE
-  := \ t → ψ t /\ χ t
+  := \ t → ψ t ∧ χ t
 ```
 
 ### Unions
@@ -97,5 +97,5 @@ The union of shapes is defined by disjunction on topes:
 ```rzk
 #def shapeUnion
   (I : CUBE) (ψ χ : I → TOPE) : I → TOPE
-  := \ t → ψ t \/ χ t
+  := \ t → ψ t ∨ χ t
 ```

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -60,11 +60,11 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
+  ( f : { (t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
     ( (t : ψ) → ((s : ζ) → X t s [ χ s ↦ f (t , s) ])
       [ ϕ t ↦ \ s → f (t , s)])
-    ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+    ( { (t , s) : I × J | ψ t ∧ ζ s} → X t s
       [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
   :=
     ( \ g (t , s) → (g t) s , -- the one way map
@@ -80,9 +80,9 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
+  ( f : { (t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
-    ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+    ( { (t , s) : I × J | ψ t ∧ ζ s} → X t s
       [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
     ( (s : ζ) → ((t : ψ) → X t s [ ϕ t ↦ f (t , s) ])
       [ χ s ↦ \ t → f (t , s) ])
@@ -100,7 +100,7 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
+  ( f : { (t , s) : I × J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
     ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
         [ ϕ t ↦ \ s → f (t , s) ])
@@ -110,7 +110,7 @@ This is a literate `rzk` file:
     comp-equiv
       ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
         [ ϕ t ↦ \ s → f (t , s) ])
-      ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+      ( { (t , s) : I × J | ψ t ∧ ζ s} → X t s
         [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
       ( {s : ζ} → ({t : ψ} → X t s [ ϕ t ↦ f (t , s) ])
         [ χ s ↦ \ t → f (t , s) ])

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -19,101 +19,101 @@ This is a literate `rzk` file:
 ```rzk title="RS17, Theorem 4.1"
 #def flip-ext-fun
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( X : U)
-  ( Y : ψ -> X -> U)
-  ( f : (t : ϕ) -> (x : X) -> Y t x)
+  ( Y : ψ → X → U)
+  ( f : (t : ϕ) → (x : X) → Y t x)
   : Equiv
-      ( (t : ψ) -> ((x : X) -> Y t x) [ϕ t |-> f t])
-      ( (x : X) -> (t : ψ) -> Y t x [ϕ t |-> f t x])
+      ( (t : ψ) → ((x : X) → Y t x) [ϕ t ↦ f t])
+      ( (x : X) → (t : ψ) → Y t x [ϕ t ↦ f t x])
   :=
-    ( \ g x t -> g t x ,
-      ( ( \ h t x -> (h x) t ,
-          \ g -> refl) ,
-        ( \ h t x -> (h x) t ,
-          \ h -> refl)))
+    ( \ g x t → g t x ,
+      ( ( \ h t x → (h x) t ,
+          \ g → refl) ,
+        ( \ h t x → (h x) t ,
+          \ h → refl)))
 
 #def flip-ext-fun-inv
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
   ( X : U)
-  ( Y : ψ -> X -> U)
-  ( f : (t : ϕ) -> (x : X) -> Y t x)
+  ( Y : ψ → X → U)
+  ( f : (t : ϕ) → (x : X) → Y t x)
   : Equiv
-    ( (x : X) -> (t : ψ) -> Y t x [ ϕ t |-> f t x])
-    ( (t : ψ) -> ((x : X) -> Y t x) [ ϕ t |-> f t ])
+    ( (x : X) → (t : ψ) → Y t x [ ϕ t ↦ f t x])
+    ( (t : ψ) → ((x : X) → Y t x) [ ϕ t ↦ f t ])
   :=
-    ( \ h t x -> (h x) t , -- the one-way map
-      ( ( \ g x t -> g t x , -- the retraction
-          \ h -> refl) , -- the retracting homotopy
-        ( \ g x t -> g t x , -- the section
-          \ g -> refl)))
+    ( \ h t x → (h x) t , -- the one-way map
+      ( ( \ g x t → g t x , -- the retraction
+          \ h → refl) , -- the retracting homotopy
+        ( \ g x t → g t x , -- the section
+          \ g → refl)))
 ```
 
 ```rzk title="RS17, Theorem 4.2"
 #def curry-uncurry
   ( I J : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( ζ : J -> TOPE)
-  ( χ : ζ -> TOPE)
-  ( X : ψ -> ζ -> U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} -> X t s )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( X : ψ → ζ → U)
+  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
   : Equiv
-    ( (t : ψ) -> ((s : ζ) -> X t s [ χ s |-> f (t , s) ])
-      [ ϕ t |-> \ s -> f (t , s)])
-    ( { (t , s) : I * J | ψ t /\ ζ s} -> X t s
-      [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) |-> f (t , s)])
+    ( (t : ψ) → ((s : ζ) → X t s [ χ s ↦ f (t , s) ])
+      [ ϕ t ↦ \ s → f (t , s)])
+    ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
+      [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
   :=
-    ( \ g (t , s) -> (g t) s , -- the one way map
-      ( ( \ h t s -> h (t , s) , -- its retraction
-          \ g -> refl) , -- the retracting homotopy
-        ( \ h t s -> h (t , s) , -- its section
-          \ h -> refl)))  -- the section homotopy
+    ( \ g (t , s) → (g t) s , -- the one way map
+      ( ( \ h t s → h (t , s) , -- its retraction
+          \ g → refl) , -- the retracting homotopy
+        ( \ h t s → h (t , s) , -- its section
+          \ h → refl)))  -- the section homotopy
 
 #def uncurry-opcurry
   ( I J : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( ζ : J -> TOPE)
-  ( χ : ζ -> TOPE)
-  ( X : ψ -> ζ -> U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} -> X t s )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( X : ψ → ζ → U)
+  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
   : Equiv
-    ( { (t , s) : I * J | ψ t /\ ζ s} -> X t s
-      [ (ϕ t /\ ζ s) \/ (ψ t /\ χ s) |-> f (t , s)])
-    ( (s : ζ) -> ((t : ψ) -> X t s [ ϕ t |-> f (t , s) ])
-      [ χ s |-> \ t -> f (t , s) ])
+    ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
+      [ (ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
+    ( (s : ζ) → ((t : ψ) → X t s [ ϕ t ↦ f (t , s) ])
+      [ χ s ↦ \ t → f (t , s) ])
   :=
-    ( \ h s t -> h (t , s) ,
-      ( ( \ g (t , s) -> (g s) t ,
-          \ h -> refl) ,
-        ( \ g (t , s) -> (g s) t ,
-          \ g -> refl)))
+    ( \ h s t → h (t , s) ,
+      ( ( \ g (t , s) → (g s) t ,
+          \ h → refl) ,
+        ( \ g (t , s) → (g s) t ,
+          \ g → refl)))
 
 #def fubini
   ( I J : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( ζ : J -> TOPE)
-  ( χ : ζ -> TOPE)
-  ( X : ψ -> ζ -> U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} -> X t s )
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( ζ : J → TOPE)
+  ( χ : ζ → TOPE)
+  ( X : ψ → ζ → U)
+  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
   : Equiv
-    ( {t : ψ} -> ({s : ζ} -> X t s [ χ s |-> f (t , s) ])
-        [ ϕ t |-> \ s -> f (t , s) ])
-    ( {s : ζ} -> ({t : ψ} -> X t s [ ϕ t |-> f (t , s) ])
-        [ χ s |-> \ t -> f (t , s) ])
+    ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
+        [ ϕ t ↦ \ s → f (t , s) ])
+    ( {s : ζ} → ({t : ψ} → X t s [ ϕ t ↦ f (t , s) ])
+        [ χ s ↦ \ t → f (t , s) ])
   :=
     comp-equiv
-      ( {t : ψ} -> ({s : ζ} -> X t s [ χ s |-> f (t , s) ])
-        [ ϕ t |-> \ s -> f (t , s) ])
-      ( { (t , s) : I * J | ψ t /\ ζ s} -> X t s
-        [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) |-> f (t , s)])
-      ( {s : ζ} -> ({t : ψ} -> X t s [ ϕ t |-> f (t , s) ])
-        [ χ s |-> \ t -> f (t , s) ])
+      ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
+        [ ϕ t ↦ \ s → f (t , s) ])
+      ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
+        [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
+      ( {s : ζ} → ({t : ψ} → X t s [ ϕ t ↦ f (t , s) ])
+        [ χ s ↦ \ t → f (t , s) ])
       ( curry-uncurry I J ψ ϕ ζ χ X f)
       ( uncurry-opcurry I J ψ ϕ ζ χ X f)
 ```
@@ -123,22 +123,22 @@ This is a literate `rzk` file:
 ```rzk title="RS17, Theorem 4.3"
 #def axiom-choice
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( X : ψ -> U)
-  ( Y : (t : ψ) -> (x : X t) -> U)
-  ( a : (t : ϕ) -> X t)
-  ( b : (t : ϕ) -> Y t (a t))
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( X : ψ → U)
+  ( Y : (t : ψ) → (x : X t) → U)
+  ( a : (t : ϕ) → X t)
+  ( b : (t : ϕ) → Y t (a t))
   : Equiv
-    ( {t : ψ} -> (Σ (x : X t) , Y t x) [ ϕ t |-> (a t , b t) ])
-    ( Σ ( f : ((t : ψ) -> X t [ ϕ t |-> a t ])) ,
-        ( (t : ψ) -> Y t (f t) [ ϕ t |-> b t ]))
+    ( {t : ψ} → (Σ (x : X t) , Y t x) [ ϕ t ↦ (a t , b t) ])
+    ( Σ ( f : ((t : ψ) → X t [ ϕ t ↦ a t ])) ,
+        ( (t : ψ) → Y t (f t) [ ϕ t ↦ b t ]))
     :=
-      ( \ g -> (\ t -> (first (g t)) , \ t -> second (g t)) ,
-        ( ( \ (f, h) t -> (f t , h t) ,
-            \ _ -> refl) ,
-          ( \ (f, h) t -> (f t , h t) ,
-            \ _ -> refl)))
+      ( \ g → (\ t → (first (g t)) , \ t → second (g t)) ,
+        ( ( \ (f, h) t → (f t , h t) ,
+            \ _ → refl) ,
+          ( \ (f, h) t → (f t , h t) ,
+            \ _ → refl)))
 ```
 
 ## Composites and unions of cofibrations
@@ -148,51 +148,51 @@ This is a literate `rzk` file:
 -- See https://github.com/rzk-lang/rzk/issues/8
 #def cofibration-composition'
   ( I : CUBE)
-  ( χ ψ ϕ : I -> TOPE)
-  ( X : χ -> U)
-  ( a : {t : I | χ t /\ ψ t /\ ϕ t} -> X t )
+  ( χ ψ ϕ : I → TOPE)
+  ( X : χ → U)
+  ( a : {t : I | χ t /\ ψ t /\ ϕ t} → X t )
   : Equiv
-      ( (t : χ) -> X t [ χ t /\ ψ t /\ ϕ t |-> a t ])
-      ( Σ ( f : {t : I | χ t /\ ψ t} -> X t [ χ t /\ ψ t /\ ϕ t |-> a t ]) ,
-          ( (t : χ) -> X t [ χ t /\ ψ t |-> f t ]))
+      ( (t : χ) → X t [ χ t /\ ψ t /\ ϕ t ↦ a t ])
+      ( Σ ( f : {t : I | χ t /\ ψ t} → X t [ χ t /\ ψ t /\ ϕ t ↦ a t ]) ,
+          ( (t : χ) → X t [ χ t /\ ψ t ↦ f t ]))
   :=
-    ( \ h -> (\ t -> h t , \ t -> h t) ,
-      ( ( \ (_f, g) t -> g t , \ h -> refl) ,
-        ( \ (_f, g) t -> g t , \ h -> refl)))
+    ( \ h → (\ t → h t , \ t → h t) ,
+      ( ( \ (_f, g) t → g t , \ h → refl) ,
+        ( \ (_f, g) t → g t , \ h → refl)))
 ```
 
 ```rzk title="RS17, Theorem 4.4"
 -- original form
 #def cofibration-composition
   ( I : CUBE)
-  ( χ : I -> TOPE)
-  ( ψ : χ -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( X : χ -> U)
-  ( a : (t : ϕ) -> X t)
+  ( χ : I → TOPE)
+  ( ψ : χ → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( X : χ → U)
+  ( a : (t : ϕ) → X t)
   : Equiv
-    ( (t : χ) -> X t [ ϕ t |-> a t ])
-    ( Σ ( f : (t : ψ) -> X t [ ϕ t |-> a t ]) ,
-        ( (t : χ) -> X t [ ψ t |-> f t ]))
+    ( (t : χ) → X t [ ϕ t ↦ a t ])
+    ( Σ ( f : (t : ψ) → X t [ ϕ t ↦ a t ]) ,
+        ( (t : χ) → X t [ ψ t ↦ f t ]))
   :=
-    ( \ h -> (\ t -> h t , \ t -> h t) ,
-      ( ( \ (_f, g) t -> g t , \ h -> refl) ,
-        ( ( \ (_f, g) t -> g t , \ h -> refl))))
+    ( \ h → (\ t → h t , \ t → h t) ,
+      ( ( \ (_f, g) t → g t , \ h → refl) ,
+        ( ( \ (_f, g) t → g t , \ h → refl))))
 ```
 
 ```rzk title="RS17, Theorem 4.5"
 #def cofibration-union
   ( I : CUBE)
-  ( ϕ ψ : I -> TOPE)
-  ( X : {t : I | ϕ t \/ ψ t} -> U )
-  ( a : (t : ψ) -> X t)
+  ( ϕ ψ : I → TOPE)
+  ( X : {t : I | ϕ t \/ ψ t} → U )
+  ( a : (t : ψ) → X t)
   : Equiv
-      ( {t : I | ϕ t \/ ψ t} -> X t [ ψ t |-> a t ])
-      ( (t : ϕ) -> X t [ ϕ t /\ ψ t |-> a t ])
+      ( {t : I | ϕ t \/ ψ t} → X t [ ψ t ↦ a t ])
+      ( (t : ϕ) → X t [ ϕ t /\ ψ t ↦ a t ])
   :=
-    (\ h -> \ t -> h t ,
-      ( ( \ g -> \ t -> recOR (ϕ t |-> g t , ψ t |-> a t) , \ h -> refl) ,
-        ( \ g -> \ t -> recOR (ϕ t |-> g t , ψ t |-> a t) , \ h -> refl)))
+    (\ h → \ t → h t ,
+      ( ( \ g → \ t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ h → refl) ,
+        ( \ g → \ t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ h → refl)))
 ```
 
 ## Relative function extensionality
@@ -203,18 +203,18 @@ axiom. Here we state the one that will be most useful and derive an application.
 ```rzk
 #def ext-htpy-eq
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( A : ψ -> U)
-  ( a : (t : ϕ) -> A t)
-  ( f g : (t : ψ) -> A t [ ϕ t |-> a t ])
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( a : (t : ϕ) → A t)
+  ( f g : (t : ψ) → A t [ ϕ t ↦ a t ])
   ( p : f = g)
-  : (t : ψ) -> (f t = g t) [ ϕ t |-> refl ]
+  : (t : ψ) → (f t = g t) [ ϕ t ↦ refl ]
   := idJ
-    ( ( (t : ψ) -> A t [ ϕ t |-> a t ]) ,
+    ( ( (t : ψ) → A t [ ϕ t ↦ a t ]) ,
       ( f) ,
-      ( \ g' p' -> (t : ψ) -> (f t = g' t) [ ϕ t |-> refl ]) ,
-      ( \ t -> refl) ,
+      ( \ g' p' → (t : ψ) → (f t = g' t) [ ϕ t ↦ refl ]) ,
+      ( \ t → refl) ,
       ( g) ,
       ( p))
 ```
@@ -227,16 +227,16 @@ footnote 8, we assert this as an "extension extensionality" axiom
 #def ExtExt
   : U
   :=
-    ( I : CUBE) ->
-    ( ψ : I -> TOPE) ->
-    ( ϕ : ψ -> TOPE) ->
-    ( A : ψ -> U) ->
-    ( a : (t : ϕ) -> A t) ->
-    ( f : (t : ψ) -> A t [ ϕ t |-> a t ]) ->
-    ( g : (t : ψ) -> A t [ ϕ t |-> a t ]) ->
+    ( I : CUBE) →
+    ( ψ : I → TOPE) →
+    ( ϕ : ψ → TOPE) →
+    ( A : ψ → U) →
+    ( a : (t : ϕ) → A t) →
+    ( f : (t : ψ) → A t [ ϕ t ↦ a t ]) →
+    ( g : (t : ψ) → A t [ ϕ t ↦ a t ]) →
     is-equiv
       ( f = g)
-      ( (t : ψ) -> (f t = g t) [ ϕ t |-> refl ])
+      ( (t : ψ) → (f t = g t) [ ϕ t ↦ refl ])
       ( ext-htpy-eq I ψ ϕ A a f g)
 
 #assume extext : ExtExt
@@ -244,12 +244,12 @@ footnote 8, we assert this as an "extension extensionality" axiom
 -- The equivalence provided by extension extensionality.
 #def equiv-ExtExt uses (extext)
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( A : ψ -> U)
-  ( a : (t : ϕ) -> A t)
-  ( f g : (t : ψ) -> A t [ ϕ t |-> a t ])
-  : Equiv (f = g) ((t : ψ) -> (f t = g t) [ ϕ t |-> refl ])
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( a : (t : ϕ) → A t)
+  ( f g : (t : ψ) → A t [ ϕ t ↦ a t ])
+  : Equiv (f = g) ((t : ψ) → (f t = g t) [ ϕ t ↦ refl ])
   := (ext-htpy-eq I ψ ϕ A a f g , extext I ψ ϕ A a f g)
 ```
 
@@ -260,12 +260,12 @@ identifications. This definition defines `eq-ext-htpy` to be the retraction to
 ```rzk
 #def eq-ext-htpy uses (extext)
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( ϕ : ψ -> TOPE)
-  ( A : ψ -> U)
-  ( a : (t : ϕ) -> A t)
-  ( f g : (t : ψ) -> A t [ ϕ t |-> a t ])
-  : ((t : ψ) -> (f t = g t) [ ϕ t |-> refl ]) -> (f = g)
+  ( ψ : I → TOPE)
+  ( ϕ : ψ → TOPE)
+  ( A : ψ → U)
+  ( a : (t : ϕ) → A t)
+  ( f g : (t : ψ) → A t [ ϕ t ↦ a t ])
+  : ((t : ψ) → (f t = g t) [ ϕ t ↦ refl ]) → (f = g)
   := first (first (extext I ψ ϕ A a f g))
 ```
 
@@ -277,34 +277,34 @@ equivalences of extension types.
 -- simplicity extending from BOT
 #def equiv-extension-equiv-fibered uses (extext)
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( A B : ψ -> U)
-  ( fibequiv : (t : ψ) -> (Equiv (A t) (B t)) )
-  : Equiv ((t : ψ) -> A t ) ((t : ψ) -> B t )
+  ( ψ : I → TOPE)
+  ( A B : ψ → U)
+  ( fibequiv : (t : ψ) → (Equiv (A t) (B t)) )
+  : Equiv ((t : ψ) → A t ) ((t : ψ) → B t )
   :=
-    ( ( \ a t -> (first (fibequiv t)) (a t)) ,
-      ( ( ( \ b t -> (first (first (second (fibequiv t)))) (b t)) ,
-          ( \ a ->
+    ( ( \ a t → (first (fibequiv t)) (a t)) ,
+      ( ( ( \ b t → (first (first (second (fibequiv t)))) (b t)) ,
+          ( \ a →
             eq-ext-htpy
               ( I)
               ( ψ)
-              ( \ t -> BOT)
+              ( \ t → BOT)
               ( A)
-              ( \ u -> recBOT)
-              ( \ t ->
+              ( \ u → recBOT)
+              ( \ t →
                 first (first (second (fibequiv t))) (first (fibequiv t) (a t)))
               ( a)
-              ( \ t -> second (first (second (fibequiv t))) (a t)))) ,
-        ( ( \ b t -> first (second (second (fibequiv t))) (b t)) ,
-          ( \ b ->
+              ( \ t → second (first (second (fibequiv t))) (a t)))) ,
+        ( ( \ b t → first (second (second (fibequiv t))) (b t)) ,
+          ( \ b →
             eq-ext-htpy
               ( I)
               ( ψ)
-              ( \ t -> BOT)
+              ( \ t → BOT)
               ( B)
-              ( \ u -> recBOT)
-              ( \ t ->
+              ( \ u → recBOT)
+              ( \ t →
                 first (fibequiv t) (first (second (second (fibequiv t))) (b t)))
               ( b)
-              ( \ t -> second (second (second (fibequiv t))) (b t))))))
+              ( \ t → second (second (second (fibequiv t))) (b t))))))
 ```

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -60,12 +60,12 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
+  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
     ( (t : ψ) → ((s : ζ) → X t s [ χ s ↦ f (t , s) ])
       [ ϕ t ↦ \ s → f (t , s)])
-    ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
-      [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
+    ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+      [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
   :=
     ( \ g (t , s) → (g t) s , -- the one way map
       ( ( \ h t s → h (t , s) , -- its retraction
@@ -80,10 +80,10 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
+  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
-    ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
-      [ (ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
+    ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+      [ (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
     ( (s : ζ) → ((t : ψ) → X t s [ ϕ t ↦ f (t , s) ])
       [ χ s ↦ \ t → f (t , s) ])
   :=
@@ -100,7 +100,7 @@ This is a literate `rzk` file:
   ( ζ : J → TOPE)
   ( χ : ζ → TOPE)
   ( X : ψ → ζ → U)
-  ( f : { (t , s) : I * J | (ϕ t /\ ζ s) \/ (ψ t /\ χ s)} → X t s )
+  ( f : { (t , s) : I * J | (ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s)} → X t s )
   : Equiv
     ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
         [ ϕ t ↦ \ s → f (t , s) ])
@@ -110,8 +110,8 @@ This is a literate `rzk` file:
     comp-equiv
       ( {t : ψ} → ({s : ζ} → X t s [ χ s ↦ f (t , s) ])
         [ ϕ t ↦ \ s → f (t , s) ])
-      ( { (t , s) : I * J | ψ t /\ ζ s} → X t s
-        [(ϕ t /\ ζ s) \/ (ψ t /\ χ s) ↦ f (t , s)])
+      ( { (t , s) : I * J | ψ t ∧ ζ s} → X t s
+        [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
       ( {s : ζ} → ({t : ψ} → X t s [ ϕ t ↦ f (t , s) ])
         [ χ s ↦ \ t → f (t , s) ])
       ( curry-uncurry I J ψ ϕ ζ χ X f)
@@ -150,11 +150,11 @@ This is a literate `rzk` file:
   ( I : CUBE)
   ( χ ψ ϕ : I → TOPE)
   ( X : χ → U)
-  ( a : {t : I | χ t /\ ψ t /\ ϕ t} → X t )
+  ( a : {t : I | χ t ∧ ψ t ∧ ϕ t} → X t )
   : Equiv
-      ( (t : χ) → X t [ χ t /\ ψ t /\ ϕ t ↦ a t ])
-      ( Σ ( f : {t : I | χ t /\ ψ t} → X t [ χ t /\ ψ t /\ ϕ t ↦ a t ]) ,
-          ( (t : χ) → X t [ χ t /\ ψ t ↦ f t ]))
+      ( (t : χ) → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ])
+      ( Σ ( f : {t : I | χ t ∧ ψ t} → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ]) ,
+          ( (t : χ) → X t [ χ t ∧ ψ t ↦ f t ]))
   :=
     ( \ h → (\ t → h t , \ t → h t) ,
       ( ( \ (_f, g) t → g t , \ h → refl) ,
@@ -184,11 +184,11 @@ This is a literate `rzk` file:
 #def cofibration-union
   ( I : CUBE)
   ( ϕ ψ : I → TOPE)
-  ( X : {t : I | ϕ t \/ ψ t} → U )
+  ( X : {t : I | ϕ t ∨ ψ t} → U )
   ( a : (t : ψ) → X t)
   : Equiv
-      ( {t : I | ϕ t \/ ψ t} → X t [ ψ t ↦ a t ])
-      ( (t : ϕ) → X t [ ϕ t /\ ψ t ↦ a t ])
+      ( {t : I | ϕ t ∨ ψ t} → X t [ ψ t ↦ a t ])
+      ( (t : ϕ) → X t [ ϕ t ∧ ψ t ↦ a t ])
   :=
     (\ h → \ t → h t ,
       ( ( \ g → \ t → recOR (ϕ t ↦ g t , ψ t ↦ a t) , \ h → refl) ,

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -44,9 +44,9 @@ Extension types are used ∂to define the type of arrows between fixed terms:
   (A : U)
   (x y : A)
   : U
-  := (t : Δ¹) -> A [
-    t === 0_2 |-> x ,    -- * the left endpoint is exactly x
-    t === 1_2 |-> y     -- * the right endpoint is exactly y
+  := (t : Δ¹) → A [
+    t === 0_2 ↦ x ,    -- * the left endpoint is exactly x
+    t === 1_2 ↦ y     -- * the right endpoint is exactly y
   ]
 ```
 
@@ -74,10 +74,10 @@ Extension types are also used to define the type of commutative triangles:
   (g : hom A y z)
   (h : hom A x z)
   : U
-  := { (t1 , t2) : Δ² } -> A [
-    t2 === 0_2 |-> f t1 ,        -- * the top edge is exactly `f`,
-    t1 === 1_2 |-> g t2 ,        -- * the right edge is exactly `g`, and
-    t2 === t1 |-> h t2         -- * the diagonal is exactly `h`
+  := { (t1 , t2) : Δ² } → A [
+    t2 === 0_2 ↦ f t1 ,        -- * the top edge is exactly `f`,
+    t1 === 1_2 ↦ g t2 ,        -- * the right edge is exactly `g`, and
+    t2 === t1 ↦ h t2         -- * the diagonal is exactly `h`
   ]
 ```
 
@@ -91,8 +91,8 @@ requires homotopical uniqueness of higher-order composites.
 #def is-segal
   (A : U)
   : U
-  := (x : A) -> (y : A) -> (z : A) ->
-      (f : hom A x y) -> (g : hom A y z) ->
+  := (x : A) → (y : A) → (z : A) →
+      (f : hom A x y) → (g : hom A y z) →
       is-contr ( Σ (h : hom A x z) , hom2 A x y z f g h)
 ```
 
@@ -162,7 +162,7 @@ composite equals $h$.
   : (Segal-comp A is-segal-A x y z f g) = h
   := first-path-Σ
       (hom A x z)
-      (\ k -> hom2 A x y z f g k)
+      (\ k → hom2 A x y z f g k)
       (Segal-comp A is-segal-A x y z f g ,
         Segal-comp-witness A is-segal-A x y z f g)
       (h , alpha)
@@ -195,27 +195,27 @@ A pair of composable arrows form a horn.
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
-  : Λ -> A
+  : Λ → A
   :=
-    \ (t , s) ->
+    \ (t , s) →
     recOR
-    ( s === 0_2 |-> f t ,
-      t === 1_2 |-> g s)
+    ( s === 0_2 ↦ f t ,
+      t === 1_2 ↦ g s)
 ```
 
 The underlying horn of a simplex:
 
 ```rzk
 #def horn-restriction (A : U)
-  : (Δ² -> A) -> (Λ -> A)
-  := \ f t -> f t
+  : (Δ² → A) → (Λ → A)
+  := \ f t → f t
 ```
 
 This provides an alternate definition of Segal types.
 
 ```rzk
 #def is-local-horn-inclusion (A : U) : U
-  := is-equiv (Δ² -> A) (Λ -> A) (horn-restriction A)
+  := is-equiv (Δ² → A) (Λ → A) (horn-restriction A)
 ```
 
 Now we prove this definition is equivalent to the original one. Here, we prove
@@ -232,71 +232,71 @@ witnesses of the equivalence).
   (g : hom A y z)
   : Equiv
     ( Σ (h : hom A x z) , hom2 A x y z f g h)
-    ( (t : Δ²) -> A [ Λ t |-> horn A x y z f g t ])
+    ( (t : Δ²) → A [ Λ t ↦ horn A x y z f g t ])
   :=
-    ( \ hh t -> (second hh) t ,
-      ( ( \ k -> (\ t -> k (t , t) , \ (t , s) -> k (t , s)) ,
-          \ hh -> refl) ,
-        ( \ k -> (\ t -> k (t , t) , \ (t , s) -> k (t , s)) ,
-          \ hh -> refl)))
+    ( \ hh t → (second hh) t ,
+      ( ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s)) ,
+          \ hh → refl) ,
+        ( \ k → (\ t → k (t , t) , \ (t , s) → k (t , s)) ,
+          \ hh → refl)))
 
 #def equiv-horn-restriction
   (A : U)
   : Equiv
-    ( Δ² -> A)
-    ( Σ ( k : Λ -> A) ,
+    ( Δ² → A)
+    ( Σ ( k : Λ → A) ,
         ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
             ( hom2 A
               ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
+              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
               ( h))))
   :=
-    ( \ k ->
-      ( \ t -> k t ,
-        ( \ t -> k (t , t) ,
-          \ t -> k t)) ,
-      ( ( \ khh t -> (second (second khh)) t ,
-          \ k -> refl) ,
-        ( \ khh t -> (second (second khh)) t ,
-          \ k -> refl)))
+    ( \ k →
+      ( \ t → k t ,
+        ( \ t → k (t , t) ,
+          \ t → k t)) ,
+      ( ( \ khh t → (second (second khh)) t ,
+          \ k → refl) ,
+        ( \ khh t → (second (second khh)) t ,
+          \ k → refl)))
 ```
 
 ```rzk title="RS17, Theorem 5.5 (the hard direction)"
 #def Segal-equiv-horn-restriction
   (A : U)
   (is-segal-A : is-segal A)
-  : Equiv (Δ² -> A) (Λ -> A)
+  : Equiv (Δ² → A) (Λ → A)
   :=
     comp-equiv
-      ( Δ² -> A)
-      ( Σ ( k : Λ -> A) ,
+      ( Δ² → A)
+      ( Σ ( k : Λ → A) ,
           ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
                 ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
+                ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
                 ( h))))
-      ( Λ -> A)
+      ( Λ → A)
       ( equiv-horn-restriction A)
       ( total-space-projection
-        ( Λ -> A )
-        ( \ k ->
+        ( Λ → A )
+        ( \ k →
           Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
             ( hom2 A
               ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
+              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
               ( h))) ,
       ( is-equiv-projection-contractible-fibers
-          ( Λ -> A)
-          ( \ k ->
+          ( Λ → A)
+          ( \ k →
             Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
                 ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t))
+                ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
                 ( h)))
-          ( \ k ->
+          ( \ k →
             is-segal-A
               ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t -> k (t , 0_2)) (\ t -> k (1_2 , t)))))
+              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t)))))
 
 -- Verify that the mapping in (Segal-equiv-horn-restriction A is-segal-A)
 -- is exactly (horn-restriction A)
@@ -325,35 +325,35 @@ Types that are local at the horn inclusion are Segal types:
   ( is-local-horn-inclusion-A : is-local-horn-inclusion A)
   : is-segal A
   :=
-    \ x y z f g ->
+    \ x y z f g →
     contractible-fibers-is-equiv-projection
-      (  Λ -> A )
-      ( \ k ->
+      (  Λ → A )
+      ( \ k →
         Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
           ( hom2 A
             ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-            ( \ t -> k (t , 0_2))
-            ( \ t -> k (1_2 , t))
+            ( \ t → k (t , 0_2))
+            ( \ t → k (1_2 , t))
             ( h)))
       ( second
         ( comp-equiv
-          ( Σ ( k : Λ -> A ) ,
+          ( Σ ( k : Λ → A ) ,
             Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
               ( hom2 A
                 ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t -> k (t , 0_2))
-                ( \ t -> k (1_2 , t))
+                ( \ t → k (t , 0_2))
+                ( \ t → k (1_2 , t))
                 ( h)))
-          ( Δ² -> A )
-          ( Λ  -> A )
+          ( Δ² → A )
+          ( Λ  → A )
           ( inv-equiv
-            ( Δ² -> A )
-            ( Σ ( k : Λ -> A ) ,
+            ( Δ² → A )
+            ( Σ ( k : Λ → A ) ,
               Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
                 ( hom2 A
                   ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                  ( \ t -> k (t , 0_2))
-                  ( \ t -> k (1_2 , t))
+                  ( \ t → k (t , 0_2))
+                  ( \ t → k (1_2 , t))
                   ( h)))
             ( equiv-horn-restriction A))
           ( horn-restriction A , is-local-horn-inclusion-A)))
@@ -379,38 +379,38 @@ all $x$ then $(x : X) → A x$ is a Segal type.
 ```rzk title="RS17, Corollary 5.6(i)"
 #def Segal-function-types uses (funext)
   (X : U)
-  (A : (_ : X) -> U)
-  (fiberwise-is-segal-A : (x : X) -> is-local-horn-inclusion (A x))
-  : is-local-horn-inclusion ((x : X) -> A x)
+  (A : (_ : X) → U)
+  (fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
+  : is-local-horn-inclusion ((x : X) → A x)
   :=
     triple-compose-is-equiv
-      ( Δ² -> ((x : X) -> A x) )
-      ( (x : X) -> Δ² -> A x )
-      ( (x : X) -> Λ -> A x )
-      ( Λ -> ((x : X) -> A x) )
-      ( \ g x t -> g t x) -- first equivalence
+      ( Δ² → ((x : X) → A x) )
+      ( (x : X) → Δ² → A x )
+      ( (x : X) → Λ → A x )
+      ( Λ → ((x : X) → A x) )
+      ( \ g x t → g t x) -- first equivalence
       ( second (flip-ext-fun
         ( 2 * 2)
         ( Δ²)
-        ( \ t -> BOT)
+        ( \ t → BOT)
         ( X)
-        (\ t -> A)
-        (\ t -> recBOT)))
-      ( \ h x t -> h x t) -- second equivalence
+        (\ t → A)
+        (\ t → recBOT)))
+      ( \ h x t → h x t) -- second equivalence
       ( second (equiv-function-equiv-fibered
         ( funext)
         ( X)
-        ( \ x -> (Δ² -> A x) )
-        ( \ x -> (Λ -> A x) )
-        ( \ x -> (horn-restriction (A x) , fiberwise-is-segal-A x))))
-      ( \ h t x -> (h x) t) -- third equivalence
+        ( \ x → (Δ² → A x) )
+        ( \ x → (Λ → A x) )
+        ( \ x → (horn-restriction (A x) , fiberwise-is-segal-A x))))
+      ( \ h t x → (h x) t) -- third equivalence
       ( second (flip-ext-fun-inv
         ( 2 * 2)
         ( Λ)
-        ( \ t -> BOT)
+        ( \ t → BOT)
         ( X)
-        ( \ t -> A)
-        ( \ t -> recBOT)))
+        ( \ t → A)
+        ( \ t → recBOT)))
 ```
 
 If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $x$
@@ -419,41 +419,41 @@ then $(x : X) → A x$ is a Segal type.
 ```rzk title="RS17, Corollary 5.6(ii)"
 #def Segal-extension-types uses (extext)
   (I : CUBE)
-  (ψ : (s : I) -> TOPE)
-  (A : (s : ψ) -> U )
-  (fiberwise-is-segal-A : (s : ψ) -> is-local-horn-inclusion (A s) )
-  : is-local-horn-inclusion ((s : ψ) -> A s )
+  (ψ : (s : I) → TOPE)
+  (A : (s : ψ) → U )
+  (fiberwise-is-segal-A : (s : ψ) → is-local-horn-inclusion (A s) )
+  : is-local-horn-inclusion ((s : ψ) → A s )
   :=
     triple-compose-is-equiv
-    ( Δ² -> (s : ψ) -> A s  )
-    ( (s : ψ) -> Δ² -> A s  )
-    ( (s : ψ) -> Λ -> A s  )
-    ( Λ -> (s : ψ) -> A s  )
-    ( \ g s t -> g t s)  -- first equivalence
+    ( Δ² → (s : ψ) → A s  )
+    ( (s : ψ) → Δ² → A s  )
+    ( (s : ψ) → Λ → A s  )
+    ( Λ → (s : ψ) → A s  )
+    ( \ g s t → g t s)  -- first equivalence
     ( second (fubini
       ( 2 * 2)
       ( I)
       ( Δ²)
-      ( \ t -> BOT)
+      ( \ t → BOT)
       ( ψ)
-      ( \ s -> BOT)
-      ( \ t s -> A s)
-      ( \ u -> recBOT)))
-    ( \ h s t -> h s t) -- second equivalence
+      ( \ s → BOT)
+      ( \ t s → A s)
+      ( \ u → recBOT)))
+    ( \ h s t → h s t) -- second equivalence
     ( second (equiv-extension-equiv-fibered extext I ψ
-      ( \ s -> Δ² -> A s )
-      ( \ s -> Λ -> A s )
-      ( \ s -> (horn-restriction (A s) , fiberwise-is-segal-A s)) ))
-    ( \ h t s -> (h s) t) -- third equivalence
+      ( \ s → Δ² → A s )
+      ( \ s → Λ → A s )
+      ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s)) ))
+    ( \ h t s → (h s) t) -- third equivalence
     ( second (fubini
       ( I)
       ( 2 * 2)
       ( ψ)
-      ( \ s -> BOT)
+      ( \ s → BOT)
       ( Λ)
-      ( \ t -> BOT)
-      ( \ s t -> A s)
-      ( \ u -> recBOT)))
+      ( \ t → BOT)
+      ( \ s t → A s)
+      ( \ u → recBOT)))
 ```
 
 In particular, the arrow type of a Segal type is Segal. First, we define the
@@ -463,7 +463,7 @@ arrow type:
 #def arr
   (A : U)
   : U
-  := (t : Δ¹) -> A
+  := (t : Δ¹) → A
 ```
 
 For later use, an equivalent characterization of the arrow type.
@@ -473,9 +473,9 @@ For later use, an equivalent characterization of the arrow type.
   (A : U)
   : Equiv (arr A) (Σ (x : A) , (Σ (y : A) , hom A x y))
   :=
-    ( \ f -> (f 0_2 , (f 1_2 , f)) ,
-      ( ( \ (x , (y , f)) -> f , \ f -> refl) ,
-        ( \ (x , (y , f)) -> f , \ xyf -> refl)))
+    ( \ f → (f 0_2 , (f 1_2 , f)) ,
+      ( ( \ (x , (y , f)) → f , \ f → refl) ,
+        ( \ (x , (y , f)) → f , \ xyf → refl)))
 ```
 
 ```rzk title="RS17, Corollary 5.6(ii)"
@@ -488,8 +488,8 @@ For later use, an equivalent characterization of the arrow type.
     Segal-extension-types
       ( 2)
       ( Δ¹)
-      ( \ t -> A)
-      ( \ t -> is-segal-A)
+      ( \ t → A)
+      ( \ t → is-segal-A)
 
 -- special case using `is-segal`
 #def Segal-arrow-types uses (extext)
@@ -501,8 +501,8 @@ For later use, an equivalent characterization of the arrow type.
       ( Segal-extension-types
           ( 2)
           ( Δ¹)
-          ( \ t -> A)
-          ( \ t -> (is-local-horn-inclusion-is-segal A is-segal-A)))
+          ( \ t → A)
+          ( \ t → (is-local-horn-inclusion-is-segal A is-segal-A)))
 ```
 
 ## Identity
@@ -522,7 +522,7 @@ All types have identity arrows and witnesses to the identity composition law.
   (A : U)
   (x : A)
   : hom A x x
-  := \ t -> x
+  := \ t → x
 ```
 
 Witness for the right identity law:
@@ -548,7 +548,7 @@ Witness for the right identity law:
   (x y : A)
   (f : hom A x y)
   : hom2 A x y y f (id-arr A y) f
-  := \ (t, s) -> f t
+  := \ (t, s) → f t
 ```
 
 Witness for the left identity law:
@@ -574,7 +574,7 @@ Witness for the left identity law:
   (x y : A)
   (f : hom A x y)
   : hom2 A x x y (id-arr A x) f f
-  := \ (t, s) -> f s
+  := \ (t, s) → f s
 ```
 
 In a Segal type, where composition is unique, it follows that composition with
@@ -639,12 +639,12 @@ that the type of arrows in a Segal type is itself a Segal type.
 ```rzk
 #def unfolding-square
   (A : U)
-  (triangle : Δ² -> A)
-  : Δ¹×Δ¹ -> A
+  (triangle : Δ² → A)
+  : Δ¹×Δ¹ → A
   :=
-    \ (t , s) ->
-    recOR ( t <= s |-> triangle (s , t) ,
-            s <= t |-> triangle (t , s))
+    \ (t , s) →
+    recOR ( t <= s ↦ triangle (s , t) ,
+            s <= t ↦ triangle (t , s))
 ```
 
 For use in the proof of associativity:
@@ -675,7 +675,7 @@ For use in the proof of associativity:
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
-  : Δ¹×Δ¹ -> A
+  : Δ¹×Δ¹ → A
   := unfolding-square A (Segal-comp-witness A is-segal-A x y z f g)
 ```
 
@@ -701,7 +701,7 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
   (f : hom A x y)
   (g : hom A y z)
   : hom (arr A) f g
-  := \ t s -> (Segal-comp-witness-square A is-segal-A x y z f g) (t , s)
+  := \ t s → (Segal-comp-witness-square A is-segal-A x y z f g) (t , s)
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -783,9 +783,9 @@ $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
   (f : hom A w x)
   (g : hom A x y)
   (h : hom A y z)
-  : Δ³ -> A
+  : Δ³ → A
   :=
-    \ ((t , s) , r) ->
+    \ ((t , s) , r) →
     (Segal-associativity-witness A is-segal-A w x y z f g h) (t , r) s
 ```
 
@@ -820,7 +820,7 @@ The diagonal composite of three arrows extracted from the
   (h : hom A y z)
   : hom A w z
   :=
-    \ t ->
+    \ t →
     ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
       ( (t , t) , t)
 ```
@@ -858,7 +858,7 @@ The diagonal composite of three arrows extracted from the
     h
     (Segal-triple-composite A is-segal-A w x y z f g h)
   :=
-    \ (t , s) ->
+    \ (t , s) →
     ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
       ( (t , t) , s)
 ```
@@ -898,7 +898,7 @@ The front face:
     (Segal-comp A is-segal-A x y z g h)
     (Segal-triple-composite A is-segal-A w x y z f g h)
   :=
-    \ (t , s) ->
+    \ (t , s) →
     ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
       ((t , s) , s)
 ```
@@ -957,16 +957,16 @@ The front face:
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
-  : (z : A) -> (hom A z x) -> (hom A z y)
-  := \ z -> \ g -> (Segal-comp A is-segal-A z x y g f)
+  : (z : A) → (hom A z x) → (hom A z y)
+  := \ z → \ g → (Segal-comp A is-segal-A z x y g f)
 
 #def Segal-precomp
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
-  : (z : A) -> (hom A y z) -> (hom A x z)
-  := \ z -> \ g -> (Segal-comp A is-segal-A x y z f g)
+  : (z : A) → (hom A y z) → (hom A x z)
+  := \ z → \ g → (Segal-comp A is-segal-A x y z f g)
 ```
 
 ## Homotopies
@@ -983,16 +983,16 @@ arrow.
   (p : f = g)
   : (hom2 A x x y (id-arr A x) f g)
   := idJ (hom A x y , f ,
-          \ g' p' -> (hom2 A x x y (id-arr A x) f g') ,
+          \ g' p' → (hom2 A x x y (id-arr A x) f g') ,
           (id-comp-witness A x y f) , g , p)
 
 #def homotopy-to-hom2-total-map
   (A : U)
   (x y : A)
   (f : hom A x y)
-  : (Σ (g : hom A x y) , f = g) ->
+  : (Σ (g : hom A x y) , f = g) →
       (Σ (g : hom A x y) , (hom2 A x x y (id-arr A x) f g))
-  := \ (g , p) -> (g , homotopy-to-hom2 A x y f g p)
+  := \ (g , p) → (g , homotopy-to-hom2 A x y f g p)
 
 #def Segal-homotopy-to-hom2-total-map-is-equiv
   (A : U)
@@ -1023,8 +1023,8 @@ arrow.
     ( ( homotopy-to-hom2 A x y f h) ,
       ( total-equiv-family-of-equiv
         ( hom A x y)
-        ( \ k -> (f = k))
-        ( \ k -> (hom2 A x x y (id-arr A x) f k))
+        ( \ k → (f = k))
+        ( \ k → (hom2 A x x y (id-arr A x) f k))
         ( homotopy-to-hom2 A x y f)
         ( Segal-homotopy-to-hom2-total-map-is-equiv A is-segal-A x y f)
         ( h)))
@@ -1040,16 +1040,16 @@ A dual notion of homotopy can be defined similarly.
   (p : f = g)
   : (hom2 A x y y f (id-arr A y) g)
   := idJ (hom A x y , f ,
-          \ g' p' -> (hom2 A x y y f (id-arr A y) g') ,
+          \ g' p' → (hom2 A x y y f (id-arr A y) g') ,
           (comp-id-witness A x y f) , g , p)
 
 #def homotopy-to-hom2'-total-map
   (A : U)
   (x y : A)
   (f : hom A x y)
-  : (Σ (g : hom A x y) , f = g) ->
+  : (Σ (g : hom A x y) , f = g) →
       (Σ (g : hom A x y) , (hom2 A x y y f (id-arr A y) g))
-  := \ (g , p) -> (g , homotopy-to-hom2' A x y f g p)
+  := \ (g , p) → (g , homotopy-to-hom2' A x y f g p)
 
 #def Segal-homotopy-to-hom2'-total-map-is-equiv
   (A : U)
@@ -1080,8 +1080,8 @@ A dual notion of homotopy can be defined similarly.
     ( ( homotopy-to-hom2' A x y f h) ,
       ( total-equiv-family-of-equiv
         ( hom A x y)
-        ( \ k -> (f = k))
-        ( \ k -> (hom2 A x y y f (id-arr A y) k))
+        ( \ k → (f = k))
+        ( \ k → (hom2 A x y y f (id-arr A y) k))
         ( homotopy-to-hom2' A x y f)
         ( Segal-homotopy-to-hom2'-total-map-is-equiv A is-segal-A x y f)
         ( h)))
@@ -1101,7 +1101,7 @@ the data provided by a commutative triangle with that boundary.
   (p : (Segal-comp A is-segal-A x y z f g) = h)
   : (hom2 A x y z f g h)
   := idJ (hom A x z , (Segal-comp A is-segal-A x y z f g) ,
-          \ h' p' -> (hom2 A x y z f g h') ,
+          \ h' p' → (hom2 A x y z f g h') ,
           Segal-comp-witness A is-segal-A x y z f g , h , p)
 
 #def Segal-eq-to-hom2-total-map
@@ -1110,9 +1110,9 @@ the data provided by a commutative triangle with that boundary.
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
-  : (Σ (h : hom A x z) , (Segal-comp A is-segal-A x y z f g) = h) ->
+  : (Σ (h : hom A x z) , (Segal-comp A is-segal-A x y z f g) = h) →
       (Σ (h : hom A x z) , (hom2 A x y z f g h))
-  := \ (h , p) -> (h , Segal-eq-to-hom2 A is-segal-A x y z f g h p)
+  := \ (h , p) → (h , Segal-eq-to-hom2 A is-segal-A x y z f g h p)
 
 #def Segal-eq-to-hom2-total-map-is-equiv
   (A : U)
@@ -1146,8 +1146,8 @@ the data provided by a commutative triangle with that boundary.
     ( Segal-eq-to-hom2 A is-segal-A x y z f g k ,
       total-equiv-family-of-equiv
       ( hom A x z)
-      ( \ m -> (Segal-comp A is-segal-A x y z f g) = m)
-      ( \ m -> hom2 A x y z f g m)
+      ( \ m → (Segal-comp A is-segal-A x y z f g) = m)
+      ( \ m → hom2 A x y z f g m)
       ( Segal-eq-to-hom2 A is-segal-A x y z f g)
       ( Segal-eq-to-hom2-total-map-is-equiv A is-segal-A x y z f g)
       ( k))
@@ -1170,13 +1170,13 @@ composition:
     idJ
       ( ( hom A y z),
         ( h),
-        ( \ k' q' ->
+        ( \ k' q' →
           (Segal-comp A is-segal-A x y z f h) =
           (Segal-comp A is-segal-A x y z g k')),
         ( idJ
           ( ( hom A x y ),
             ( f),
-            ( \ g' p' ->
+            ( \ g' p' →
               (Segal-comp A is-segal-A x y z f h) =
               (Segal-comp A is-segal-A x y z g' h)),
             ( refl),
@@ -1217,16 +1217,16 @@ composition:
   (h : hom A y z)
   (p : f = g)
   : (Segal-homotopy-postwhisker A is-segal-A x y z f g h p) =
-    ap (hom A x y) (hom A x z) f g (\ k -> Segal-comp A is-segal-A x y z k h) p
+    ap (hom A x y) (hom A x z) f g (\ k → Segal-comp A is-segal-A x y z k h) p
   :=
     idJ
     ( hom A x y,
       f,
-      \ g' p' ->
+      \ g' p' →
       (Segal-homotopy-postwhisker A is-segal-A x y z f g' h p') =
       ap
         (hom A x y) (hom A x z)
-        f g' (\ k -> Segal-comp A is-segal-A x y z k h) p' ,
+        f g' (\ k → Segal-comp A is-segal-A x y z k h) p' ,
       refl ,
       g ,
       p)
@@ -1246,7 +1246,7 @@ composition:
     idJ
     ( hom A x y ,
       f ,
-      \ g' p' ->
+      \ g' p' →
       (Segal-homotopy-prewhisker A is-segal-A w x y k f g' p') =
       ap (hom A x y) (hom A w y) f g' (Segal-comp A is-segal-A w x y k) p' ,
       refl ,
@@ -1255,29 +1255,29 @@ composition:
 
 #section is-segal-Unit
 
-#def iscontr-Unit : is-contr Unit := (unit , \ _ -> refl)
+#def iscontr-Unit : is-contr Unit := (unit , \ _ → refl)
 
 #def is-contr-Δ²→Unit uses (extext)
-  : is-contr (Δ² -> Unit)
-  := (\ _ -> unit , \ k -> eq-ext-htpy extext
-    (2 * 2) Δ² (\ _ -> BOT)
-    (\ _ -> Unit) (\ _ -> recBOT)
-    (\ _ -> unit) k
-    (\ _ -> refl)
+  : is-contr (Δ² → Unit)
+  := (\ _ → unit , \ k → eq-ext-htpy extext
+    (2 * 2) Δ² (\ _ → BOT)
+    (\ _ → Unit) (\ _ → recBOT)
+    (\ _ → unit) k
+    (\ _ → refl)
     )
 
 #def is-segal-Unit uses (extext)
   : is-segal Unit
-  := \ x y z f g -> is-retract-of-is-contr-is-contr
+  := \ x y z f g → is-retract-of-is-contr-is-contr
     (Σ (h : hom Unit x z) , hom2 Unit x y z f g h)
-    (Δ² -> Unit)
-    (\ (_ , k) -> k , (\ k -> (\ t -> k (t , t) , k) , \ _ -> refl))
+    (Δ² → Unit)
+    (\ (_ , k) → k , (\ k → (\ t → k (t , t) , k) , \ _ → refl))
     is-contr-Δ²→Unit
 
 #end is-segal-Unit
 ```
 
-<!-- Definitions for the SVG images above -->
+<!-- Definitions for the SVG images above -→
 <svg width="0" height="0">
   <defs>
     <style data-bx-fonts="Noto Serif">@import url(https://fonts.googleapis.com/css2?family=Noto+Serif&display=swap);</style>

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -45,8 +45,8 @@ Extension types are used ∂to define the type of arrows between fixed terms:
   (x y : A)
   : U
   := (t : Δ¹) → A [
-    t ≡ 0_2 ↦ x ,    -- * the left endpoint is exactly x
-    t ≡ 1_2 ↦ y     -- * the right endpoint is exactly y
+    t ≡ 0₂ ↦ x ,    -- * the left endpoint is exactly x
+    t ≡ 1₂ ↦ y     -- * the right endpoint is exactly y
   ]
 ```
 
@@ -75,8 +75,8 @@ Extension types are also used to define the type of commutative triangles:
   (h : hom A x z)
   : U
   := { (t1 , t2) : Δ² } → A [
-    t2 ≡ 0_2 ↦ f t1 ,        -- * the top edge is exactly `f`,
-    t1 ≡ 1_2 ↦ g t2 ,        -- * the right edge is exactly `g`, and
+    t2 ≡ 0₂ ↦ f t1 ,        -- * the top edge is exactly `f`,
+    t1 ≡ 1₂ ↦ g t2 ,        -- * the right edge is exactly `g`, and
     t2 ≡ t1 ↦ h t2         -- * the diagonal is exactly `h`
   ]
 ```
@@ -199,8 +199,8 @@ A pair of composable arrows form a horn.
   :=
     \ (t , s) →
     recOR
-    ( s ≡ 0_2 ↦ f t ,
-      t ≡ 1_2 ↦ g s)
+    ( s ≡ 0₂ ↦ f t ,
+      t ≡ 1₂ ↦ g s)
 ```
 
 The underlying horn of a simplex:
@@ -245,10 +245,10 @@ witnesses of the equivalence).
   : Equiv
     ( Δ² → A)
     ( Σ ( k : Λ → A) ,
-        ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+        ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
             ( hom2 A
-              ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
+              ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+              ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
               ( h))))
   :=
     ( \ k →
@@ -270,33 +270,33 @@ witnesses of the equivalence).
     comp-equiv
       ( Δ² → A)
       ( Σ ( k : Λ → A) ,
-          ( Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+          ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
               ( hom2 A
-                ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
+                ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
                 ( h))))
       ( Λ → A)
       ( equiv-horn-restriction A)
       ( total-space-projection
         ( Λ → A )
         ( \ k →
-          Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+          Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
             ( hom2 A
-              ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
+              ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+              ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
               ( h))) ,
       ( is-equiv-projection-contractible-fibers
           ( Λ → A)
           ( \ k →
-            Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
               ( hom2 A
-                ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t → k (t , 0_2)) (\ t → k (1_2 , t))
+                ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                ( \ t → k (t , 0₂)) (\ t → k (1₂ , t))
                 ( h)))
           ( \ k →
             is-segal-A
-              ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-              ( \ t → k (t , 0_2)) (\ t → k (1_2 , t)))))
+              ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+              ( \ t → k (t , 0₂)) (\ t → k (1₂ , t)))))
 
 -- Verify that the mapping in (Segal-equiv-horn-restriction A is-segal-A)
 -- is exactly (horn-restriction A)
@@ -329,31 +329,31 @@ Types that are local at the horn inclusion are Segal types:
     contractible-fibers-is-equiv-projection
       (  Λ → A )
       ( \ k →
-        Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+        Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
           ( hom2 A
-            ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-            ( \ t → k (t , 0_2))
-            ( \ t → k (1_2 , t))
+            ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+            ( \ t → k (t , 0₂))
+            ( \ t → k (1₂ , t))
             ( h)))
       ( second
         ( comp-equiv
           ( Σ ( k : Λ → A ) ,
-            Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+            Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
               ( hom2 A
-                ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                ( \ t → k (t , 0_2))
-                ( \ t → k (1_2 , t))
+                ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                ( \ t → k (t , 0₂))
+                ( \ t → k (1₂ , t))
                 ( h)))
           ( Δ² → A )
           ( Λ  → A )
           ( inv-equiv
             ( Δ² → A )
             ( Σ ( k : Λ → A ) ,
-              Σ ( h : hom A (k (0_2 , 0_2)) (k (1_2 , 1_2))) ,
+              Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
                 ( hom2 A
-                  ( k (0_2 , 0_2)) (k (1_2 , 0_2)) (k (1_2 , 1_2))
-                  ( \ t → k (t , 0_2))
-                  ( \ t → k (1_2 , t))
+                  ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
+                  ( \ t → k (t , 0₂))
+                  ( \ t → k (1₂ , t))
                   ( h)))
             ( equiv-horn-restriction A))
           ( horn-restriction A , is-local-horn-inclusion-A)))
@@ -473,7 +473,7 @@ For later use, an equivalent characterization of the arrow type.
   (A : U)
   : Equiv (arr A) (Σ (x : A) , (Σ (y : A) , hom A x y))
   :=
-    ( \ f → (f 0_2 , (f 1_2 , f)) ,
+    ( \ f → (f 0₂ , (f 1₂ , f)) ,
       ( ( \ (x , (y , f)) → f , \ f → refl) ,
         ( \ (x , (y , f)) → f , \ xyf → refl)))
 ```

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -45,8 +45,8 @@ Extension types are used ∂to define the type of arrows between fixed terms:
   (x y : A)
   : U
   := (t : Δ¹) → A [
-    t === 0_2 ↦ x ,    -- * the left endpoint is exactly x
-    t === 1_2 ↦ y     -- * the right endpoint is exactly y
+    t ≡ 0_2 ↦ x ,    -- * the left endpoint is exactly x
+    t ≡ 1_2 ↦ y     -- * the right endpoint is exactly y
   ]
 ```
 
@@ -75,9 +75,9 @@ Extension types are also used to define the type of commutative triangles:
   (h : hom A x z)
   : U
   := { (t1 , t2) : Δ² } → A [
-    t2 === 0_2 ↦ f t1 ,        -- * the top edge is exactly `f`,
-    t1 === 1_2 ↦ g t2 ,        -- * the right edge is exactly `g`, and
-    t2 === t1 ↦ h t2         -- * the diagonal is exactly `h`
+    t2 ≡ 0_2 ↦ f t1 ,        -- * the top edge is exactly `f`,
+    t1 ≡ 1_2 ↦ g t2 ,        -- * the right edge is exactly `g`, and
+    t2 ≡ t1 ↦ h t2         -- * the diagonal is exactly `h`
   ]
 ```
 
@@ -199,8 +199,8 @@ A pair of composable arrows form a horn.
   :=
     \ (t , s) →
     recOR
-    ( s === 0_2 ↦ f t ,
-      t === 1_2 ↦ g s)
+    ( s ≡ 0_2 ↦ f t ,
+      t ≡ 1_2 ↦ g s)
 ```
 
 The underlying horn of a simplex:
@@ -643,8 +643,8 @@ that the type of arrows in a Segal type is itself a Segal type.
   : Δ¹×Δ¹ → A
   :=
     \ (t , s) →
-    recOR ( t <= s ↦ triangle (s , t) ,
-            s <= t ↦ triangle (t , s))
+    recOR ( t ≤ s ↦ triangle (s , t) ,
+            s ≤ t ↦ triangle (t , s))
 ```
 
 For use in the proof of associativity:

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -45,8 +45,8 @@ Extension types are used ∂to define the type of arrows between fixed terms:
   (x y : A)
   : U
   := (t : Δ¹) → A [
-    t ≡ 0₂ ↦ x ,    -- × the left endpoint is exactly x
-    t ≡ 1₂ ↦ y     -- × the right endpoint is exactly y
+    t ≡ 0₂ ↦ x ,  -- the left endpoint is exactly x
+    t ≡ 1₂ ↦ y    -- the right endpoint is exactly y
   ]
 ```
 
@@ -75,9 +75,9 @@ Extension types are also used to define the type of commutative triangles:
   (h : hom A x z)
   : U
   := { (t1 , t2) : Δ² } → A [
-    t2 ≡ 0₂ ↦ f t1 ,        -- × the top edge is exactly `f`,
-    t1 ≡ 1₂ ↦ g t2 ,        -- × the right edge is exactly `g`, and
-    t2 ≡ t1 ↦ h t2         -- × the diagonal is exactly `h`
+    t2 ≡ 0₂ ↦ f t1 ,  -- the top edge is exactly `f`,
+    t1 ≡ 1₂ ↦ g t2 ,  -- the right edge is exactly `g`, and
+    t2 ≡ t1 ↦ h t2    -- the diagonal is exactly `h`
   ]
 ```
 

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -45,8 +45,8 @@ Extension types are used ∂to define the type of arrows between fixed terms:
   (x y : A)
   : U
   := (t : Δ¹) → A [
-    t ≡ 0₂ ↦ x ,    -- * the left endpoint is exactly x
-    t ≡ 1₂ ↦ y     -- * the right endpoint is exactly y
+    t ≡ 0₂ ↦ x ,    -- × the left endpoint is exactly x
+    t ≡ 1₂ ↦ y     -- × the right endpoint is exactly y
   ]
 ```
 
@@ -75,9 +75,9 @@ Extension types are also used to define the type of commutative triangles:
   (h : hom A x z)
   : U
   := { (t1 , t2) : Δ² } → A [
-    t2 ≡ 0₂ ↦ f t1 ,        -- * the top edge is exactly `f`,
-    t1 ≡ 1₂ ↦ g t2 ,        -- * the right edge is exactly `g`, and
-    t2 ≡ t1 ↦ h t2         -- * the diagonal is exactly `h`
+    t2 ≡ 0₂ ↦ f t1 ,        -- × the top edge is exactly `f`,
+    t1 ≡ 1₂ ↦ g t2 ,        -- × the right edge is exactly `g`, and
+    t2 ≡ t1 ↦ h t2         -- × the diagonal is exactly `h`
   ]
 ```
 
@@ -390,7 +390,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
       ( Λ → ((x : X) → A x) )
       ( \ g x t → g t x) -- first equivalence
       ( second (flip-ext-fun
-        ( 2 * 2)
+        ( 2 × 2)
         ( Δ²)
         ( \ t → BOT)
         ( X)
@@ -405,7 +405,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
         ( \ x → (horn-restriction (A x) , fiberwise-is-segal-A x))))
       ( \ h t x → (h x) t) -- third equivalence
       ( second (flip-ext-fun-inv
-        ( 2 * 2)
+        ( 2 × 2)
         ( Λ)
         ( \ t → BOT)
         ( X)
@@ -431,7 +431,7 @@ then $(x : X) → A x$ is a Segal type.
     ( Λ → (s : ψ) → A s  )
     ( \ g s t → g t s)  -- first equivalence
     ( second (fubini
-      ( 2 * 2)
+      ( 2 × 2)
       ( I)
       ( Δ²)
       ( \ t → BOT)
@@ -447,7 +447,7 @@ then $(x : X) → A x$ is a Segal type.
     ( \ h t s → (h s) t) -- third equivalence
     ( second (fubini
       ( I)
-      ( 2 * 2)
+      ( 2 × 2)
       ( ψ)
       ( \ s → BOT)
       ( Λ)
@@ -1260,7 +1260,7 @@ composition:
 #def is-contr-Δ²→Unit uses (extext)
   : is-contr (Δ² → Unit)
   := (\ _ → unit , \ k → eq-ext-htpy extext
-    (2 * 2) Δ² (\ _ → BOT)
+    (2 × 2) Δ² (\ _ → BOT)
     (\ _ → Unit) (\ _ → recBOT)
     (\ _ → unit) k
     (\ _ → refl)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -65,8 +65,8 @@ Functions between types automatically preserve identity arrows.
       ∂Δ¹
       (\ t → B)
       (\ t → recOR
-      ( t ≡ 0_2 ↦ F x ,
-        t ≡ 1_2 ↦ F x))
+      ( t ≡ 0₂ ↦ F x ,
+        t ≡ 1₂ ↦ F x))
       (ap-hom A B F x x (id-arr A x))
       (id-arr B (F x))
       (\ t → refl)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -65,8 +65,8 @@ Functions between types automatically preserve identity arrows.
       ∂Δ¹
       (\ t → B)
       (\ t → recOR
-      ( t === 0_2 ↦ F x ,
-        t === 1_2 ↦ F x))
+      ( t ≡ 0_2 ↦ F x ,
+        t ≡ 1_2 ↦ F x))
       (ap-hom A B F x x (id-arr A x))
       (id-arr B (F x))
       (\ t → refl)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -30,15 +30,15 @@ targets.
 -- Action of maps on homs. Called "ap-hom" to avoid conflicting with "ap".
 #def ap-hom
   (A B : U)
-  (F : A -> B)
+  (F : A → B)
   (x y : A)
   (f : hom A x y)
   : hom B (F x) (F y)
-  := \ t -> F (f t)
+  := \ t → F (f t)
 
 #def ap-hom2
   (A B : U)
-  (F : A -> B)
+  (F : A → B)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
@@ -46,7 +46,7 @@ targets.
   (alpha : hom2 A x y z f g h)
   : hom2 B (F x) (F y) (F z)
     ( ap-hom A B F x y f) (ap-hom A B F y z g) (ap-hom A B F x z h)
-  := \ t -> F (alpha t)
+  := \ t → F (alpha t)
 ```
 
 Functions between types automatically preserve identity arrows.
@@ -55,7 +55,7 @@ Functions between types automatically preserve identity arrows.
 -- Preservation of identities follows from extension extensionality because these arrows are pointwise equal.
 #def functors-pres-id uses (extext)
   (A B : U)
-  (F : A -> B)
+  (F : A → B)
   (x : A)
   : (ap-hom A B F x x (id-arr A x)) = (id-arr B (F x))
   := eq-ext-htpy
@@ -63,13 +63,13 @@ Functions between types automatically preserve identity arrows.
       2
       Δ¹
       ∂Δ¹
-      (\ t -> B)
-      (\ t -> recOR
-      ( t === 0_2 |-> F x ,
-        t === 1_2 |-> F x))
+      (\ t → B)
+      (\ t → recOR
+      ( t === 0_2 ↦ F x ,
+        t === 1_2 ↦ F x))
       (ap-hom A B F x x (id-arr A x))
       (id-arr B (F x))
-      (\ t -> refl)
+      (\ t → refl)
 ```
 
 ```rzk title="RS17, Proposition 6.1.b"
@@ -78,7 +78,7 @@ Functions between types automatically preserve identity arrows.
   (A B : U)
   (is-segal-A : is-segal A)
   (is-segal-B : is-segal B)
-  (F : A -> B)
+  (F : A → B)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
@@ -104,16 +104,16 @@ Functions between types automatically preserve identity arrows.
 
 This corresponds to Section 6.2 in [RS17].
 
-Given two simplicial maps `f g : (x : A) -> B x` , a **natural transformation**
-from `f` to `g` is an arrow `η : hom ((x : A) -> B x) f g` between them.
+Given two simplicial maps `f g : (x : A) → B x` , a **natural transformation**
+from `f` to `g` is an arrow `η : hom ((x : A) → B x) f g` between them.
 
 ```rzk
 #def nat-trans
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   : U
-  := hom ((x : A) -> (B x)) f g
+  := hom ((x : A) → (B x)) f g
 ```
 
 Equivalently , natural transformations can be determined by their **components**
@@ -122,28 +122,28 @@ Equivalently , natural transformations can be determined by their **components**
 ```rzk
 #def nat-trans-components
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   : U
-  := (x : A) -> hom (B x) (f x) (g x)
+  := (x : A) → hom (B x) (f x) (g x)
 ```
 
 ```rzk
 #def ev-components-nat-trans
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   (η : nat-trans A B f g)
   : nat-trans-components A B f g
-  := \ x t -> η t x
+  := \ x t → η t x
 
 #def nat-trans-nat-trans-components
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   (η : nat-trans-components A B f g)
   : nat-trans A B f g
-  := \ t x -> η x t
+  := \ t x → η x t
 ```
 
 ### Natural transformation extensionality
@@ -151,20 +151,20 @@ Equivalently , natural transformations can be determined by their **components**
 ```rzk title="RS17, Proposition 6.3"
 #def is-equiv-ev-components-nat-trans
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   : is-equiv
       ( nat-trans A B f g)
       ( nat-trans-components A B f g)
       ( ev-components-nat-trans A B f g)
   :=
-    ( ( \ η t x -> η x t , \ _ -> refl) ,
-      ( \ η t x -> η x t , \ _ -> refl))
+    ( ( \ η t x → η x t , \ _ → refl) ,
+      ( \ η t x → η x t , \ _ → refl))
 
 #def equiv-components-nat-trans
   (A : U)
-  (B : A -> U)
-  (f g : (x : A) -> (B x))
+  (B : A → U)
+  (f g : (x : A) → (B x))
   : Equiv (nat-trans A B f g) (nat-trans-components A B f g)
   :=
     ( ev-components-nat-trans A B f g ,
@@ -180,21 +180,21 @@ Segal.
 ```rzk
 #def horizontal-comp-nat-trans
   (A B C : U)
-  (f g : A -> B)
-  (f' g' : B -> C)
-  (η : nat-trans A (\ _ -> B) f g)
-  (η' : nat-trans B (\ _ -> C) f' g')
-  : nat-trans A (\ _ -> C) (\ x -> f' (f x)) (\ x -> g' (g x))
-  := \ t x -> η' t (η t x)
+  (f g : A → B)
+  (f' g' : B → C)
+  (η : nat-trans A (\ _ → B) f g)
+  (η' : nat-trans B (\ _ → C) f' g')
+  : nat-trans A (\ _ → C) (\ x → f' (f x)) (\ x → g' (g x))
+  := \ t x → η' t (η t x)
 
 #def horizontal-comp-nat-trans-components
   (A B C : U)
-  (f g : A -> B)
-  (f' g' : B -> C)
-  (η : nat-trans-components A (\ _ -> B) f g)
-  (η' : nat-trans-components B (\ _ -> C) f' g')
-  : nat-trans-components A (\ _ -> C) (\ x -> f' (f x)) (\ x -> g' (g x))
-  := \ x t -> η' (η x t) t
+  (f g : A → B)
+  (f' g' : B → C)
+  (η : nat-trans-components A (\ _ → B) f g)
+  (η' : nat-trans-components B (\ _ → C) f' g')
+  : nat-trans-components A (\ _ → C) (\ x → f' (f x)) (\ x → g' (g x))
+  := \ x t → η' (η x t) t
 ```
 
 ### Vertical composition
@@ -205,27 +205,27 @@ Segal types.
 ```rzk
 #def vertical-comp-nat-trans-components
   (A : U)
-  (B : A -> U)
-  (is-segal-B : (x : A) -> is-segal (B x))
-  (f g h : (x : A) -> (B x))
+  (B : A → U)
+  (is-segal-B : (x : A) → is-segal (B x))
+  (f g h : (x : A) → (B x))
   (η : nat-trans-components A B f g)
   (η' : nat-trans-components A B g h)
   : nat-trans-components A B f h
-  := \ x -> Segal-comp (B x) (is-segal-B x) (f x) (g x) (h x) (η x) (η' x)
+  := \ x → Segal-comp (B x) (is-segal-B x) (f x) (g x) (h x) (η x) (η' x)
 
 #def vertical-comp-nat-trans
   (A : U)
-  (B : A -> U)
-  (is-segal-B : (x : A) -> is-segal (B x))
-  (f g h : (x : A) -> (B x))
+  (B : A → U)
+  (is-segal-B : (x : A) → is-segal (B x))
+  (f g h : (x : A) → (B x))
   (η : nat-trans A B f g)
   (η' : nat-trans A B g h)
   : nat-trans A B f h
   :=
-    \ t x ->
+    \ t x →
     vertical-comp-nat-trans-components A B is-segal-B f g h
-      ( \ x' t' -> η t' x')
-      ( \ x' t' -> η' t' x')
+      ( \ x' t' → η t' x')
+      ( \ x' t' → η' t' x')
       ( x)
       ( t)
 ```
@@ -235,9 +235,9 @@ The identity natural transformation is identity arrows on components
 ```rzk title="RS17, Proposition 6.5(ii)"
 #def id-arr-components-id-nat-trans
   (A : U)
-  (B : A -> U)
-  (f : (x : A) -> (B x))
+  (B : A → U)
+  (f : (x : A) → (B x))
   (a : A)
-  : (\ t -> id-arr ((x : A) -> B x) f t a) =_{Δ¹ -> B a} id-arr (B a) (f a)
+  : (\ t → id-arr ((x : A) → B x) f t a) =_{Δ¹ → B a} id-arr (B a) (f a)
   := refl
 ```

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -72,7 +72,7 @@ of discrete types is discrete.
         ( ∂Δ¹)
         ( X)
         ( \ t x → A x)
-        ( \ t x → recOR (t === 0_2 ↦ f x , t === 1_2 ↦ g x)))
+        ( \ t x → recOR (t ≡ 0_2 ↦ f x , t ≡ 1_2 ↦ g x)))
 
 #def equiv-discrete-family-map uses (funext)
   ( X : U)
@@ -145,7 +145,7 @@ only, extending from BOT, that's all we prove here for now.
         ( Δ¹)
         ( ∂Δ¹)
         ( \ t s → A t)
-        ( \ (t , s) → recOR (s === 0_2 ↦ f t , s === 1_2 ↦ g t)))
+        ( \ (t , s) → recOR (s ≡ 0_2 ↦ f t , s ≡ 1_2 ↦ g t)))
 
 #def Eq-discrete-extension-map uses (extext)
   ( I : CUBE)
@@ -224,10 +224,10 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ t === 0_2 /\ Δ¹ s ↦ f s ,
-                  t === 1_2 /\ Δ¹ s ↦ g s ,
-                  Δ¹ t /\ s === 0_2 ↦ h t ,
-                  Δ¹ t /\ s === 1_2 ↦ k t])))
+                [ t ≡ 0_2 ∧ Δ¹ s ↦ f s ,
+                  t ≡ 1_2 ∧ Δ¹ s ↦ g s ,
+                  Δ¹ t ∧ s ≡ 0_2 ↦ h t ,
+                  Δ¹ t ∧ s ≡ 1_2 ↦ k t])))
   :=
     ( \ α →
       ( ( \ t → α t 0_2) ,
@@ -291,10 +291,10 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                  ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                  (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-                  (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
+                [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                  ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                  (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+                  (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
   :=
     left-cancel-equiv
       ( f =_{Δ¹ → A} g)
@@ -304,10 +304,10 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                  ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                  (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-                  (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
+                [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                  ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                  (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+                  (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
       ( comp-equiv
         ( f =_{Δ¹ → A} g)
         ( fibered-arr-free-arr f = fibered-arr-free-arr g)
@@ -322,10 +322,10 @@ Discrete types are automatically Segal types.
         ( Σ ( h : hom A x z) ,
             ( Σ ( k : hom A y w) ,
                 ( { (t , s) : Δ¹×Δ¹ } → A
-                  [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                    ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                    (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-                    (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
+                  [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                    ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                    (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+                    (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
         ( equiv-arr-eq-discrete)
         ( equiv-square-hom-arr))
 
@@ -342,10 +342,10 @@ Discrete types are automatically Segal types.
   : ( g : hom A z w) →
     ( product-transport A A (hom A) x z y w p q f = g) →
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z p) t ,
-        (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])
   :=
     idJ
     ( ( A) ,
@@ -354,10 +354,10 @@ Discrete types are automatically Segal types.
         ( g : hom A z' w) →
         ( product-transport A A (hom A) x z' y w p' q f = g) →
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z' p') t ,
-            (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])) ,
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z' p') t ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])) ,
       ( idJ
         ( ( A) ,
           ( y) ,
@@ -365,20 +365,20 @@ Discrete types are automatically Segal types.
             ( g : hom A x w') →
             ( product-transport A A (hom A) x x y w' refl q' f = g) →
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                (Δ¹ t /\ (s === 0_2)) ↦ x ,
-                (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w' q') t ])) ,
+              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+                (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w' q') t ])) ,
           ( \ g τ →
             idJ
             ( ( hom A x y) ,
               ( f) ,
               ( \ g' τ' →
                 ( { (t , s) : Δ¹×Δ¹ } → A
-                  [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                    ((t === 1_2) /\ Δ¹ s) ↦ g' s ,
-                    (Δ¹ t /\ (s === 0_2)) ↦ x ,
-                    (Δ¹ t /\ (s === 1_2)) ↦ y ])),
+                  [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                    ((t ≡ 1_2) ∧ Δ¹ s) ↦ g' s ,
+                    (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+                    (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])),
               ( \ (t , s) → f s) ,
               ( g) ,
               ( τ))),
@@ -400,10 +400,10 @@ Discrete types are automatically Segal types.
   : Σ ( h : hom A x z) ,
       ( Σ ( k : hom A y w) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-              (Δ¹ t /\ (s === 1_2)) ↦ k t ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ]))
   :=
     ( arr-eq A x z p ,
       ( arr-eq A y w q ,
@@ -509,10 +509,10 @@ Discrete types are automatically Segal types.
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-                (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
+              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+                (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
   :=
     is-equiv-rev-homotopic-is-equiv
@@ -522,10 +522,10 @@ Discrete types are automatically Segal types.
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-                (Δ¹ t /\ (s === 0_2)) ↦ h t ,
-                (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
+              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
+                (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
     ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y z w f g))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
@@ -546,10 +546,10 @@ Discrete types are automatically Segal types.
   : is-equiv
     ( product-transport A A (hom A) x z y w p q f = g)
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z p) t ,
-        (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])
     ( fibered-map-square-sigma-over-product A is-discrete-A x y z w f p q g)
   :=
     fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
@@ -560,10 +560,10 @@ Discrete types are automatically Segal types.
       ( \ p' q' → (product-transport A A (hom A) x z y w p' q' f) = g)
       ( \ h' k' →
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ h' t ,
-            (Δ¹ t /\ (s === 1_2)) ↦ k' t ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ h' t ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ k' t ]))
       ( arr-eq A x z)
       ( arr-eq A y w)
       ( \ p' q' →
@@ -589,10 +589,10 @@ Discrete types are automatically Segal types.
   : is-equiv
     (f = g)
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ x ,
-        (Δ¹ t /\ (s === 1_2)) ↦ y ])
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
     ( fibered-map-square-sigma-over-product
       A is-discrete-A x y x y f refl refl g)
   :=
@@ -612,19 +612,19 @@ The previous calculations allow us to establish a family of equivalences:
     ( Σ (g : hom A x y) , f = g)
     ( Σ (g : hom A x y) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ x ,
-            (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
     ( total-map-family-of-maps
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →
         { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ x ,
-          (Δ¹ t /\ (s === 1_2)) ↦ y ])
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl))
   :=
@@ -633,10 +633,10 @@ The previous calculations allow us to establish a family of equivalences:
       ( \ g → f = g)
       ( \ g →
         { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ x ,
-          (Δ¹ t /\ (s === 1_2)) ↦ y ])
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl)
       ( \ g →
@@ -654,20 +654,20 @@ The previous calculations allow us to establish a family of equivalences:
       ( Σ (g : hom A x y) , f = g)
       ( Σ (g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ x ,
-              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
   :=
     ( ( total-map-family-of-maps
         ( hom A x y)
         ( \ g → f = g)
         ( \ g →
           { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ x ,
-              (Δ¹ t /\ (s === 1_2)) ↦ y ])
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
         ( fibered-map-square-sigma-over-product
             A is-discrete-A x y x y f refl refl)) ,
     is-equiv-sum-fibered-map-square-sigma-over-product-refl-refl
@@ -686,18 +686,18 @@ spaces, we conclude that the codomain extension type is contractible.
   : is-contr
     ( Σ ( g : hom A x y) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ x ,
-            (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
   := is-contr-is-equiv-from-contr
       ( Σ ( g : hom A x y) , f = g)
       ( Σ ( g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ x ,
-              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
       ( equiv-sum-fibered-map-square-sigma-over-product-refl-refl
           A is-discrete-A x y f)
       ( is-contr-based-paths (hom A x y) f)
@@ -713,11 +713,11 @@ The extension types that appear in the Segal condition are retracts of this type
   (f g : hom A x y)
   (α : hom2 A x y y f (id-arr A y) g)
   : { (t , s) : Δ¹×Δ¹ } → A
-    [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-      ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-      (Δ¹ t /\ (s === 0_2)) ↦ x ,
-      (Δ¹ t /\ (s === 1_2)) ↦ y ]
-  := \ (t , s) → recOR (t <= s ↦ α (s , t) , s <= t ↦ g s)
+    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+      ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+      (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+      (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]
+  := \ (t , s) → recOR (t ≤ s ↦ α (s , t) , s ≤ t ↦ g s)
 
 #def sigma-triangle-to-sigma-square-section
   ( A : U)
@@ -726,10 +726,10 @@ The extension types that appear in the Segal condition are retracts of this type
   ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
   : Σ ( g : hom A x y) ,
       ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ x ,
-          (Δ¹ t /\ (s === 1_2)) ↦ y ])
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
   := (d , triangle-to-square-section A x y f d α)
 
 #def sigma-square-to-sigma-triangle-retraction
@@ -739,10 +739,10 @@ The extension types that appear in the Segal condition are retracts of this type
   ( (g , σ) :
     Σ (g : hom A x y) ,
       ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ x ,
-          (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
   : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d
   := ((\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
 
@@ -754,10 +754,10 @@ The extension types that appear in the Segal condition are retracts of this type
       ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
       ( Σ (g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ x ,
-              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
   :=
     ( sigma-triangle-to-sigma-square-section A x y f ,
       ( sigma-square-to-sigma-triangle-retraction A x y f ,
@@ -779,10 +779,10 @@ the second arrow is an identity.
       ( Σ ( d : hom A x y) , (hom2 A x y y f (id-arr A y) d))
       ( Σ ( g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ x ,
-              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
       ( sigma-triangle-to-sigma-square-retract A x y f)
       ( is-contr-horn-refl-refl-extension-type A is-discrete-A x y f)
 ```

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -72,7 +72,7 @@ of discrete types is discrete.
         ( ∂Δ¹)
         ( X)
         ( \ t x → A x)
-        ( \ t x → recOR (t ≡ 0_2 ↦ f x , t ≡ 1_2 ↦ g x)))
+        ( \ t x → recOR (t ≡ 0₂ ↦ f x , t ≡ 1₂ ↦ g x)))
 
 #def equiv-discrete-family-map uses (funext)
   ( X : U)
@@ -145,7 +145,7 @@ only, extending from BOT, that's all we prove here for now.
         ( Δ¹)
         ( ∂Δ¹)
         ( \ t s → A t)
-        ( \ (t , s) → recOR (s ≡ 0_2 ↦ f t , s ≡ 1_2 ↦ g t)))
+        ( \ (t , s) → recOR (s ≡ 0₂ ↦ f t , s ≡ 1₂ ↦ g t)))
 
 #def Eq-discrete-extension-map uses (extext)
   ( I : CUBE)
@@ -224,14 +224,14 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ t ≡ 0_2 ∧ Δ¹ s ↦ f s ,
-                  t ≡ 1_2 ∧ Δ¹ s ↦ g s ,
-                  Δ¹ t ∧ s ≡ 0_2 ↦ h t ,
-                  Δ¹ t ∧ s ≡ 1_2 ↦ k t])))
+                [ t ≡ 0₂ ∧ Δ¹ s ↦ f s ,
+                  t ≡ 1₂ ∧ Δ¹ s ↦ g s ,
+                  Δ¹ t ∧ s ≡ 0₂ ↦ h t ,
+                  Δ¹ t ∧ s ≡ 1₂ ↦ k t])))
   :=
     ( \ α →
-      ( ( \ t → α t 0_2) ,
-        ( ( \ t → α t 1_2) , (\ (t , s) → α t s))) ,
+      ( ( \ t → α t 0₂) ,
+        ( ( \ t → α t 1₂) , (\ (t , s) → α t s))) ,
       ( ( ( \ σ → \ t → \ s → (second (second σ)) (t , s)) ,
           ( \ α → refl)) ,
         ( ( \ σ → \ t → \ s → (second (second σ)) (t , s)) ,
@@ -240,7 +240,7 @@ Discrete types are automatically Segal types.
 -- The equivalence underlying Eq-arr.
 #def fibered-arr-free-arr
   : (arr A) → (Σ (u : A) , (Σ (v : A) , hom A u v))
-  := \ k → (k 0_2 , (k 1_2 , k))
+  := \ k → (k 0₂ , (k 1₂ , k))
 
 #def id-equiv-Eq-arr uses (w x y z)
   : is-equiv
@@ -291,10 +291,10 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                  ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                  (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-                  (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
+                [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                  ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                  (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+                  (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ])))
   :=
     left-cancel-equiv
       ( f =_{Δ¹ → A} g)
@@ -304,10 +304,10 @@ Discrete types are automatically Segal types.
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
               ( { (t , s) : Δ¹×Δ¹ } → A
-                [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                  ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                  (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-                  (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
+                [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                  ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                  (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+                  (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ])))
       ( comp-equiv
         ( f =_{Δ¹ → A} g)
         ( fibered-arr-free-arr f = fibered-arr-free-arr g)
@@ -322,10 +322,10 @@ Discrete types are automatically Segal types.
         ( Σ ( h : hom A x z) ,
             ( Σ ( k : hom A y w) ,
                 ( { (t , s) : Δ¹×Δ¹ } → A
-                  [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                    ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                    (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-                    (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
+                  [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                    ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                    (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+                    (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ])))
         ( equiv-arr-eq-discrete)
         ( equiv-square-hom-arr))
 
@@ -342,10 +342,10 @@ Discrete types are automatically Segal types.
   : ( g : hom A z w) →
     ( product-transport A A (hom A) x z y w p q f = g) →
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z p) t ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ (arr-eq A y w q) t ])
   :=
     idJ
     ( ( A) ,
@@ -354,10 +354,10 @@ Discrete types are automatically Segal types.
         ( g : hom A z' w) →
         ( product-transport A A (hom A) x z' y w p' q f = g) →
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z' p') t ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])) ,
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ (arr-eq A x z' p') t ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ (arr-eq A y w q) t ])) ,
       ( idJ
         ( ( A) ,
           ( y) ,
@@ -365,20 +365,20 @@ Discrete types are automatically Segal types.
             ( g : hom A x w') →
             ( product-transport A A (hom A) x x y w' refl q' f = g) →
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-                (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w' q') t ])) ,
+              [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+                (Δ¹ t ∧ (s ≡ 1₂)) ↦ (arr-eq A y w' q') t ])) ,
           ( \ g τ →
             idJ
             ( ( hom A x y) ,
               ( f) ,
               ( \ g' τ' →
                 ( { (t , s) : Δ¹×Δ¹ } → A
-                  [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                    ((t ≡ 1_2) ∧ Δ¹ s) ↦ g' s ,
-                    (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-                    (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])),
+                  [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                    ((t ≡ 1₂) ∧ Δ¹ s) ↦ g' s ,
+                    (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+                    (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])),
               ( \ (t , s) → f s) ,
               ( g) ,
               ( τ))),
@@ -400,10 +400,10 @@ Discrete types are automatically Segal types.
   : Σ ( h : hom A x z) ,
       ( Σ ( k : hom A y w) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ]))
   :=
     ( arr-eq A x z p ,
       ( arr-eq A y w q ,
@@ -509,10 +509,10 @@ Discrete types are automatically Segal types.
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-                (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
+              [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+                (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ])))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
   :=
     is-equiv-rev-homotopic-is-equiv
@@ -522,10 +522,10 @@ Discrete types are automatically Segal types.
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
             ( { (t , s) : Δ¹×Δ¹ } → A
-              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-                ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-                (Δ¹ t ∧ (s ≡ 0_2)) ↦ h t ,
-                (Δ¹ t ∧ (s ≡ 1_2)) ↦ k t ])))
+              [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+                ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+                (Δ¹ t ∧ (s ≡ 0₂)) ↦ h t ,
+                (Δ¹ t ∧ (s ≡ 1₂)) ↦ k t ])))
     ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y z w f g))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
@@ -546,10 +546,10 @@ Discrete types are automatically Segal types.
   : is-equiv
     ( product-transport A A (hom A) x z y w p q f = g)
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ (arr-eq A x z p) t ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ (arr-eq A y w q) t ])
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ (arr-eq A y w q) t ])
     ( fibered-map-square-sigma-over-product A is-discrete-A x y z w f p q g)
   :=
     fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
@@ -560,10 +560,10 @@ Discrete types are automatically Segal types.
       ( \ p' q' → (product-transport A A (hom A) x z y w p' q' f) = g)
       ( \ h' k' →
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ h' t ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ k' t ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ h' t ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ k' t ]))
       ( arr-eq A x z)
       ( arr-eq A y w)
       ( \ p' q' →
@@ -589,10 +589,10 @@ Discrete types are automatically Segal types.
   : is-equiv
     (f = g)
     ( { (t , s) : Δ¹×Δ¹ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])
     ( fibered-map-square-sigma-over-product
       A is-discrete-A x y x y f refl refl g)
   :=
@@ -612,19 +612,19 @@ The previous calculations allow us to establish a family of equivalences:
     ( Σ (g : hom A x y) , f = g)
     ( Σ (g : hom A x y) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
     ( total-map-family-of-maps
       ( hom A x y)
       ( \ g → f = g)
       ( \ g →
         { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl))
   :=
@@ -633,10 +633,10 @@ The previous calculations allow us to establish a family of equivalences:
       ( \ g → f = g)
       ( \ g →
         { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl)
       ( \ g →
@@ -654,20 +654,20 @@ The previous calculations allow us to establish a family of equivalences:
       ( Σ (g : hom A x y) , f = g)
       ( Σ (g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
   :=
     ( ( total-map-family-of-maps
         ( hom A x y)
         ( \ g → f = g)
         ( \ g →
           { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])
         ( fibered-map-square-sigma-over-product
             A is-discrete-A x y x y f refl refl)) ,
     is-equiv-sum-fibered-map-square-sigma-over-product-refl-refl
@@ -686,18 +686,18 @@ spaces, we conclude that the codomain extension type is contractible.
   : is-contr
     ( Σ ( g : hom A x y) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
   := is-contr-is-equiv-from-contr
       ( Σ ( g : hom A x y) , f = g)
       ( Σ ( g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
       ( equiv-sum-fibered-map-square-sigma-over-product-refl-refl
           A is-discrete-A x y f)
       ( is-contr-based-paths (hom A x y) f)
@@ -713,10 +713,10 @@ The extension types that appear in the Segal condition are retracts of this type
   (f g : hom A x y)
   (α : hom2 A x y y f (id-arr A y) g)
   : { (t , s) : Δ¹×Δ¹ } → A
-    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-      ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-      (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-      (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]
+    [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+      ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+      (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+      (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]
   := \ (t , s) → recOR (t ≤ s ↦ α (s , t) , s ≤ t ↦ g s)
 
 #def sigma-triangle-to-sigma-square-section
@@ -726,10 +726,10 @@ The extension types that appear in the Segal condition are retracts of this type
   ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
   : Σ ( g : hom A x y) ,
       ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ])
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ])
   := (d , triangle-to-square-section A x y f d α)
 
 #def sigma-square-to-sigma-triangle-retraction
@@ -739,10 +739,10 @@ The extension types that appear in the Segal condition are retracts of this type
   ( (g , σ) :
     Σ (g : hom A x y) ,
       ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-          ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+          ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
   : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d
   := ((\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
 
@@ -754,10 +754,10 @@ The extension types that appear in the Segal condition are retracts of this type
       ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
       ( Σ (g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
   :=
     ( sigma-triangle-to-sigma-square-section A x y f ,
       ( sigma-square-to-sigma-triangle-retraction A x y f ,
@@ -779,10 +779,10 @@ the second arrow is an identity.
       ( Σ ( d : hom A x y) , (hom2 A x y y f (id-arr A y) d))
       ( Σ ( g : hom A x y) ,
           ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ f s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ g s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ x ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ y ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ f s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ g s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ x ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ y ]))
       ( sigma-triangle-to-sigma-square-retract A x y f)
       ( is-contr-horn-refl-refl-extension-type A is-discrete-A x y f)
 ```

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -36,12 +36,12 @@ identity types.
   (x y : A)           -- Two points of type A.
   (p : x = y)         -- A path p from x to y in A.
   : hom A x y         -- An arrow p from x to y in A.
-  := idJ (A , x , \ y' -> \ p' -> hom A x y' , (id-arr A x) , y , p)
+  := idJ (A , x , \ y' → \ p' → hom A x y' , (id-arr A x) , y , p)
 
 #def is-discrete
   (A : U)             -- A type.
   : U
-  := (x : A) -> (y : A) -> is-equiv (x =_{A} y) (hom A x y) (arr-eq A x y)
+  := (x : A) → (y : A) → is-equiv (x =_{A} y) (hom A x y) (arr-eq A x y)
 ```
 
 ## Families of discrete types
@@ -52,42 +52,42 @@ of discrete types is discrete.
 ```rzk
 #def equiv-discrete-family uses (funext)
   ( X : U)
-  ( A : X -> U)
-  ( is-discrete-A : (x : X) -> is-discrete (A x))
-  ( f g : (x : X) -> A x)
-  : Equiv (f = g) (hom ((x : X) -> A x) f g)
+  ( A : X → U)
+  ( is-discrete-A : (x : X) → is-discrete (A x))
+  ( f g : (x : X) → A x)
+  : Equiv (f = g) (hom ((x : X) → A x) f g)
   :=
     triple-comp-equiv
       ( f = g)
-      ( (x : X) -> f x = g x)
-      ( (x : X) -> hom (A x) (f x) (g x))
-      ( hom ((x : X) -> A x) f g)
+      ( (x : X) → f x = g x)
+      ( (x : X) → hom (A x) (f x) (g x))
+      ( hom ((x : X) → A x) f g)
       ( FunExt-equiv funext X A f g)
       ( equiv-function-equiv-fibered funext X
-        ( \ x -> (f x = g x)) (\ x -> hom (A x) (f x) (g x))
-        ( \ x -> (arr-eq (A x) (f x) (g x) , (is-discrete-A x (f x) (g x)))))
+        ( \ x → (f x = g x)) (\ x → hom (A x) (f x) (g x))
+        ( \ x → (arr-eq (A x) (f x) (g x) , (is-discrete-A x (f x) (g x)))))
       ( flip-ext-fun-inv
         ( 2)
         ( Δ¹)
         ( ∂Δ¹)
         ( X)
-        ( \ t x -> A x)
-        ( \ t x -> recOR (t === 0_2 |-> f x , t === 1_2 |-> g x)))
+        ( \ t x → A x)
+        ( \ t x → recOR (t === 0_2 ↦ f x , t === 1_2 ↦ g x)))
 
 #def equiv-discrete-family-map uses (funext)
   ( X : U)
-  ( A : X -> U)
-  ( is-discrete-A : (x : X) -> is-discrete (A x))
-  ( f g : (x : X) -> A x)
+  ( A : X → U)
+  ( is-discrete-A : (x : X) → is-discrete (A x))
+  ( f g : (x : X) → A x)
   ( h : f = g)
-  : ( arr-eq ((x : X) -> A x) f g h) =
+  : ( arr-eq ((x : X) → A x) f g h) =
     ( first (equiv-discrete-family X A is-discrete-A f g)) h
   :=
     idJ
-    ( ( (x : X) -> A x) ,
+    ( ( (x : X) → A x) ,
       ( f) ,
-      ( \ g' h' ->
-        arr-eq ((x : X) -> A x) f g' h' =
+      ( \ g' h' →
+        arr-eq ((x : X) → A x) f g' h' =
         (first (equiv-discrete-family X A is-discrete-A f g')) h') ,
       ( refl) ,
       ( g) ,
@@ -97,15 +97,15 @@ of discrete types is discrete.
 ```rzk title="RS17, Proposition 7.2"
 #def is-discrete-dependent-function-discrete-family uses (funext)
   ( X : U)
-  ( A : X -> U)
-  ( is-discrete-A : (x : X) -> is-discrete (A x))
-  : is-discrete ((x : X) -> A x)
+  ( A : X → U)
+  ( is-discrete-A : (x : X) → is-discrete (A x))
+  : is-discrete ((x : X) → A x)
   :=
-    \ f g ->
+    \ f g →
     is-equiv-homotopic-is-equiv
       ( f = g)
-      ( hom ((x : X) -> A x) f g)
-      ( arr-eq ((x : X) -> A x) f g)
+      ( hom ((x : X) → A x) f g)
+      ( arr-eq ((x : X) → A x) f g)
       ( first (equiv-discrete-family X A is-discrete-A f g))
       ( equiv-discrete-family-map X A is-discrete-A f g)
       ( second (equiv-discrete-family X A is-discrete-A f g))
@@ -118,50 +118,50 @@ only, extending from BOT, that's all we prove here for now.
 ```rzk
 #def Eq-discrete-extension uses (extext)
   ( I : CUBE)
-  ( ψ : I -> TOPE)
-  ( A : ψ -> U)
-  ( is-discrete-A : (t : ψ) -> is-discrete (A t))
-  ( f g : (t : ψ) -> A t)
-  : Equiv (f = g) (hom ((t : ψ) -> A t) f g)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( is-discrete-A : (t : ψ) → is-discrete (A t))
+  ( f g : (t : ψ) → A t)
+  : Equiv (f = g) (hom ((t : ψ) → A t) f g)
   :=
     triple-comp-equiv
       ( f = g)
-      ( (t : ψ) -> f t = g t)
-      ( (t : ψ) -> hom (A t) (f t) (g t))
-      ( hom ((t : ψ) -> A t) f g)
-      ( equiv-ExtExt extext I ψ (\ _ -> BOT) A (\ _ -> recBOT) f g)
+      ( (t : ψ) → f t = g t)
+      ( (t : ψ) → hom (A t) (f t) (g t))
+      ( hom ((t : ψ) → A t) f g)
+      ( equiv-ExtExt extext I ψ (\ _ → BOT) A (\ _ → recBOT) f g)
       ( equiv-extension-equiv-fibered
         ( extext)
         ( I)
         ( ψ)
-        ( \ t -> f t = g t)
-        ( \ t -> hom (A t) (f t) (g t))
-        ( \ t -> (arr-eq (A t) (f t) (g t) , (is-discrete-A t (f t) (g t)))))
+        ( \ t → f t = g t)
+        ( \ t → hom (A t) (f t) (g t))
+        ( \ t → (arr-eq (A t) (f t) (g t) , (is-discrete-A t (f t) (g t)))))
       ( fubini
         ( I)
         ( 2)
         ( ψ)
-        ( \ t -> BOT)
+        ( \ t → BOT)
         ( Δ¹)
         ( ∂Δ¹)
-        ( \ t s -> A t)
-        ( \ (t , s) -> recOR (s === 0_2 |-> f t , s === 1_2 |-> g t)))
+        ( \ t s → A t)
+        ( \ (t , s) → recOR (s === 0_2 ↦ f t , s === 1_2 ↦ g t)))
 
 #def Eq-discrete-extension-map uses (extext)
   ( I : CUBE)
-  ( ψ : (t : I) -> TOPE)
-  ( A : ψ -> U)
-  ( is-discrete-A : (t : ψ) -> is-discrete (A t))
-  ( f g : (t : ψ) -> A t)
+  ( ψ : (t : I) → TOPE)
+  ( A : ψ → U)
+  ( is-discrete-A : (t : ψ) → is-discrete (A t))
+  ( f g : (t : ψ) → A t)
   ( h : f = g)
-  : arr-eq ((t : ψ) -> A t) f g h =
+  : arr-eq ((t : ψ) → A t) f g h =
     ( first (Eq-discrete-extension I ψ A is-discrete-A f g)) h
   :=
     idJ
-    ( ( (t : ψ) -> A t) ,
+    ( ( (t : ψ) → A t) ,
       ( f) ,
-      ( \ g' h' ->
-        ( arr-eq ((t : ψ) -> A t) f g' h') =
+      ( \ g' h' →
+        ( arr-eq ((t : ψ) → A t) f g' h') =
         ( first (Eq-discrete-extension I ψ A is-discrete-A f g') h')) ,
       ( refl) ,
       ( g) ,
@@ -171,16 +171,16 @@ only, extending from BOT, that's all we prove here for now.
 ```rzk title="RS17, Proposition 7.2, for extension types"
 #def is-discrete-extension-family uses (extext)
   ( I : CUBE)
-  ( ψ : (t : I) -> TOPE)
-  ( A : ψ -> U)
-  ( is-discrete-A : (t : ψ) -> is-discrete (A t))
-  : is-discrete ((t : ψ) -> A t)
+  ( ψ : (t : I) → TOPE)
+  ( A : ψ → U)
+  ( is-discrete-A : (t : ψ) → is-discrete (A t))
+  : is-discrete ((t : ψ) → A t)
   :=
-    \ f g ->
+    \ f g →
     is-equiv-homotopic-is-equiv
       ( f = g)
-      ( hom ((t : ψ) -> A t) f g)
-      ( arr-eq ((t : ψ) -> A t) f g)
+      ( hom ((t : ψ) → A t) f g)
+      ( arr-eq ((t : ψ) → A t) f g)
       ( first (Eq-discrete-extension I ψ A is-discrete-A f g))
       ( Eq-discrete-extension-map I ψ A is-discrete-A f g)
       ( second (Eq-discrete-extension I ψ A is-discrete-A f g))
@@ -193,7 +193,7 @@ For instance, the arrow type of a discrete type is discrete.
   ( A : U)
   ( is-discrete-A : is-discrete A)
   : is-discrete (arr A)
-  := is-discrete-extension-family 2 Δ¹ (\ _ -> A) (\ _ -> is-discrete-A)
+  := is-discrete-extension-family 2 Δ¹ (\ _ → A) (\ _ → is-discrete-A)
 ```
 
 ## Discrete types are Segal types
@@ -210,11 +210,11 @@ Discrete types are automatically Segal types.
 #variable g : hom A z w
 
 #def is-equiv-arr-eq-discrete uses (extext x y z w)
-  : is-equiv (f =_{Δ¹ -> A} g) (hom (arr A) f g) (arr-eq (arr A) f g)
+  : is-equiv (f =_{Δ¹ → A} g) (hom (arr A) f g) (arr-eq (arr A) f g)
   := (is-discrete-arr-is-discrete A is-discrete-A) f g
 
 #def equiv-arr-eq-discrete uses (extext x y z w)
-  : Equiv (f =_{Δ¹ -> A} g) (hom (arr A) f g)
+  : Equiv (f =_{Δ¹ → A} g) (hom (arr A) f g)
   := (arr-eq (arr A) f g ,
           (is-discrete-arr-is-discrete A is-discrete-A) f g)
 
@@ -223,28 +223,28 @@ Discrete types are automatically Segal types.
       ( hom (arr A) f g)
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
-              ( { (t , s) : Δ¹×Δ¹ } -> A
-                [ t === 0_2 /\ Δ¹ s |-> f s ,
-                  t === 1_2 /\ Δ¹ s |-> g s ,
-                  Δ¹ t /\ s === 0_2 |-> h t ,
-                  Δ¹ t /\ s === 1_2 |-> k t])))
+              ( { (t , s) : Δ¹×Δ¹ } → A
+                [ t === 0_2 /\ Δ¹ s ↦ f s ,
+                  t === 1_2 /\ Δ¹ s ↦ g s ,
+                  Δ¹ t /\ s === 0_2 ↦ h t ,
+                  Δ¹ t /\ s === 1_2 ↦ k t])))
   :=
-    ( \ α ->
-      ( ( \ t -> α t 0_2) ,
-        ( ( \ t -> α t 1_2) , (\ (t , s) -> α t s))) ,
-      ( ( ( \ σ -> \ t -> \ s -> (second (second σ)) (t , s)) ,
-          ( \ α -> refl)) ,
-        ( ( \ σ -> \ t -> \ s -> (second (second σ)) (t , s)) ,
-          ( \ σ -> refl))))
+    ( \ α →
+      ( ( \ t → α t 0_2) ,
+        ( ( \ t → α t 1_2) , (\ (t , s) → α t s))) ,
+      ( ( ( \ σ → \ t → \ s → (second (second σ)) (t , s)) ,
+          ( \ α → refl)) ,
+        ( ( \ σ → \ t → \ s → (second (second σ)) (t , s)) ,
+          ( \ σ → refl))))
 
 -- The equivalence underlying Eq-arr.
 #def fibered-arr-free-arr
-  : (arr A) -> (Σ (u : A) , (Σ (v : A) , hom A u v))
-  := \ k -> (k 0_2 , (k 1_2 , k))
+  : (arr A) → (Σ (u : A) , (Σ (v : A) , hom A u v))
+  := \ k → (k 0_2 , (k 1_2 , k))
 
 #def id-equiv-Eq-arr uses (w x y z)
   : is-equiv
-      ( f =_{Δ¹ -> A} g)
+      ( f =_{Δ¹ → A} g)
       ( fibered-arr-free-arr f = fibered-arr-free-arr g)
       ( ap
         ( arr A)
@@ -262,7 +262,7 @@ Discrete types are automatically Segal types.
       ( g)
 
 #def id-Eq-Eq-arr uses (w x y z)
-  : Equiv (f =_{Δ¹ -> A} g) (fibered-arr-free-arr f = fibered-arr-free-arr g)
+  : Equiv (f =_{Δ¹ → A} g) (fibered-arr-free-arr f = fibered-arr-free-arr g)
   :=
     Eq-ap-is-equiv
       ( arr A)
@@ -290,26 +290,26 @@ Discrete types are automatically Segal types.
               ( product-transport A A (hom A) x z y w p q f = g)))
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
-              ( { (t , s) : Δ¹×Δ¹ } -> A
-                [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                  ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                  (Δ¹ t /\ (s === 0_2)) |-> h t ,
-                  (Δ¹ t /\ (s === 1_2)) |-> k t ])))
+              ( { (t , s) : Δ¹×Δ¹ } → A
+                [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                  ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                  (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+                  (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
   :=
     left-cancel-equiv
-      ( f =_{Δ¹ -> A} g)
+      ( f =_{Δ¹ → A} g)
       ( Σ ( p : x = z) ,
           ( Σ ( q : y = w) ,
               ( product-transport A A (hom A) x z y w p q f = g)))
       ( Σ ( h : hom A x z) ,
           ( Σ ( k : hom A y w) ,
-              ( { (t , s) : Δ¹×Δ¹ } -> A
-                [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                  ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                  (Δ¹ t /\ (s === 0_2)) |-> h t ,
-                  (Δ¹ t /\ (s === 1_2)) |-> k t ])))
+              ( { (t , s) : Δ¹×Δ¹ } → A
+                [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                  ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                  (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+                  (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
       ( comp-equiv
-        ( f =_{Δ¹ -> A} g)
+        ( f =_{Δ¹ → A} g)
         ( fibered-arr-free-arr f = fibered-arr-free-arr g)
         ( Σ ( p : x = z) ,
             ( Σ ( q : y = w) ,
@@ -317,15 +317,15 @@ Discrete types are automatically Segal types.
         id-Eq-Eq-arr
         equiv-sigma-over-product-arr-eq)
       ( comp-equiv
-        ( f =_{Δ¹ -> A} g)
+        ( f =_{Δ¹ → A} g)
         ( hom (arr A) f g)
         ( Σ ( h : hom A x z) ,
             ( Σ ( k : hom A y w) ,
-                ( { (t , s) : Δ¹×Δ¹ } -> A
-                  [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                    ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                    (Δ¹ t /\ (s === 0_2)) |-> h t ,
-                    (Δ¹ t /\ (s === 1_2)) |-> k t ])))
+                ( { (t , s) : Δ¹×Δ¹ } → A
+                  [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                    ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                    (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+                    (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
         ( equiv-arr-eq-discrete)
         ( equiv-square-hom-arr))
 
@@ -339,47 +339,47 @@ Discrete types are automatically Segal types.
   ( f : hom A x y)
   ( p : x = z)
   ( q : y = w)
-  : ( g : hom A z w) ->
-    ( product-transport A A (hom A) x z y w p q f = g) ->
-    ( { (t , s) : Δ¹×Δ¹ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-        ((t === 1_2) /\ Δ¹ s) |-> g s ,
-        (Δ¹ t /\ (s === 0_2)) |-> (arr-eq A x z p) t ,
-        (Δ¹ t /\ (s === 1_2)) |-> (arr-eq A y w q) t ])
+  : ( g : hom A z w) →
+    ( product-transport A A (hom A) x z y w p q f = g) →
+    ( { (t , s) : Δ¹×Δ¹ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])
   :=
     idJ
     ( ( A) ,
       ( x) ,
-      ( \ z' p' ->
-        ( g : hom A z' w) ->
-        ( product-transport A A (hom A) x z' y w p' q f = g) ->
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-            ((t === 1_2) /\ Δ¹ s) |-> g s ,
-            (Δ¹ t /\ (s === 0_2)) |-> (arr-eq A x z' p') t ,
-            (Δ¹ t /\ (s === 1_2)) |-> (arr-eq A y w q) t ])) ,
+      ( \ z' p' →
+        ( g : hom A z' w) →
+        ( product-transport A A (hom A) x z' y w p' q f = g) →
+        ( { (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z' p') t ,
+            (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])) ,
       ( idJ
         ( ( A) ,
           ( y) ,
-          ( \ w' q' ->
-            ( g : hom A x w') ->
-            ( product-transport A A (hom A) x x y w' refl q' f = g) ->
-            ( { (t , s) : Δ¹×Δ¹ } -> A
-              [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                (Δ¹ t /\ (s === 0_2)) |-> x ,
-                (Δ¹ t /\ (s === 1_2)) |-> (arr-eq A y w' q') t ])) ,
-          ( \ g τ ->
+          ( \ w' q' →
+            ( g : hom A x w') →
+            ( product-transport A A (hom A) x x y w' refl q' f = g) →
+            ( { (t , s) : Δ¹×Δ¹ } → A
+              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                (Δ¹ t /\ (s === 0_2)) ↦ x ,
+                (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w' q') t ])) ,
+          ( \ g τ →
             idJ
             ( ( hom A x y) ,
               ( f) ,
-              ( \ g' τ' ->
-                ( { (t , s) : Δ¹×Δ¹ } -> A
-                  [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                    ((t === 1_2) /\ Δ¹ s) |-> g' s ,
-                    (Δ¹ t /\ (s === 0_2)) |-> x ,
-                    (Δ¹ t /\ (s === 1_2)) |-> y ])),
-              ( \ (t , s) -> f s) ,
+              ( \ g' τ' →
+                ( { (t , s) : Δ¹×Δ¹ } → A
+                  [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                    ((t === 1_2) /\ Δ¹ s) ↦ g' s ,
+                    (Δ¹ t /\ (s === 0_2)) ↦ x ,
+                    (Δ¹ t /\ (s === 1_2)) ↦ y ])),
+              ( \ (t , s) → f s) ,
               ( g) ,
               ( τ))),
           ( w) ,
@@ -399,11 +399,11 @@ Discrete types are automatically Segal types.
             ( product-transport A A (hom A) x z y w p q f = g))))
   : Σ ( h : hom A x z) ,
       ( Σ ( k : hom A y w) ,
-          ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> h t ,
-              (Δ¹ t /\ (s === 1_2)) |-> k t ]))
+          ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+              (Δ¹ t /\ (s === 1_2)) ↦ k t ]))
   :=
     ( arr-eq A x z p ,
       ( arr-eq A y w q ,
@@ -434,7 +434,7 @@ Discrete types are automatically Segal types.
     idJ
     ( ( hom A x y) ,
       ( f) ,
-      ( \ g' τ' ->
+      ( \ g' τ' →
         ( first
           ( equiv-square-sigma-over-product A is-discrete-A x y x y f g')
           ( refl , (refl , τ'))) =
@@ -454,8 +454,8 @@ Discrete types are automatically Segal types.
   ( f : hom A x y)
   ( p : x = z)
   ( q : y = w)
-  : ( g : hom A z w) ->
-    ( τ : product-transport A A (hom A) x z y w p q f = g) ->
+  : ( g : hom A z w) →
+    ( τ : product-transport A A (hom A) x z y w p q f = g) →
     ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y z w f g)
       ( p , (q , τ))) =
@@ -465,9 +465,9 @@ Discrete types are automatically Segal types.
     idJ
     ( A ,
       y ,
-      \ w' q' ->
-      ( g : hom A z w') ->
-      ( τ : product-transport A A (hom A) x z y w' p q' f = g) ->
+      \ w' q' →
+      ( g : hom A z w') →
+      ( τ : product-transport A A (hom A) x z y w' p q' f = g) →
       ( first (equiv-square-sigma-over-product
                 A is-discrete-A x y z w' f g))
         ( p , (q' , τ)) =
@@ -476,16 +476,16 @@ Discrete types are automatically Segal types.
       idJ
       ( ( A) ,
         ( x) ,
-        ( \ z' p' ->
-          ( g : hom A z' y) ->
+        ( \ z' p' →
+          ( g : hom A z' y) →
           ( τ :
-            product-transport A A (hom A) x z' y y p' refl f = g) ->
+            product-transport A A (hom A) x z' y y p' refl f = g) →
           ( first
             ( equiv-square-sigma-over-product A is-discrete-A x y z' y f g)
             ( p' , (refl , τ))) =
           ( square-sigma-over-product A is-discrete-A x y z' y f g
             ( p' , (refl , τ)))) ,
-        ( \ g τ ->
+        ( \ g τ →
           refl-refl-map-equiv-square-sigma-over-product
             ( A) (is-discrete-A)
             ( x) (y)
@@ -508,11 +508,11 @@ Discrete types are automatically Segal types.
             ( product-transport A A (hom A) x z y w p q f = g)))
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
-            ( { (t , s) : Δ¹×Δ¹ } -> A
-              [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                (Δ¹ t /\ (s === 0_2)) |-> h t ,
-                (Δ¹ t /\ (s === 1_2)) |-> k t ])))
+            ( { (t , s) : Δ¹×Δ¹ } → A
+              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+                (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
   :=
     is-equiv-rev-homotopic-is-equiv
@@ -521,15 +521,15 @@ Discrete types are automatically Segal types.
             ( product-transport A A (hom A) x z y w p q f = g)))
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,
-            ( { (t , s) : Δ¹×Δ¹ } -> A
-              [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-                ((t === 1_2) /\ Δ¹ s) |-> g s ,
-                (Δ¹ t /\ (s === 0_2)) |-> h t ,
-                (Δ¹ t /\ (s === 1_2)) |-> k t ])))
+            ( { (t , s) : Δ¹×Δ¹ } → A
+              [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+                ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+                (Δ¹ t /\ (s === 0_2)) ↦ h t ,
+                (Δ¹ t /\ (s === 1_2)) ↦ k t ])))
     ( first
       ( equiv-square-sigma-over-product A is-discrete-A x y z w f g))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
-    ( \ (p , (q , τ)) ->
+    ( \ (p , (q , τ)) →
       map-equiv-square-sigma-over-product
         A is-discrete-A x y z w f p q g τ)
     ( second
@@ -545,11 +545,11 @@ Discrete types are automatically Segal types.
   ( q : y = w)
   : is-equiv
     ( product-transport A A (hom A) x z y w p q f = g)
-    ( { (t , s) : Δ¹×Δ¹ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-        ((t === 1_2) /\ Δ¹ s) |-> g s ,
-        (Δ¹ t /\ (s === 0_2)) |-> (arr-eq A x z p) t ,
-        (Δ¹ t /\ (s === 1_2)) |-> (arr-eq A y w q) t ])
+    ( { (t , s) : Δ¹×Δ¹ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ (arr-eq A x z p) t ,
+        (Δ¹ t /\ (s === 1_2)) ↦ (arr-eq A y w q) t ])
     ( fibered-map-square-sigma-over-product A is-discrete-A x y z w f p q g)
   :=
     fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
@@ -557,16 +557,16 @@ Discrete types are automatically Segal types.
       ( hom A x z)
       ( y = w)
       ( hom A y w)
-      ( \ p' q' -> (product-transport A A (hom A) x z y w p' q' f) = g)
-      ( \ h' k' ->
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-            ((t === 1_2) /\ Δ¹ s) |-> g s ,
-            (Δ¹ t /\ (s === 0_2)) |-> h' t ,
-            (Δ¹ t /\ (s === 1_2)) |-> k' t ]))
+      ( \ p' q' → (product-transport A A (hom A) x z y w p' q' f) = g)
+      ( \ h' k' →
+        ( { (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ h' t ,
+            (Δ¹ t /\ (s === 1_2)) ↦ k' t ]))
       ( arr-eq A x z)
       ( arr-eq A y w)
-      ( \ p' q' ->
+      ( \ p' q' →
         fibered-map-square-sigma-over-product
           ( A) (is-discrete-A)
           ( x) (y) (z) (w)
@@ -588,11 +588,11 @@ Discrete types are automatically Segal types.
   ( g : hom A x y)
   : is-equiv
     (f = g)
-    ( { (t , s) : Δ¹×Δ¹ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-        ((t === 1_2) /\ Δ¹ s) |-> g s ,
-        (Δ¹ t /\ (s === 0_2)) |-> x ,
-        (Δ¹ t /\ (s === 1_2)) |-> y ])
+    ( { (t , s) : Δ¹×Δ¹ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ x ,
+        (Δ¹ t /\ (s === 1_2)) ↦ y ])
     ( fibered-map-square-sigma-over-product
       A is-discrete-A x y x y f refl refl g)
   :=
@@ -611,35 +611,35 @@ The previous calculations allow us to establish a family of equivalences:
   : is-equiv
     ( Σ (g : hom A x y) , f = g)
     ( Σ (g : hom A x y) ,
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-            ((t === 1_2) /\ Δ¹ s) |-> g s ,
-            (Δ¹ t /\ (s === 0_2)) |-> x ,
-            (Δ¹ t /\ (s === 1_2)) |-> y ]))
+        ( { (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ x ,
+            (Δ¹ t /\ (s === 1_2)) ↦ y ]))
     ( total-map-family-of-maps
       ( hom A x y)
-      ( \ g -> f = g)
-      ( \ g ->
-        { (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-          ((t === 1_2) /\ Δ¹ s) |-> g s ,
-          (Δ¹ t /\ (s === 0_2)) |-> x ,
-          (Δ¹ t /\ (s === 1_2)) |-> y ])
+      ( \ g → f = g)
+      ( \ g →
+        { (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ x ,
+          (Δ¹ t /\ (s === 1_2)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl))
   :=
     family-of-equiv-total-equiv
       ( hom A x y)
-      ( \ g -> f = g)
-      ( \ g ->
-        { (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-          ((t === 1_2) /\ Δ¹ s) |-> g s ,
-          (Δ¹ t /\ (s === 0_2)) |-> x ,
-          (Δ¹ t /\ (s === 1_2)) |-> y ])
+      ( \ g → f = g)
+      ( \ g →
+        { (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ x ,
+          (Δ¹ t /\ (s === 1_2)) ↦ y ])
       ( fibered-map-square-sigma-over-product
           A is-discrete-A x y x y f refl refl)
-      ( \ g ->
+      ( \ g →
         is-equiv-fibered-map-square-sigma-over-product-refl-refl
           ( A) (is-discrete-A)
           ( x) (y)
@@ -653,21 +653,21 @@ The previous calculations allow us to establish a family of equivalences:
   : Equiv
       ( Σ (g : hom A x y) , f = g)
       ( Σ (g : hom A x y) ,
-          ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> x ,
-              (Δ¹ t /\ (s === 1_2)) |-> y ]))
+          ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ x ,
+              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
   :=
     ( ( total-map-family-of-maps
         ( hom A x y)
-        ( \ g -> f = g)
-        ( \ g ->
-          { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> x ,
-              (Δ¹ t /\ (s === 1_2)) |-> y ])
+        ( \ g → f = g)
+        ( \ g →
+          { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ x ,
+              (Δ¹ t /\ (s === 1_2)) ↦ y ])
         ( fibered-map-square-sigma-over-product
             A is-discrete-A x y x y f refl refl)) ,
     is-equiv-sum-fibered-map-square-sigma-over-product-refl-refl
@@ -685,19 +685,19 @@ spaces, we conclude that the codomain extension type is contractible.
   ( f : hom A x y)
   : is-contr
     ( Σ ( g : hom A x y) ,
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-            ((t === 1_2) /\ Δ¹ s) |-> g s ,
-            (Δ¹ t /\ (s === 0_2)) |-> x ,
-            (Δ¹ t /\ (s === 1_2)) |-> y ]))
+        ( { (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ x ,
+            (Δ¹ t /\ (s === 1_2)) ↦ y ]))
   := is-contr-is-equiv-from-contr
       ( Σ ( g : hom A x y) , f = g)
       ( Σ ( g : hom A x y) ,
-          ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> x ,
-              (Δ¹ t /\ (s === 1_2)) |-> y ]))
+          ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ x ,
+              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
       ( equiv-sum-fibered-map-square-sigma-over-product-refl-refl
           A is-discrete-A x y f)
       ( is-contr-based-paths (hom A x y) f)
@@ -712,12 +712,12 @@ The extension types that appear in the Segal condition are retracts of this type
   (x y : A)
   (f g : hom A x y)
   (α : hom2 A x y y f (id-arr A y) g)
-  : { (t , s) : Δ¹×Δ¹ } -> A
-    [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-      ((t === 1_2) /\ Δ¹ s) |-> g s ,
-      (Δ¹ t /\ (s === 0_2)) |-> x ,
-      (Δ¹ t /\ (s === 1_2)) |-> y ]
-  := \ (t , s) -> recOR (t <= s |-> α (s , t) , s <= t |-> g s)
+  : { (t , s) : Δ¹×Δ¹ } → A
+    [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+      ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+      (Δ¹ t /\ (s === 0_2)) ↦ x ,
+      (Δ¹ t /\ (s === 1_2)) ↦ y ]
+  := \ (t , s) → recOR (t <= s ↦ α (s , t) , s <= t ↦ g s)
 
 #def sigma-triangle-to-sigma-square-section
   ( A : U)
@@ -725,11 +725,11 @@ The extension types that appear in the Segal condition are retracts of this type
   ( f : hom A x y)
   ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
   : Σ ( g : hom A x y) ,
-      ( { (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-          ((t === 1_2) /\ Δ¹ s) |-> g s ,
-          (Δ¹ t /\ (s === 0_2)) |-> x ,
-          (Δ¹ t /\ (s === 1_2)) |-> y ])
+      ( { (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ x ,
+          (Δ¹ t /\ (s === 1_2)) ↦ y ])
   := (d , triangle-to-square-section A x y f d α)
 
 #def sigma-square-to-sigma-triangle-retraction
@@ -738,13 +738,13 @@ The extension types that appear in the Segal condition are retracts of this type
   ( f : hom A x y)
   ( (g , σ) :
     Σ (g : hom A x y) ,
-      ( { (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-          ((t === 1_2) /\ Δ¹ s) |-> g s ,
-          (Δ¹ t /\ (s === 0_2)) |-> x ,
-          (Δ¹ t /\ (s === 1_2)) |-> y ]))
+      ( { (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+          ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ x ,
+          (Δ¹ t /\ (s === 1_2)) ↦ y ]))
   : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d
-  := ((\ t -> σ (t , t)) , (\ (t , s) -> σ (s , t)))
+  := ((\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
 
 #def sigma-triangle-to-sigma-square-retract
   ( A : U)
@@ -753,15 +753,15 @@ The extension types that appear in the Segal condition are retracts of this type
   : is-retract-of
       ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
       ( Σ (g : hom A x y) ,
-          ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> x ,
-              (Δ¹ t /\ (s === 1_2)) |-> y ]))
+          ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ x ,
+              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
   :=
     ( sigma-triangle-to-sigma-square-section A x y f ,
       ( sigma-square-to-sigma-triangle-retraction A x y f ,
-        \ dα -> refl ))
+        \ dα → refl ))
 ```
 
 We can now verify the Segal condition in the case of composable pairs in which
@@ -778,11 +778,11 @@ the second arrow is an identity.
     is-retract-of-is-contr-is-contr
       ( Σ ( d : hom A x y) , (hom2 A x y y f (id-arr A y) d))
       ( Σ ( g : hom A x y) ,
-          ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> f s ,
-              ((t === 1_2) /\ Δ¹ s) |-> g s ,
-              (Δ¹ t /\ (s === 0_2)) |-> x ,
-              (Δ¹ t /\ (s === 1_2)) |-> y ]))
+          ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ f s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ g s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ x ,
+              (Δ¹ t /\ (s === 1_2)) ↦ y ]))
       ( sigma-triangle-to-sigma-square-retract A x y f)
       ( is-contr-horn-refl-refl-extension-type A is-discrete-A x y f)
 ```
@@ -803,10 +803,10 @@ case to the one just proven:
     ind-based-path
       A
       y
-      ( \ w -> hom A y w)
-      ( \ w -> arr-eq A y w)
+      ( \ w → hom A y w)
+      ( \ w → arr-eq A y w)
       ( is-discrete-A y)
-      ( \ w d -> is-contr ( Σ (h : hom A x w) , hom2 A x y w f d h))
+      ( \ w d → is-contr ( Σ (h : hom A x w) , hom2 A x y w f d h))
       ( is-contr-hom2-with-id-is-discrete
           A is-discrete-A x y f)
       ( z)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -28,13 +28,13 @@ live over a specified arrow in the base type.
   (A : U)            -- The base type.
   (x y : A)          -- Two points in the base.
   (f : hom A x y)        -- An arrow in the base.
-  (C : A -> U)        -- A type family.
+  (C : A → U)        -- A type family.
   (u : C x)          -- A lift of the domain.
   (v : C y)          -- A lift of the codomain.
   : U
-    := {t : Δ¹ } -> C (f t)
-      [ t === 0_2 |-> u ,
-        t === 1_2 |-> v ]
+    := {t : Δ¹ } → C (f t)
+      [ t === 0_2 ↦ u ,
+        t === 1_2 ↦ v ]
 ```
 
 It will be convenient to collect together dependent hom types with fixed domain
@@ -45,7 +45,7 @@ but varying codomain.
   (A : U)            -- The base type.
   (x y : A)          -- Two points in the base.
   (f : hom A x y)        -- An arrow in the base.
-  (C : A -> U)        -- A type family.
+  (C : A → U)        -- A type family.
   (u : C x)          -- A lift of the domain.
   : U
      := (Σ (v : C y) , dhom A x y f C u v)
@@ -62,7 +62,7 @@ triangle.
   (g : hom A y z)          -- An arrow in the base.
   (h : hom A x z)          -- An arrow in the base.
   (alpha : hom2 A x y z f g h)  -- A composition witness in the base.
-  (C : A -> U)          -- A type family.
+  (C : A → U)          -- A type family.
   (u : C x)            -- A lift of the initial point.
   (v : C y)            -- A lift of the second point.
   (w : C z)            -- A lift of the third point.
@@ -70,10 +70,10 @@ triangle.
   (gg : dhom A y z g C v w)    -- A lift of the second arrow.
   (hh : dhom A x z h C u w)    -- A lift of the diagonal arrow.
   : U
-    := { (t1 , t2) : Δ² } -> C (alpha (t1 , t2))
-      [ t2 === 0_2 |-> ff t1 ,
-        t1 === 1_2 |-> gg t2 ,
-        t2 === t1  |-> hh t2 ]
+    := { (t1 , t2) : Δ² } → C (alpha (t1 , t2))
+      [ t2 === 0_2 ↦ ff t1 ,
+        t1 === 1_2 ↦ gg t2 ,
+        t2 === t1  ↦ hh t2 ]
 ```
 
 ## Covariant families
@@ -84,14 +84,14 @@ unique lift with specified domain.
 ```rzk title="RS17, Definition 8.2"
 #def is-covariant
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : U
-  := (x : A) -> (y : A) -> (f : hom A x y) -> (u : C x)
-    -> is-contr (dhom-from A x y f C u)
+  := (x : A) → (y : A) → (f : hom A x y) → (u : C x)
+    → is-contr (dhom-from A x y f C u)
 
 -- Type of covariant families over a fixed type
 #def covariant-family (A : U) : U
-  := (Σ (C : ((a : A) -> U)) , is-covariant A C)
+  := (Σ (C : ((a : A) → U)) , is-covariant A C)
 ```
 
 The notion of having a unique lift with a fixed domain may also be expressed by
@@ -101,10 +101,10 @@ contractibility of the type of extensions along the domain inclusion into the
 ```rzk
 #def has-unique-lifts-with-fixed-domain
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : U
-  := (x : A) -> (y : A) -> (f : hom A x y) -> (u : C x)
-    -> is-contr ((t : Δ¹) -> C (f t) [ t === 0_2 |-> u ])
+  := (x : A) → (y : A) → (f : hom A x y) → (u : C x)
+    → is-contr ((t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -115,17 +115,17 @@ here.
 ```rzk
 #def equiv-lifts-with-fixed-domain
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   (x y : A)
   (f : hom A x y)
   (u : C x)
   : Equiv
-      ((t : Δ¹) -> C (f t) [ t === 0_2 |-> u ])
+      ((t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
       (dhom-from A x y f C u)
   :=
-    ( \ h -> (h 1_2 , \ t -> h t) ,
-      ( ( \ fg t -> (second fg) t , \ h -> refl) ,
-        ( ( \ fg t -> (second fg) t , \ h -> refl))))
+    ( \ h → (h 1_2 , \ t → h t) ,
+      ( ( \ fg t → (second fg) t , \ h → refl) ,
+        ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
 
 By the equivalence-invariance of contractibility, this proves the desired
@@ -134,20 +134,20 @@ logical equivalence
 ```rzk title="RS17, Proposition 8.4"
 #def has-unique-lifts-with-fixed-domain-iff-is-covariant
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : iff
       (has-unique-lifts-with-fixed-domain A C)
       (is-covariant A C)
   :=
-    ( \ C-has-unique-lifts x y f u ->
+    ( \ C-has-unique-lifts x y f u →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) -> C (f t) [ t === 0_2 |-> u ])
+        ( (t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-has-unique-lifts x y f u),
-      \ C-is-covariant x y f u ->
+      \ C-is-covariant x y f u →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) -> C (f t) [ t === 0_2 |-> u ])
+        ( (t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-is-covariant x y f u))
@@ -168,7 +168,7 @@ equivalences.
   (u : hom A a x)        -- A lift of the domain.
   (v : hom A a y)        -- A lift of the codomain.
   : U
-  := dhom A x y f (\ z -> hom A a z) u v
+  := dhom A x y f (\ z → hom A a z) u v
 
 -- By uncurrying (RS 4.2) we have an equivalence:
 #def uncurried-dhom-representable
@@ -178,17 +178,17 @@ equivalences.
   (u : hom A a x)        -- A lift of the domain.
   (v : hom A a y)        -- A lift of the codomain.
   : Equiv (dhom-representable A a x y f u v)
-  ({ (t , s) : Δ¹×Δ¹ } -> A
-    [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-      (Δ¹ t /\ (s === 0_2)) |-> a ,
-      (Δ¹ t /\ (s === 1_2)) |-> f t ])
-  := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s -> A)
-    (\ (t , s) -> recOR
-      ( ((t === 0_2) /\ Δ¹ s) |-> u s ,
-        ((t === 1_2) /\ Δ¹ s) |-> v s ,
-        (Δ¹ t /\ (s === 0_2)) |-> a ,
-        (Δ¹ t /\ (s === 1_2)) |-> f t ))
+  ({ (t , s) : Δ¹×Δ¹ } → A
+    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+      (Δ¹ t /\ (s === 0_2)) ↦ a ,
+      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+  := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
+    (\ (t , s) → recOR
+      ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ a ,
+        (Δ¹ t /\ (s === 1_2)) ↦ f t ))
 
 #def dhom-from-representable
   (A : U)            -- The ambient type.
@@ -196,7 +196,7 @@ equivalences.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : U
-  := dhom-from A x y f (\ z -> hom A a z) u
+  := dhom-from A x y f (\ z → hom A a z) u
 
 -- By uncurrying (RS 4.2) we have an equivalence:
 #def uncurried-dhom-from-representable
@@ -205,18 +205,18 @@ equivalences.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
-    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-        ((t === 1_2) /\ Δ¹ s) |-> v s ,
-        (Δ¹ t /\ (s === 0_2)) |-> a ,
-        (Δ¹ t /\ (s === 1_2)) |-> f t ]))
-  := total-equiv-family-equiv (hom A a y) (\ v -> dhom-representable A a x y f u v)
-    (\ v -> ({ (t , s) : Δ¹×Δ¹ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-        ((t === 1_2) /\ Δ¹ s) |-> v s ,
-        (Δ¹ t /\ (s === 0_2)) |-> a ,
-        (Δ¹ t /\ (s === 1_2)) |-> f t ]))
-    (\ v -> uncurried-dhom-representable A a x y f u v)
+    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ a ,
+        (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+  := total-equiv-family-equiv (hom A a y) (\ v → dhom-representable A a x y f u v)
+    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+        (Δ¹ t /\ (s === 0_2)) ↦ a ,
+        (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+    (\ v → uncurried-dhom-representable A a x y f u v)
 
 #def square-to-hom2-pushout
   (A : U)
@@ -225,12 +225,12 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> g t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ])
-  -> (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
-  := \ sq -> ((\ t -> sq (t , t)) , (\ (t , s) -> sq (s , t) , \ (t , s) -> sq (t , s)))
+  : ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+  → (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
+  := \ sq → ((\ t → sq (t , t)) , (\ (t , s) → sq (s , t) , \ (t , s) → sq (t , s)))
 
 #def hom2-pushout-to-square
   (A : U)
@@ -240,12 +240,12 @@ equivalences.
   (g : hom A w y)
   (v : hom A y z)
   : (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
-  -> ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> g t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ])
-  := \ (d , (alpha1 , alpha2)) (t , s) -> recOR (t <= s |-> alpha1 (s , t) ,
-                        s <= t |-> alpha2 (t , s))
+  → ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+  := \ (d , (alpha1 , alpha2)) (t , s) → recOR (t <= s ↦ alpha1 (s , t) ,
+                        s <= t ↦ alpha2 (t , s))
 #def Eq-square-hom2-pushout
   (A : U)
   (w x y z : A)
@@ -253,32 +253,32 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : Equiv ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> g t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ])
+  : Equiv ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
     (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   := (square-to-hom2-pushout A w x y z u f g v ,
-    ((hom2-pushout-to-square A w x y z u f g v , \ sq -> refl) ,
-    (hom2-pushout-to-square A w x y z u f g v , \ alphas -> refl)))
+    ((hom2-pushout-to-square A w x y z u f g v , \ sq → refl) ,
+    (hom2-pushout-to-square A w x y z u f g v , \ alphas → refl)))
 
 #def representable-dhom-from-uncurry-hom2
   (A : U)            -- The ambient type.
   (a x y : A)          -- The representing object and two points in the base.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
-  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> a ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := total-equiv-family-equiv (hom A a y)
-    (\ v -> ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> a ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ]))
-    (\ v -> (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
-    (\ v -> Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
+    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+    (\ v → (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+    (\ v → Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
 
 #def representable-dhom-from-hom2
   (A : U)            -- The ambient type.
@@ -289,16 +289,16 @@ equivalences.
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := triple-comp-equiv
     (dhom-from-representable A a x y f u)
-    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> a ,
-                      (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (uncurried-dhom-from-representable A a x y f u)
     (representable-dhom-from-uncurry-hom2 A a x y f u)
     (fubini-Σ (hom A a y) (hom A a y)
-      (\ v d -> product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+      (\ v d → product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
 
 #def representable-dhom-from-hom2-dist
   (A : U)            -- The ambient type.
@@ -313,9 +313,9 @@ equivalences.
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (representable-dhom-from-hom2 A a x y f u)
     (total-equiv-family-equiv (hom A a y)
-      (\ d -> (product (hom2 A a x y u f d) (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
-      (\ d -> (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
-      (\ d -> (distributive-product-Σ (hom2 A a x y u f d) (hom A a y) (\ v -> hom2 A a a y (id-arr A a) v d))))
+      (\ d → (product (hom2 A a x y u f d) (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+      (\ d → (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+      (\ d → (distributive-product-Σ (hom2 A a x y u f d) (hom A a y) (\ v → hom2 A a a y (id-arr A a) v d))))
 ```
 
 Now we introduce the hypothesis that A is Segal type.
@@ -335,15 +335,15 @@ Now we introduce the hypothesis that A is Segal type.
     (Σ (d : hom A a y) , (product (hom2 A a x y u f d) (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
     (representable-dhom-from-hom2-dist A a x y f u)
     (total-equiv-family-equiv (hom A a y)
-      (\ d -> (product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
-      (\ d -> (product (hom2 A a x y u f d) (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
-      (\ d -> (total-equiv-family-equiv (hom2 A a x y u f d)
-        (\ alpha -> (Σ (v : hom A a y) , (v = d)))
-        (\ alpha -> (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d))
-        (\ alpha -> (total-equiv-family-equiv (hom A a y)
-          (\ v -> (v = d))
-          (\ v -> hom2 A a a y (id-arr A a) v d)
-          (\ v -> (Eq-Segal-homotopy-hom2 A is-segal-A a y v d)))))))
+      (\ d → (product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
+      (\ d → (product (hom2 A a x y u f d) (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+      (\ d → (total-equiv-family-equiv (hom2 A a x y u f d)
+        (\ alpha → (Σ (v : hom A a y) , (v = d)))
+        (\ alpha → (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d))
+        (\ alpha → (total-equiv-family-equiv (hom A a y)
+          (\ v → (v = d))
+          (\ v → hom2 A a a y (id-arr A a) v d)
+          (\ v → (Eq-Segal-homotopy-hom2 A is-segal-A a y v d)))))))
 
 
 #def codomain-based-paths-contraction
@@ -353,8 +353,8 @@ Now we introduce the hypothesis that A is Segal type.
   (u : hom A a x)        -- A lift of the domain.
   (d : hom A a y)
   : Equiv (product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))) (hom2 A a x y u f d)
-  := equiv-projection-contractible-fibers (hom2 A a x y u f d) (\ alpha -> (Σ (v : hom A a y) , (v = d)))
-    (\ alpha -> is-contr-codomain-based-paths (hom A a y) d)
+  := equiv-projection-contractible-fibers (hom2 A a x y u f d) (\ alpha → (Σ (v : hom A a y) , (v = d)))
+    (\ alpha → is-contr-codomain-based-paths (hom A a y) d)
 
 #def is-segal-representable-dhom-from-hom2
   (A : U)            -- The ambient type.
@@ -370,9 +370,9 @@ Now we introduce the hypothesis that A is Segal type.
     (Σ (d : hom A a y) , (hom2 A a x y u f d))
     (Segal-representable-dhom-from-path-space A is-segal-A a x y f u)
     (total-equiv-family-equiv (hom A a y)
-      (\ d -> product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
-      (\ d -> hom2 A a x y u f d)
-      (\ d -> codomain-based-paths-contraction A a x y f u d))
+      (\ d → product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
+      (\ d → hom2 A a x y u f d)
+      (\ d → codomain-based-paths-contraction A a x y f u d))
 
 #def is-segal-representable-dhom-from-contractible
   (A : U)            -- The ambient type.
@@ -394,23 +394,23 @@ Finally, we see that covariant hom families in a Segal type are covariant.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  : is-covariant A (\ x -> hom A a x)
-  := \ x y f u -> is-segal-representable-dhom-from-contractible A is-segal-A a x y f u
+  : is-covariant A (\ x → hom A a x)
+  := \ x y f u → is-segal-representable-dhom-from-contractible A is-segal-A a x y f u
 ```
 
 The proof of the claimed converse result given in the original source is
 circular - using Proposition 5.10, which holds only for Segal types - so instead
 we argue as follows:
 
-```rzk title="RS17, Proposition 8.13(->)"
+```rzk title="RS17, Proposition 8.13(→)"
 #def representable-is-covariant-is-segal
   (A : U)
-  (repiscovfam : (a : A) -> is-covariant A (\ x -> hom A a x))
+  (repiscovfam : (a : A) → is-covariant A (\ x → hom A a x))
   : is-segal A
-  := \ x y z f g -> is-contr-base-is-contr-Σ
+  := \ x y z f g → is-contr-base-is-contr-Σ
     (Σ (h : hom A x z) , hom2 A x y z f g h)
-    (\ hk -> Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
-    (\ hk -> (first hk , \ (t , s) -> first hk s))
+    (\ hk → Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
+    (\ hk → (first hk , \ (t , s) → first hk s))
     (is-contr-is-equiv-to-contr
       (Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) , Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
       (dhom-from-representable A x y z g f)
@@ -423,8 +423,8 @@ we argue as follows:
           (representable-dhom-from-hom2-dist A x y z g f)
           (associative-Σ
             (hom A x z)
-            (\ h -> hom2 A x y z f g h)
-            (\ h _ -> Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v h))))
+            (\ h → hom2 A x y z f g h)
+            (\ h _ → Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v h))))
       (repiscovfam x y z g f))
 ```
 
@@ -439,24 +439,24 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ( { (t , s) : ∂□ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ])
-    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} -> A
-      [ ((t === 1_2) /\ (s === 0_2)) |-> a ,
-        ((t === 1_2) /\ (s === 1_2)) |-> y ])
+    ( { (t , s) : ∂□ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
+      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
+        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
   :=
     cofibration-union (2 * 2)
-    ( \ (t , s) -> (t === 1_2) /\ Δ¹ s)
-    ( \ (t , s) ->
+    ( \ (t , s) → (t === 1_2) /\ Δ¹ s)
+    ( \ (t , s) →
       ((t === 0_2) /\ Δ¹ s) \/ (Δ¹ t /\ (s === 0_2)) \/ (Δ¹ t /\ (s === 1_2)))
-    ( \ (t , s) -> A)
-    ( \ (t , s) ->
+    ( \ (t , s) → A)
+    ( \ (t , s) →
       recOR
-        ( ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t))
+        ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t))
 
 #def base-hom-rewriting
   (A : U)            -- The ambient type.
@@ -464,16 +464,16 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ({ (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} -> A
-      [ ((t === 1_2) /\ (s === 0_2)) |-> a ,
-        ((t === 1_2) /\ (s === 1_2)) |-> y ])
+    ({ (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
+      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
+        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
     (hom A a y)
   :=
-    ( \ v -> (\ r -> v ((1_2 , r))) ,
-      ( ( \ v -> \ (t , s) -> v s ,
-          \ v -> refl) ,
-        ( \ v -> \ (t , s) -> v s ,
-          \ v -> refl)))
+    ( \ v → (\ r → v ((1_2 , r))) ,
+      ( ( \ v → \ (t , s) → v s ,
+          \ v → refl) ,
+        ( \ v → \ (t , s) → v s ,
+          \ v → refl)))
 
 #def base-hom-expansion
   (A : U)            -- The ambient type.
@@ -481,20 +481,20 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ( { (t , s) : ∂□ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t])
+    ( { (t , s) : ∂□ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t])
     (hom A a y)
   :=
     comp-equiv
-    ( { (t , s) : ∂□ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t ] )
-    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} -> A
-      [ ((t === 1_2) /\ (s === 0_2)) |-> a ,
-        ((t === 1_2) /\ (s === 1_2)) |-> y ])
+    ( { (t , s) : ∂□ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t ] )
+    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
+      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
+        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
     ( hom A a y)
     ( cofibration-union-test A a x y f u)
     ( base-hom-rewriting A a x y f u)
@@ -505,36 +505,36 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    (Σ (sq : { (t , s) : ∂□ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t ]) ,
-        ({ (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> (sq (1_2 , s)) ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    (Σ (sq : { (t , s) : ∂□ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        ({ (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) ,
-      ({ (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> v s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+      ({ (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
   :=
     total-equiv-pullback-is-equiv
-    (  { (t , s) : ∂□ } -> A
-      [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ] )
+    (  { (t , s) : ∂□ } → A
+      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ] )
             (hom A a y)
             (first (base-hom-expansion A a x y f u))
             (second (base-hom-expansion A a x y f u))
-    ( \ v ->
-      ( { (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> v s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    ( \ v →
+      ( { (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
 
 #def representable-dhom-from-composite-expansion
   (A : U)            -- The ambient type.
@@ -542,32 +542,32 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
-      (Σ (sq : { (t , s) : ∂□ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t ]) ,
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              ((t === 1_2) /\ Δ¹ s) |-> (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+      (Σ (sq : { (t , s) : ∂□ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
-    ( Σ (sq : { (t , s) : ∂□ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t ]) ,
-        ( { (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              ((t === 1_2) /\ Δ¹ s) |-> (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t ]))
-    ( Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          ((t === 1_2) /\ Δ¹ s) |-> v s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    ( Σ (sq : { (t , s) : ∂□ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        ( { (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+    ( Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
     ( uncurried-dhom-from-representable A a x y f u)
     ( representable-dhom-from-expansion A a x y f u)
 
@@ -577,28 +577,28 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ({ (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t] )
-    (Σ (sq : { (t , s) : ∂□ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]) ,
-        ({ (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> (sq (1_2 , s)) ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    ({ (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t] )
+    (Σ (sq : { (t , s) : ∂□ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        ({ (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
   :=
     cofibration-composition (2 * 2) Δ¹×Δ¹ ∂□
-    ( \ (t , s) ->
+    ( \ (t , s) →
       ((t === 0_2) /\ Δ¹ s) \/ (Δ¹ t /\ (s === 0_2)) \/ (Δ¹ t /\ (s === 1_2)))
-    ( \ ts -> A)
-    ( \ (t , s) ->
-      recOR ( ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t))
+    ( \ ts → A)
+    ( \ (t , s) →
+      recOR ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t))
 
 #def representable-dhom-from-as-extension-type
   (A : U)            -- The ambient type.
@@ -607,26 +607,26 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
       (dhom-from-representable A a x y f u)
-      ({ (t , s) : Δ¹×Δ¹ } -> A
-              [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-                (Δ¹ t /\ (s === 0_2)) |-> a ,
-                (Δ¹ t /\ (s === 1_2)) |-> f t] )
+      ({ (t , s) : Δ¹×Δ¹ } → A
+              [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                (Δ¹ t /\ (s === 0_2)) ↦ a ,
+                (Δ¹ t /\ (s === 1_2)) ↦ f t] )
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
-    ( { (t , s) : Δ¹×Δ¹ } -> A
-        [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-          (Δ¹ t /\ (s === 0_2)) |-> a ,
-          (Δ¹ t /\ (s === 1_2)) |-> f t] )
-    ( Σ (sq : { (t , s) : ∂□ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            (Δ¹ t /\ (s === 0_2)) |-> a ,
-            (Δ¹ t /\ (s === 1_2)) |-> f t ]) ,
-        ({ (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              ((t === 1_2) /\ Δ¹ s) |-> (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) |-> a ,
-              (Δ¹ t /\ (s === 1_2)) |-> f t ]))
+    ( { (t , s) : Δ¹×Δ¹ } → A
+        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+          (Δ¹ t /\ (s === 0_2)) ↦ a ,
+          (Δ¹ t /\ (s === 1_2)) ↦ f t] )
+    ( Σ (sq : { (t , s) : ∂□ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ a ,
+            (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        ({ (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t /\ (s === 0_2)) ↦ a ,
+              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
     ( representable-dhom-from-composite-expansion A a x y f u)
     ( representable-dhom-from-cofibration-composition A a x y f u)
 ```
@@ -641,7 +641,7 @@ along an arrow f : hom A x y to give a term in C y.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C x)
    : C y
@@ -653,7 +653,7 @@ along an arrow f : hom A x y to give a term in C y.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C x)
   : (dhom A x y f C u (covariant-transport A x y f C is-covariant-C u))
@@ -663,7 +663,7 @@ along an arrow f : hom A x y to give a term in C y.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C x)
   (lift : dhom-from A x y f C u)
@@ -671,7 +671,7 @@ along an arrow f : hom A x y to give a term in C y.
   :=
     first-path-Σ
     ( C y)
-    ( \ v -> dhom A x y f C u v)
+    ( \ v → dhom A x y f C u v)
     ( contraction-center (dhom-from A x y f C u) (is-covariant-C x y f u))
     ( lift)
     ( contracting-htpy (dhom-from A x y f C u) (is-covariant-C x y f u) lift)
@@ -687,10 +687,10 @@ transport law.
 #def d-id-arr
   (A : U)
   (x : A)
-  (C : A -> U)
+  (C : A → U)
   (u : C x)
   : dhom A x x (id-arr A x) C u u
-  := \ t -> u
+  := \ t → u
 ```
 
 ```rzk title="RS17, Proposition 8.16, Part 2"
@@ -698,7 +698,7 @@ transport law.
 #def id-arr-covariant-transport
   (A : U)
   (x : A)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C x)
   : (covariant-transport A x x (id-arr A x) C is-covariant-C u) = u
@@ -718,22 +718,22 @@ with the covariant lifts.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C D : A -> U)
+  (C D : A → U)
   (is-covariant-C : is-covariant A C)
-  (ϕ : (z : A) -> C z -> D z)
+  (ϕ : (z : A) → C z → D z)
   (u : C x)
   : dhom-from A x y f D (ϕ x u)
   := (ϕ y (covariant-transport A x y f C is-covariant-C u) ,
-  \ t -> ϕ (f t) (covariant-lift A x y f C is-covariant-C u t))
+  \ t → ϕ (f t) (covariant-lift A x y f C is-covariant-C u t))
 
 #def naturality-covariant-fiberwise-transformation
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C D : A -> U)
+  (C D : A → U)
   (is-covariant-C : is-covariant A C)
   (DisCov : is-covariant A D)
-  (ϕ : (z : A) -> C z -> D z)
+  (ϕ : (z : A) → C z → D z)
   (u : C x)
   : (covariant-transport A x y f D DisCov (ϕ x u)) =
     (ϕ y (covariant-transport A x y f C is-covariant-C u))
@@ -753,7 +753,7 @@ has a unique lift with specified codomain.
   (A : U)            -- The base type.
   (x y : A)          -- Two points in the base.
   (f : hom A x y)        -- An arrow in the base.
-  (C : A -> U)        -- A type family.
+  (C : A → U)        -- A type family.
   (v : C y)          -- A lift of the domain.
   : U
      := (Σ (u : C x) , dhom A x y f C u v)
@@ -762,14 +762,14 @@ has a unique lift with specified codomain.
 ```rzk title="RS17, Definition 8.2, dual form"
 #def is-contravariant
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : U
-  := (x : A) -> (y : A) -> (f : hom A x y) -> (v : C y)
-    -> is-contr (dhom-to A x y f C v)
+  := (x : A) → (y : A) → (f : hom A x y) → (v : C y)
+    → is-contr (dhom-to A x y f C v)
 
 -- Type of contravariant families over a fixed type
 #def contravariant-family (A : U) : U
-  := (Σ (C : A -> U) , is-contravariant A C)
+  := (Σ (C : A → U) , is-contravariant A C)
 ```
 
 The notion of having a unique lift with a fixed codomain may also be expressed
@@ -779,10 +779,10 @@ the 1-simplex.
 ```rzk
 #def has-unique-lifts-with-fixed-codomain
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : U
-  := (x : A) -> (y : A) -> (f : hom A x y) -> (v : C y)
-    -> is-contr ((t : Δ¹) -> C (f t) [ t === 1_2 |-> v ])
+  := (x : A) → (y : A) → (f : hom A x y) → (v : C y)
+    → is-contr ((t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -793,17 +793,17 @@ here.
 ```rzk
 #def equiv-lifts-with-fixed-codomain
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   (x y : A)
   (f : hom A x y)
   (v : C y)
   : Equiv
-      ((t : Δ¹) -> C (f t) [ t === 1_2 |-> v ])
+      ((t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
       (dhom-to A x y f C v)
   :=
-    ( \ h -> (h 0_2 , \ t -> h t) ,
-      ( ( \ fg t -> (second fg) t , \ h -> refl) ,
-        ( ( \ fg t -> (second fg) t , \ h -> refl))))
+    ( \ h → (h 0_2 , \ t → h t) ,
+      ( ( \ fg t → (second fg) t , \ h → refl) ,
+        ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
 
 By the equivalence-invariance of contractibility, this proves the desired
@@ -812,20 +812,20 @@ logical equivalence
 ```rzk title="RS17, Proposition 8.4"
 #def has-unique-lifts-with-fixed-codomain-iff-is-contravariant
   (A : U)
-  (C : A -> U)
+  (C : A → U)
   : iff
       (has-unique-lifts-with-fixed-codomain A C)
       (is-contravariant A C)
   :=
-    ( \ C-has-unique-lifts x y f v ->
+    ( \ C-has-unique-lifts x y f v →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) -> C (f t) [ t === 1_2 |-> v ])
+        ( (t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( C-has-unique-lifts x y f v),
-      \ is-contravariant-C x y f v ->
+      \ is-contravariant-C x y f v →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) -> C (f t) [ t === 1_2 |-> v ])
+        ( (t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( is-contravariant-C x y f v))
@@ -833,7 +833,7 @@ logical equivalence
 
 ## Representable contravariant families
 
-If A is a Segal type and a : A is any term, then the family \ x -> hom A x a
+If A is a Segal type and a : A is any term, then the family \ x → hom A x a
 defines a contravariant family over A , and conversely if this family is
 contravariant for every a : A , then A must be a Segal type. The proof involves
 a rather lengthy composition of equivalences.
@@ -846,7 +846,7 @@ a rather lengthy composition of equivalences.
   (u : hom A x a)        -- A lift of the domain.
   (v : hom A y a)        -- A lift of the codomain.
   : U
-  := dhom A x y f (\ z -> hom A z a) u v
+  := dhom A x y f (\ z → hom A z a) u v
 
 -- By uncurrying (RS 4.2) we have an equivalence:
 #def uncurried-dhom-contra-representable
@@ -856,15 +856,15 @@ a rather lengthy composition of equivalences.
   (u : hom A x a)        -- A lift of the domain.
   (v : hom A y a)        -- A lift of the codomain.
   : Equiv (dhom-contra-representable A a x y f u v)
-  ({ (t , s) : Δ¹×Δ¹ } -> A [((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> f t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> a ])
-  := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s -> A)
-    (\ (t , s) -> recOR (((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> v s ,
-            (Δ¹ t /\ (s === 0_2)) |-> f t ,
-            (Δ¹ t /\ (s === 1_2)) |-> a ))
+  ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ a ])
+  := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
+    (\ (t , s) → recOR (((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+            (Δ¹ t /\ (s === 1_2)) ↦ a ))
 
 #def dhom-to-representable
   (A : U)            -- The ambient type.
@@ -872,7 +872,7 @@ a rather lengthy composition of equivalences.
   (f : hom A x y)    -- An arrow in the base.
   (v : hom A y a)    -- A lift of the codomain.
   : U
-  := dhom-to A x y f (\ z -> hom A z a) v
+  := dhom-to A x y f (\ z → hom A z a) v
 
 -- By uncurrying (RS 4.2) we have an equivalence:
 #def uncurried-dhom-to-representable
@@ -882,22 +882,22 @@ a rather lengthy composition of equivalences.
   (v : hom A y a)    -- A lift of the codomain.
   : Equiv (dhom-to-representable A a x y f v)
     (Σ (u : hom A x a) ,
-        ({ (t , s) : Δ¹×Δ¹ } -> A
-                    [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> f t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> a ]))
+        ({ (t , s) : Δ¹×Δ¹ } → A
+                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
   :=
     total-equiv-family-equiv
     ( hom A x a)
-    ( \ u -> dhom-contra-representable A a x y f u v)
-    ( \ u ->
-      ({ (t , s) : Δ¹×Δ¹ } -> A
-          [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-            ((t === 1_2) /\ Δ¹ s) |-> v s ,
-            (Δ¹ t /\ (s === 0_2)) |-> f t ,
-            (Δ¹ t /\ (s === 1_2)) |-> a ]))
-    ( \ u -> uncurried-dhom-contra-representable A a x y f u v)
+    ( \ u → dhom-contra-representable A a x y f u v)
+    ( \ u →
+      ({ (t , s) : Δ¹×Δ¹ } → A
+          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+            (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+            (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+    ( \ u → uncurried-dhom-contra-representable A a x y f u v)
 
 #def representable-dhom-to-uncurry-hom2
   (A : U)            -- The ambient type.
@@ -905,26 +905,26 @@ a rather lengthy composition of equivalences.
   (f : hom A x y)    -- An arrow in the base.
   (v : hom A y a)    -- A lift of the codomain.
   : Equiv
-    (Σ (u : hom A x a) , ({ (t , s) : Δ¹×Δ¹ } -> A
-                    [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> f t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> a ]))
+    (Σ (u : hom A x a) , ({ (t , s) : Δ¹×Δ¹ } → A
+                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
     (Σ (u : hom A x a) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
   :=
     total-equiv-family-equiv (hom A x a)
-    ( \ u ->
-      ({ (t , s) : Δ¹×Δ¹ } -> A
-                    [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-                      ((t === 1_2) /\ Δ¹ s) |-> v s ,
-                      (Δ¹ t /\ (s === 0_2)) |-> f t ,
-                      (Δ¹ t /\ (s === 1_2)) |-> a ]))
-    ( \ u ->
+    ( \ u →
+      ({ (t , s) : Δ¹×Δ¹ } → A
+                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+    ( \ u →
       (Σ (d : hom A x a) ,
           product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
-    ( \ u -> Eq-square-hom2-pushout A x a y a u (id-arr A a) f v)
+    ( \ u → Eq-square-hom2-pushout A x a y a u (id-arr A a) f v)
 
 #def representable-dhom-to-hom2
   (A : U)          -- The ambient type.
@@ -940,11 +940,11 @@ a rather lengthy composition of equivalences.
     triple-comp-equiv
     ( dhom-to-representable A a x y f v)
     ( Σ (u : hom A x a) ,
-        ({ (t , s) : Δ¹×Δ¹ } -> A
-            [ ((t === 0_2) /\ Δ¹ s) |-> u s ,
-              ((t === 1_2) /\ Δ¹ s) |-> v s ,
-              (Δ¹ t /\ (s === 0_2)) |-> f t ,
-              (Δ¹ t /\ (s === 1_2)) |-> a ]))
+        ({ (t , s) : Δ¹×Δ¹ } → A
+            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
+              ((t === 1_2) /\ Δ¹ s) ↦ v s ,
+              (Δ¹ t /\ (s === 0_2)) ↦ f t ,
+              (Δ¹ t /\ (s === 1_2)) ↦ a ]))
     ( Σ (u : hom A x a ) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
@@ -954,7 +954,7 @@ a rather lengthy composition of equivalences.
     ( uncurried-dhom-to-representable A a x y f v)
     ( representable-dhom-to-uncurry-hom2 A a x y f v)
     ( fubini-Σ (hom A x a) (hom A x a)
-      (\ u d -> product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
+      (\ u d → product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
 
 #def representable-dhom-to-hom2-swap
   (A : U)          -- The ambient type.
@@ -970,12 +970,12 @@ a rather lengthy composition of equivalences.
       (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
       (representable-dhom-to-hom2 A a x y f v)
       (total-equiv-family-equiv (hom A x a)
-        (\ d -> (Σ (u : hom A x a) , product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
-        (\ d -> (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
-        (\ d -> total-equiv-family-equiv (hom A x a)
-          (\ u -> product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))
-          (\ u -> product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d))
-          (\ u -> sym-product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))))
+        (\ d → (Σ (u : hom A x a) , product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
+        (\ d → (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+        (\ d → total-equiv-family-equiv (hom A x a)
+          (\ u → product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))
+          (\ u → product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d))
+          (\ u → sym-product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))))
 
 #def representable-dhom-to-hom2-dist
   (A : U)            -- The ambient type.
@@ -992,10 +992,10 @@ a rather lengthy composition of equivalences.
     (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d)))
     (representable-dhom-to-hom2-swap A a x y f v)
     (total-equiv-family-equiv (hom A x a)
-      (\ d -> (product (hom2 A x y a f v d)
+      (\ d → (product (hom2 A x y a f v d)
       (Σ (u : hom A x a ) , hom2 A x a a u (id-arr A a) d)))
-      (\ d -> (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
-      (\ d -> (distributive-product-Σ (hom2 A x y a f v d) (hom A x a) (\ u -> hom2 A x a a u (id-arr A a) d))))
+      (\ d → (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+      (\ d → (distributive-product-Σ (hom2 A x y a f v d) (hom A x a) (\ u → hom2 A x a a u (id-arr A a) d))))
 ```
 
 Now we introduce the hypothesis that A is Segal type.
@@ -1015,15 +1015,15 @@ Now we introduce the hypothesis that A is Segal type.
     (Σ (d : hom A x a) , (product (hom2 A x y a f v d) (Σ (u : hom A x a) , (hom2 A x a a u (id-arr A a) d))))
     (representable-dhom-to-hom2-dist A a x y f v)
     (total-equiv-family-equiv (hom A x a)
-      (\ d -> (product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
-      (\ d -> (product (hom2 A x y a f v d) (Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d)))
-      (\ d -> (total-equiv-family-equiv (hom2 A x y a f v d)
-        (\ α -> (Σ (u : hom A x a) , (u = d)))
-        (\ α -> (Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d))
-        (\ α -> (total-equiv-family-equiv (hom A x a)
-          (\ u -> (u = d))
-          (\ u -> hom2 A x a a u (id-arr A a) d)
-          (\ u -> (Eq-Segal-homotopy-hom2' A is-segal-A x a u d)))))))
+      (\ d → (product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
+      (\ d → (product (hom2 A x y a f v d) (Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d)))
+      (\ d → (total-equiv-family-equiv (hom2 A x y a f v d)
+        (\ α → (Σ (u : hom A x a) , (u = d)))
+        (\ α → (Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d))
+        (\ α → (total-equiv-family-equiv (hom A x a)
+          (\ u → (u = d))
+          (\ u → hom2 A x a a u (id-arr A a) d)
+          (\ u → (Eq-Segal-homotopy-hom2' A is-segal-A x a u d)))))))
 
 #def is-segal-representable-dhom-to-hom2
   (A : U)            -- The ambient type.
@@ -1039,9 +1039,9 @@ Now we introduce the hypothesis that A is Segal type.
     (Σ (d : hom A x a) , (hom2 A x y a f v d))
     (Segal-representable-dhom-to-path-space A is-segal-A a x y f v)
     (total-equiv-family-equiv (hom A x a)
-      (\ d -> product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))
-      (\ d -> hom2 A x y a f v d)
-      (\ d -> codomain-based-paths-contraction A x y a v f d))
+      (\ d → product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))
+      (\ d → hom2 A x y a f v d)
+      (\ d → codomain-based-paths-contraction A x y a v f d))
 
 #def is-segal-representable-dhom-to-contractible
   (A : U)                -- The ambient type.
@@ -1064,23 +1064,23 @@ contravariant.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  : is-contravariant A (\ x -> hom A x a)
-  := \ x y f v -> is-segal-representable-dhom-to-contractible A is-segal-A a x y f v
+  : is-contravariant A (\ x → hom A x a)
+  := \ x y f v → is-segal-representable-dhom-to-contractible A is-segal-A a x y f v
 ```
 
 The proof of the claimed converse result given in the original source is
 circular - using Proposition 5.10, which holds only for Segal types - so instead
 we argue as follows:
 
-```rzk title="RS17, Proposition 8.13(->), dual"
+```rzk title="RS17, Proposition 8.13(→), dual"
 #def representable-is-contravariant-is-segal
   (A : U)
-  (repiscontrafam : (a : A) -> is-contravariant A (\ x -> hom A x a))
+  (repiscontrafam : (a : A) → is-contravariant A (\ x → hom A x a))
   : is-segal A
-  := \ x y z f g -> is-contr-base-is-contr-Σ
+  := \ x y z f g → is-contr-base-is-contr-Σ
     (Σ (h : hom A x z) , hom2 A x y z f g h)
-    (\ hk -> Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
-    (\ hk -> (first hk , \ (t , s) -> first hk t))
+    (\ hk → Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
+    (\ hk → (first hk , \ (t , s) → first hk t))
     (is-contr-is-equiv-to-contr
       (Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) , Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
       (dhom-to-representable A z x y f g)
@@ -1093,8 +1093,8 @@ we argue as follows:
           (representable-dhom-to-hom2-dist A z x y f g)
           (associative-Σ
             (hom A x z)
-            (\ h -> hom2 A x y z f g h)
-            (\ h _ -> Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) h))))
+            (\ h → hom2 A x y z f g h)
+            (\ h _ → Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) h))))
       (repiscontrafam z x y f g))
 ```
 
@@ -1108,7 +1108,7 @@ transported along an arrow f : hom A x y to give a term in C x.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (v : C y)
    : C x
@@ -1120,7 +1120,7 @@ transported along an arrow f : hom A x y to give a term in C x.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (v : C y)
   : (dhom A x y f C (contravariant-transport A x y f C is-contravariant-C v) v)
@@ -1132,14 +1132,14 @@ transported along an arrow f : hom A x y to give a term in C x.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (v : C y)
   (lift : dhom-to A x y f C v)
   : (contravariant-transport A x y f C is-contravariant-C v) = (first lift)
   := first-path-Σ
     (C x)
-    (\ u -> dhom A x y f C u v)
+    (\ u → dhom A x y f C u v)
     (contraction-center (dhom-to A x y f C v) (is-contravariant-C x y f v))
     lift
     (contracting-htpy (dhom-to A x y f C v) (is-contravariant-C x y f v) lift)
@@ -1156,7 +1156,7 @@ identity transport law.
 #def id-arr-contravariant-transport
    (A : U)
   (x : A)
-   (C : A -> U)
+   (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (u : C x)
   : (contravariant-transport A x x (id-arr A x) C is-contravariant-C u) = u
@@ -1174,22 +1174,22 @@ commuting with the contravariant lifts.
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C D : A -> U)
+  (C D : A → U)
   (is-contravariant-C : is-contravariant A C)
-  (ϕ : (z : A) -> C z -> D z)
+  (ϕ : (z : A) → C z → D z)
   (v : C y)
   : dhom-to A x y f D (ϕ y v)
   := (ϕ x (contravariant-transport A x y f C is-contravariant-C v) ,
-  \ t -> ϕ (f t) (contravariant-lift A x y f C is-contravariant-C v t))
+  \ t → ϕ (f t) (contravariant-lift A x y f C is-contravariant-C v t))
 
 #def naturality-contravariant-fiberwise-transformation
   (A : U)
   (x y : A)
   (f : hom A x y)
-  (C D : A -> U)
+  (C D : A → U)
   (is-contravariant-C : is-contravariant A C)
   (DisContra : is-contravariant A D)
-  (ϕ : (z : A) -> C z -> D z)
+  (ϕ : (z : A) → C z → D z)
   (v : C y)
   : (contravariant-transport A x y f D DisContra (ϕ y v)) =
       (ϕ x (contravariant-transport A x y f C is-contravariant-C v))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -33,8 +33,8 @@ live over a specified arrow in the base type.
   (v : C y)          -- A lift of the codomain.
   : U
     := {t : Δ¹ } → C (f t)
-      [ t === 0_2 ↦ u ,
-        t === 1_2 ↦ v ]
+      [ t ≡ 0_2 ↦ u ,
+        t ≡ 1_2 ↦ v ]
 ```
 
 It will be convenient to collect together dependent hom types with fixed domain
@@ -71,9 +71,9 @@ triangle.
   (hh : dhom A x z h C u w)    -- A lift of the diagonal arrow.
   : U
     := { (t1 , t2) : Δ² } → C (alpha (t1 , t2))
-      [ t2 === 0_2 ↦ ff t1 ,
-        t1 === 1_2 ↦ gg t2 ,
-        t2 === t1  ↦ hh t2 ]
+      [ t2 ≡ 0_2 ↦ ff t1 ,
+        t1 ≡ 1_2 ↦ gg t2 ,
+        t2 ≡ t1  ↦ hh t2 ]
 ```
 
 ## Covariant families
@@ -104,7 +104,7 @@ contractibility of the type of extensions along the domain inclusion into the
   (C : A → U)
   : U
   := (x : A) → (y : A) → (f : hom A x y) → (u : C x)
-    → is-contr ((t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
+    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -120,7 +120,7 @@ here.
   (f : hom A x y)
   (u : C x)
   : Equiv
-      ((t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
+      ((t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
       (dhom-from A x y f C u)
   :=
     ( \ h → (h 1_2 , \ t → h t) ,
@@ -141,13 +141,13 @@ logical equivalence
   :=
     ( \ C-has-unique-lifts x y f u →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-has-unique-lifts x y f u),
       \ C-is-covariant x y f u →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) → C (f t) [ t === 0_2 ↦ u ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-is-covariant x y f u))
@@ -179,16 +179,16 @@ equivalences.
   (v : hom A a y)        -- A lift of the codomain.
   : Equiv (dhom-representable A a x y f u v)
   ({ (t , s) : Δ¹×Δ¹ } → A
-    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-      (Δ¹ t /\ (s === 0_2)) ↦ a ,
-      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
   := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
     (\ (t , s) → recOR
-      ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ a ,
-        (Δ¹ t /\ (s === 1_2)) ↦ f t ))
+      ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ))
 
 #def dhom-from-representable
   (A : U)            -- The ambient type.
@@ -206,16 +206,16 @@ equivalences.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
     (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ a ,
-        (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
   := total-equiv-family-equiv (hom A a y) (\ v → dhom-representable A a x y f u v)
     (\ v → ({ (t , s) : Δ¹×Δ¹ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-        ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-        (Δ¹ t /\ (s === 0_2)) ↦ a ,
-        (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     (\ v → uncurried-dhom-representable A a x y f u v)
 
 #def square-to-hom2-pushout
@@ -225,10 +225,10 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+  : ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
   → (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   := \ sq → ((\ t → sq (t , t)) , (\ (t , s) → sq (s , t) , \ (t , s) → sq (t , s)))
 
@@ -240,12 +240,12 @@ equivalences.
   (g : hom A w y)
   (v : hom A y z)
   : (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
-  → ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
-  := \ (d , (alpha1 , alpha2)) (t , s) → recOR (t <= s ↦ alpha1 (s , t) ,
-                        s <= t ↦ alpha2 (t , s))
+  → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+  := \ (d , (alpha1 , alpha2)) (t , s) → recOR (t ≤ s ↦ alpha1 (s , t) ,
+                        s ≤ t ↦ alpha2 (t , s))
 #def Eq-square-hom2-pushout
   (A : U)
   (w x y z : A)
@@ -253,10 +253,10 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : Equiv ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ g t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ])
+  : Equiv ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
     (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   := (square-to-hom2-pushout A w x y z u f g v ,
     ((hom2-pushout-to-square A w x y z u f g v , \ sq → refl) ,
@@ -267,16 +267,16 @@ equivalences.
   (a x y : A)          -- The representing object and two points in the base.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
-  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := total-equiv-family-equiv (hom A a y)
-    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     (\ v → (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (\ v → Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
 
@@ -289,10 +289,10 @@ equivalences.
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := triple-comp-equiv
     (dhom-from-representable A a x y f u)
-    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ a ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (uncurried-dhom-from-representable A a x y f u)
@@ -440,23 +440,23 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ( { (t , s) : ∂□ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ])
-    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
-      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
-        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+    ( { (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
+        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
   :=
     cofibration-union (2 * 2)
-    ( \ (t , s) → (t === 1_2) /\ Δ¹ s)
+    ( \ (t , s) → (t ≡ 1_2) ∧ Δ¹ s)
     ( \ (t , s) →
-      ((t === 0_2) /\ Δ¹ s) \/ (Δ¹ t /\ (s === 0_2)) \/ (Δ¹ t /\ (s === 1_2)))
+      ((t ≡ 0_2) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0_2)) ∨ (Δ¹ t ∧ (s ≡ 1_2)))
     ( \ (t , s) → A)
     ( \ (t , s) →
       recOR
-        ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t))
+        ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t))
 
 #def base-hom-rewriting
   (A : U)            -- The ambient type.
@@ -464,9 +464,9 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ({ (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
-      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
-        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
+    ({ (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
+        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
     (hom A a y)
   :=
     ( \ v → (\ r → v ((1_2 , r))) ,
@@ -482,19 +482,19 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ( { (t , s) : ∂□ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t])
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t])
     (hom A a y)
   :=
     comp-equiv
     ( { (t , s) : ∂□ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t ] )
-    ( { (t , s) : 2 * 2 | ((t === 1_2) /\ (Δ¹ s))} → A
-      [ ((t === 1_2) /\ (s === 0_2)) ↦ a ,
-        ((t === 1_2) /\ (s === 1_2)) ↦ y ])
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ] )
+    ( { (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
+        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
     ( hom A a y)
     ( cofibration-union-test A a x y f u)
     ( base-hom-rewriting A a x y f u)
@@ -506,35 +506,35 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     (Σ (sq : { (t , s) : ∂□ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     (Σ (v : hom A a y) ,
       ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
   :=
     total-equiv-pullback-is-equiv
     (  { (t , s) : ∂□ } → A
-      [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ] )
+      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ] )
             (hom A a y)
             (first (base-hom-expansion A a x y f u))
             (second (base-hom-expansion A a x y f u))
     ( \ v →
       ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
 
 #def representable-dhom-from-composite-expansion
   (A : U)            -- The ambient type.
@@ -543,31 +543,31 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
       (Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     ( Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     ( uncurried-dhom-from-representable A a x y f u)
     ( representable-dhom-from-expansion A a x y f u)
 
@@ -578,27 +578,27 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ({ (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t] )
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
     (Σ (sq : { (t , s) : ∂□ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
   :=
     cofibration-composition (2 * 2) Δ¹×Δ¹ ∂□
     ( \ (t , s) →
-      ((t === 0_2) /\ Δ¹ s) \/ (Δ¹ t /\ (s === 0_2)) \/ (Δ¹ t /\ (s === 1_2)))
+      ((t ≡ 0_2) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0_2)) ∨ (Δ¹ t ∧ (s ≡ 1_2)))
     ( \ ts → A)
     ( \ (t , s) →
-      recOR ( ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t))
+      recOR ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t))
 
 #def representable-dhom-from-as-extension-type
   (A : U)            -- The ambient type.
@@ -608,25 +608,25 @@ types as follows.
   : Equiv
       (dhom-from-representable A a x y f u)
       ({ (t , s) : Δ¹×Δ¹ } → A
-              [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                (Δ¹ t /\ (s === 0_2)) ↦ a ,
-                (Δ¹ t /\ (s === 1_2)) ↦ f t] )
+              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+                (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
     ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-          (Δ¹ t /\ (s === 0_2)) ↦ a ,
-          (Δ¹ t /\ (s === 1_2)) ↦ f t] )
+        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
     ( Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ a ,
-            (Δ¹ t /\ (s === 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t /\ (s === 0_2)) ↦ a ,
-              (Δ¹ t /\ (s === 1_2)) ↦ f t ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
     ( representable-dhom-from-composite-expansion A a x y f u)
     ( representable-dhom-from-cofibration-composition A a x y f u)
 ```
@@ -782,7 +782,7 @@ the 1-simplex.
   (C : A → U)
   : U
   := (x : A) → (y : A) → (f : hom A x y) → (v : C y)
-    → is-contr ((t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
+    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -798,7 +798,7 @@ here.
   (f : hom A x y)
   (v : C y)
   : Equiv
-      ((t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
+      ((t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
       (dhom-to A x y f C v)
   :=
     ( \ h → (h 0_2 , \ t → h t) ,
@@ -819,13 +819,13 @@ logical equivalence
   :=
     ( \ C-has-unique-lifts x y f v →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( C-has-unique-lifts x y f v),
       \ is-contravariant-C x y f v →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) → C (f t) [ t === 1_2 ↦ v ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( is-contravariant-C x y f v))
@@ -856,15 +856,15 @@ a rather lengthy composition of equivalences.
   (u : hom A x a)        -- A lift of the domain.
   (v : hom A y a)        -- A lift of the codomain.
   : Equiv (dhom-contra-representable A a x y f u v)
-  ({ (t , s) : Δ¹×Δ¹ } → A [((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ a ])
+  ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ])
   := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
-    (\ (t , s) → recOR (((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-            (Δ¹ t /\ (s === 1_2)) ↦ a ))
+    (\ (t , s) → recOR (((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ))
 
 #def dhom-to-representable
   (A : U)            -- The ambient type.
@@ -883,20 +883,20 @@ a rather lengthy composition of equivalences.
   : Equiv (dhom-to-representable A a x y f v)
     (Σ (u : hom A x a) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
   :=
     total-equiv-family-equiv
     ( hom A x a)
     ( \ u → dhom-contra-representable A a x y f u v)
     ( \ u →
       ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-            ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-            (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-            (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+            (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
     ( \ u → uncurried-dhom-contra-representable A a x y f u v)
 
 #def representable-dhom-to-uncurry-hom2
@@ -906,10 +906,10 @@ a rather lengthy composition of equivalences.
   (v : hom A y a)    -- A lift of the codomain.
   : Equiv
     (Σ (u : hom A x a) , ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
     (Σ (u : hom A x a) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
@@ -917,10 +917,10 @@ a rather lengthy composition of equivalences.
     total-equiv-family-equiv (hom A x a)
     ( \ u →
       ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-                      ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-                      (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-                      (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
     ( \ u →
       (Σ (d : hom A x a) ,
           product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
@@ -941,10 +941,10 @@ a rather lengthy composition of equivalences.
     ( dhom-to-representable A a x y f v)
     ( Σ (u : hom A x a) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-            [ ((t === 0_2) /\ Δ¹ s) ↦ u s ,
-              ((t === 1_2) /\ Δ¹ s) ↦ v s ,
-              (Δ¹ t /\ (s === 0_2)) ↦ f t ,
-              (Δ¹ t /\ (s === 1_2)) ↦ a ]))
+            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
+              (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
+              (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
     ( Σ (u : hom A x a ) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -33,8 +33,8 @@ live over a specified arrow in the base type.
   (v : C y)          -- A lift of the codomain.
   : U
     := {t : Δ¹ } → C (f t)
-      [ t ≡ 0_2 ↦ u ,
-        t ≡ 1_2 ↦ v ]
+      [ t ≡ 0₂ ↦ u ,
+        t ≡ 1₂ ↦ v ]
 ```
 
 It will be convenient to collect together dependent hom types with fixed domain
@@ -71,8 +71,8 @@ triangle.
   (hh : dhom A x z h C u w)    -- A lift of the diagonal arrow.
   : U
     := { (t1 , t2) : Δ² } → C (alpha (t1 , t2))
-      [ t2 ≡ 0_2 ↦ ff t1 ,
-        t1 ≡ 1_2 ↦ gg t2 ,
+      [ t2 ≡ 0₂ ↦ ff t1 ,
+        t1 ≡ 1₂ ↦ gg t2 ,
         t2 ≡ t1  ↦ hh t2 ]
 ```
 
@@ -104,7 +104,7 @@ contractibility of the type of extensions along the domain inclusion into the
   (C : A → U)
   : U
   := (x : A) → (y : A) → (f : hom A x y) → (u : C x)
-    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
+    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -120,10 +120,10 @@ here.
   (f : hom A x y)
   (u : C x)
   : Equiv
-      ((t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
+      ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u ])
       (dhom-from A x y f C u)
   :=
-    ( \ h → (h 1_2 , \ t → h t) ,
+    ( \ h → (h 1₂ , \ t → h t) ,
       ( ( \ fg t → (second fg) t , \ h → refl) ,
         ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
@@ -141,13 +141,13 @@ logical equivalence
   :=
     ( \ C-has-unique-lifts x y f u →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-has-unique-lifts x y f u),
       \ C-is-covariant x y f u →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) → C (f t) [ t ≡ 0_2 ↦ u ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u ])
         ( dhom-from A x y f C u)
         ( equiv-lifts-with-fixed-domain A C x y f u)
         ( C-is-covariant x y f u))
@@ -179,16 +179,16 @@ equivalences.
   (v : hom A a y)        -- A lift of the codomain.
   : Equiv (dhom-representable A a x y f u v)
   ({ (t , s) : Δ¹×Δ¹ } → A
-    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+    [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+      (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
   := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
     (\ (t , s) → recOR
-      ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ))
+      ( ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ))
 
 #def dhom-from-representable
   (A : U)            -- The ambient type.
@@ -206,16 +206,16 @@ equivalences.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
     (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
   := total-equiv-family-equiv (hom A a y) (\ v → dhom-representable A a x y f u v)
     (\ v → ({ (t , s) : Δ¹×Δ¹ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-        ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-        (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-        (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+        ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+        (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+        (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     (\ v → uncurried-dhom-representable A a x y f u v)
 
 #def square-to-hom2-pushout
@@ -225,10 +225,10 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+  : ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
   → (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   := \ sq → ((\ t → sq (t , t)) , (\ (t , s) → sq (s , t) , \ (t , s) → sq (t , s)))
 
@@ -240,10 +240,10 @@ equivalences.
   (g : hom A w y)
   (v : hom A y z)
   : (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
-  → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+  → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
   := \ (d , (alpha1 , alpha2)) (t , s) → recOR (t ≤ s ↦ alpha1 (s , t) ,
                         s ≤ t ↦ alpha2 (t , s))
 #def Eq-square-hom2-pushout
@@ -253,10 +253,10 @@ equivalences.
   (f : hom A x z)
   (g : hom A w y)
   (v : hom A y z)
-  : Equiv ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ g t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
+  : Equiv ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ g t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
     (Σ (d : hom A w z) , product (hom2 A w x z u f d) (hom2 A w y z g v d))
   := (square-to-hom2-pushout A w x y z u f g v ,
     ((hom2-pushout-to-square A w x y z u f g v , \ sq → refl) ,
@@ -267,16 +267,16 @@ equivalences.
   (a x y : A)          -- The representing object and two points in the base.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
-  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+  : Equiv (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := total-equiv-family-equiv (hom A a y)
-    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+    (\ v → ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     (\ v → (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (\ v → Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
 
@@ -289,10 +289,10 @@ equivalences.
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   := triple-comp-equiv
     (dhom-from-representable A a x y f u)
-    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+    (Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     (Σ (v : hom A a y) , (Σ (d : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (Σ (d : hom A a y) , (Σ (v : hom A a y) , product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
     (uncurried-dhom-from-representable A a x y f u)
@@ -440,23 +440,23 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ( { (t , s) : ∂□ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ])
-    ( { (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
-      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
-        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
+    ( { (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
+        ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
   :=
     cofibration-union (2 * 2)
-    ( \ (t , s) → (t ≡ 1_2) ∧ Δ¹ s)
+    ( \ (t , s) → (t ≡ 1₂) ∧ Δ¹ s)
     ( \ (t , s) →
-      ((t ≡ 0_2) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0_2)) ∨ (Δ¹ t ∧ (s ≡ 1_2)))
+      ((t ≡ 0₂) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0₂)) ∨ (Δ¹ t ∧ (s ≡ 1₂)))
     ( \ (t , s) → A)
     ( \ (t , s) →
       recOR
-        ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t))
+        ( ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t))
 
 #def base-hom-rewriting
   (A : U)            -- The ambient type.
@@ -464,12 +464,12 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ({ (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
-      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
-        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
+    ({ (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
+        ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
     (hom A a y)
   :=
-    ( \ v → (\ r → v ((1_2 , r))) ,
+    ( \ v → (\ r → v ((1₂ , r))) ,
       ( ( \ v → \ (t , s) → v s ,
           \ v → refl) ,
         ( \ v → \ (t , s) → v s ,
@@ -482,19 +482,19 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ( { (t , s) : ∂□ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t])
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t])
     (hom A a y)
   :=
     comp-equiv
     ( { (t , s) : ∂□ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ] )
-    ( { (t , s) : 2 * 2 | ((t ≡ 1_2) ∧ (Δ¹ s))} → A
-      [ ((t ≡ 1_2) ∧ (s ≡ 0_2)) ↦ a ,
-        ((t ≡ 1_2) ∧ (s ≡ 1_2)) ↦ y ])
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ] )
+    ( { (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+      [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
+        ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
     ( hom A a y)
     ( cofibration-union-test A a x y f u)
     ( base-hom-rewriting A a x y f u)
@@ -506,35 +506,35 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     (Σ (sq : { (t , s) : ∂□ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ (sq (1₂ , s)) ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     (Σ (v : hom A a y) ,
       ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
   :=
     total-equiv-pullback-is-equiv
     (  { (t , s) : ∂□ } → A
-      [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ] )
+      [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ] )
             (hom A a y)
             (first (base-hom-expansion A a x y f u))
             (second (base-hom-expansion A a x y f u))
     ( \ v →
       ( { (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
 
 #def representable-dhom-from-composite-expansion
   (A : U)            -- The ambient type.
@@ -543,31 +543,31 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv (dhom-from-representable A a x y f u)
       (Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ (sq (1₂ , s)) ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]) ,
         ( { (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ (sq (1₂ , s)) ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     ( Σ (v : hom A a y) , ({ (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     ( uncurried-dhom-from-representable A a x y f u)
     ( representable-dhom-from-expansion A a x y f u)
 
@@ -578,27 +578,27 @@ types as follows.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
     ({ (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t] )
     (Σ (sq : { (t , s) : ∂□ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ (sq (1₂ , s)) ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
   :=
     cofibration-composition (2 * 2) Δ¹×Δ¹ ∂□
     ( \ (t , s) →
-      ((t ≡ 0_2) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0_2)) ∨ (Δ¹ t ∧ (s ≡ 1_2)))
+      ((t ≡ 0₂) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0₂)) ∨ (Δ¹ t ∧ (s ≡ 1₂)))
     ( \ ts → A)
     ( \ (t , s) →
-      recOR ( ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t))
+      recOR ( ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t))
 
 #def representable-dhom-from-as-extension-type
   (A : U)            -- The ambient type.
@@ -608,25 +608,25 @@ types as follows.
   : Equiv
       (dhom-from-representable A a x y f u)
       ({ (t , s) : Δ¹×Δ¹ } → A
-              [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-                (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
+              [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+                (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t] )
   :=
     right-cancel-equiv
     ( dhom-from-representable A a x y f u)
     ( { (t , s) : Δ¹×Δ¹ } → A
-        [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-          (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-          (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t] )
+        [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+          (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+          (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t] )
     ( Σ (sq : { (t , s) : ∂□ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]) ,
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ (sq (1_2 , s)) ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ a ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ f t ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ (sq (1₂ , s)) ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
     ( representable-dhom-from-composite-expansion A a x y f u)
     ( representable-dhom-from-cofibration-composition A a x y f u)
 ```
@@ -782,7 +782,7 @@ the 1-simplex.
   (C : A → U)
   : U
   := (x : A) → (y : A) → (f : hom A x y) → (v : C y)
-    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
+    → is-contr ((t : Δ¹) → C (f t) [ t ≡ 1₂ ↦ v ])
 ```
 
 These two notions of covariance are equivalent because the two types of lifts of
@@ -798,10 +798,10 @@ here.
   (f : hom A x y)
   (v : C y)
   : Equiv
-      ((t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
+      ((t : Δ¹) → C (f t) [ t ≡ 1₂ ↦ v ])
       (dhom-to A x y f C v)
   :=
-    ( \ h → (h 0_2 , \ t → h t) ,
+    ( \ h → (h 0₂ , \ t → h t) ,
       ( ( \ fg t → (second fg) t , \ h → refl) ,
         ( ( \ fg t → (second fg) t , \ h → refl))))
 ```
@@ -819,13 +819,13 @@ logical equivalence
   :=
     ( \ C-has-unique-lifts x y f v →
       is-contr-is-equiv-from-contr
-        ( (t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 1₂ ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( C-has-unique-lifts x y f v),
       \ is-contravariant-C x y f v →
       is-contr-is-equiv-to-contr
-        ( (t : Δ¹) → C (f t) [ t ≡ 1_2 ↦ v ])
+        ( (t : Δ¹) → C (f t) [ t ≡ 1₂ ↦ v ])
         ( dhom-to A x y f C v)
         ( equiv-lifts-with-fixed-codomain A C x y f v)
         ( is-contravariant-C x y f v))
@@ -856,15 +856,15 @@ a rather lengthy composition of equivalences.
   (u : hom A x a)        -- A lift of the domain.
   (v : hom A y a)        -- A lift of the codomain.
   : Equiv (dhom-contra-representable A a x y f u v)
-  ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ])
+  ({ (t , s) : Δ¹×Δ¹ } → A [((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ])
   := curry-uncurry 2 2 Δ¹ ∂Δ¹ Δ¹ ∂Δ¹ (\ t s → A)
-    (\ (t , s) → recOR (((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ))
+    (\ (t , s) → recOR (((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ))
 
 #def dhom-to-representable
   (A : U)            -- The ambient type.
@@ -883,20 +883,20 @@ a rather lengthy composition of equivalences.
   : Equiv (dhom-to-representable A a x y f v)
     (Σ (u : hom A x a) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
+                    [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ]))
   :=
     total-equiv-family-equiv
     ( hom A x a)
     ( \ u → dhom-contra-representable A a x y f u v)
     ( \ u →
       ({ (t , s) : Δ¹×Δ¹ } → A
-          [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-            ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-            (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-            (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
+          [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+            ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+            (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+            (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ]))
     ( \ u → uncurried-dhom-contra-representable A a x y f u v)
 
 #def representable-dhom-to-uncurry-hom2
@@ -906,10 +906,10 @@ a rather lengthy composition of equivalences.
   (v : hom A y a)    -- A lift of the codomain.
   : Equiv
     (Σ (u : hom A x a) , ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
+                    [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ]))
     (Σ (u : hom A x a) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
@@ -917,10 +917,10 @@ a rather lengthy composition of equivalences.
     total-equiv-family-equiv (hom A x a)
     ( \ u →
       ({ (t , s) : Δ¹×Δ¹ } → A
-                    [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-                      ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-                      (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-                      (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
+                    [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+                      ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+                      (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+                      (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ]))
     ( \ u →
       (Σ (d : hom A x a) ,
           product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
@@ -941,10 +941,10 @@ a rather lengthy composition of equivalences.
     ( dhom-to-representable A a x y f v)
     ( Σ (u : hom A x a) ,
         ({ (t , s) : Δ¹×Δ¹ } → A
-            [ ((t ≡ 0_2) ∧ Δ¹ s) ↦ u s ,
-              ((t ≡ 1_2) ∧ Δ¹ s) ↦ v s ,
-              (Δ¹ t ∧ (s ≡ 0_2)) ↦ f t ,
-              (Δ¹ t ∧ (s ≡ 1_2)) ↦ a ]))
+            [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
+              ((t ≡ 1₂) ∧ Δ¹ s) ↦ v s ,
+              (Δ¹ t ∧ (s ≡ 0₂)) ↦ f t ,
+              (Δ¹ t ∧ (s ≡ 1₂)) ↦ a ]))
     ( Σ (u : hom A x a ) ,
       (Σ (d : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -443,11 +443,11 @@ types as follows.
       [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
             (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
             (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ])
-    ( { (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+    ( { (t , s) : 2 × 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
       [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
         ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
   :=
-    cofibration-union (2 * 2)
+    cofibration-union (2 × 2)
     ( \ (t , s) → (t ≡ 1₂) ∧ Δ¹ s)
     ( \ (t , s) →
       ((t ≡ 0₂) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0₂)) ∨ (Δ¹ t ∧ (s ≡ 1₂)))
@@ -464,7 +464,7 @@ types as follows.
   (f : hom A x y)        -- An arrow in the base.
   (u : hom A a x)        -- A lift of the domain.
   : Equiv
-    ({ (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+    ({ (t , s) : 2 × 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
       [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
         ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
     (hom A a y)
@@ -492,7 +492,7 @@ types as follows.
         [ ((t ≡ 0₂) ∧ Δ¹ s) ↦ u s ,
           (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
           (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ] )
-    ( { (t , s) : 2 * 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
+    ( { (t , s) : 2 × 2 | ((t ≡ 1₂) ∧ (Δ¹ s))} → A
       [ ((t ≡ 1₂) ∧ (s ≡ 0₂)) ↦ a ,
         ((t ≡ 1₂) ∧ (s ≡ 1₂)) ↦ y ])
     ( hom A a y)
@@ -591,7 +591,7 @@ types as follows.
             (Δ¹ t ∧ (s ≡ 0₂)) ↦ a ,
             (Δ¹ t ∧ (s ≡ 1₂)) ↦ f t ]))
   :=
-    cofibration-composition (2 * 2) Δ¹×Δ¹ ∂□
+    cofibration-composition (2 × 2) Δ¹×Δ¹ ∂□
     ( \ (t , s) →
       ((t ≡ 0₂) ∧ Δ¹ s) ∨ (Δ¹ t ∧ (s ≡ 0₂)) ∨ (Δ¹ t ∧ (s ≡ 1₂)))
     ( \ ts → A)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -483,7 +483,7 @@ given by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A a x)
   : Equiv
     ( hom (coslice A a) (a, id-arr A a) (x, f))
-    ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
+    ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
   :=
     ( \ h t s → (second (h s)) t,
       (( \ k s → ( k 1_2 s, \ t → k t s),
@@ -501,7 +501,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A a x)
-  : is-contr ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
                 A (\ z → hom A a z)))
@@ -524,7 +524,7 @@ This proves the initiality of identity arrows in the coslice of a Segal type.
     \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (coslice A a) (a, id-arr A a) (x, f))
-      ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
+      ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
       ( equiv-hom-in-coslice A a x f)
       ( is-contr-is-segal-hom-in-coslice A is-segal-A a x f)
 ```
@@ -712,7 +712,7 @@ by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A x a)
   : Equiv
     ( hom (slice A a) (x, f) (a, id-arr A a))
-    ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
+    ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
   :=
     ( \ h t s → (second (h s)) t,
       (( \ k s → ( k 0_2 s, \ t → k t s),
@@ -730,7 +730,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A x a)
-  : is-contr ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
                 A (\ z → hom A z a)))
@@ -753,7 +753,7 @@ This proves the finality of identity arrows in the slice of a Segal type.
     \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (slice A a) (x, f) (a, id-arr A a))
-      ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
+      ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
       ( equiv-hom-in-slice A a x f)
       ( is-contr-is-segal-hom-in-slice A is-segal-A a x f)
 ```

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -45,14 +45,14 @@ naturality-covariant-fiberwise-transformation naturality is automatic.
   (a x y : A)
   (f : hom A a x)
   (g : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
-  (ϕ : (z : A) -> hom A a z -> C z)
+  (ϕ : (z : A) → hom A a z → C z)
   : (covariant-transport A x y g C is-covariant-C (ϕ x f)) =
     (ϕ y (Segal-comp A is-segal-A a x y f g))
   :=
     naturality-covariant-fiberwise-transformation A x y g
-      (\ z -> hom A a z)
+      (\ z → hom A a z)
       ( C)
       ( is-segal-representable-is-covariant A is-segal-A a)
       ( is-covariant-C)
@@ -76,19 +76,19 @@ map makes use of the covariant transport operation.
 #def evid
   (A : U)
   (a : A)
-  (C : A -> U)
-  : ((z : A) -> hom A a z -> C z) -> C a
-  := \ ϕ -> ϕ a (id-arr A a)
+  (C : A → U)
+  : ((z : A) → hom A a z → C z) → C a
+  := \ ϕ → ϕ a (id-arr A a)
 
 -- The inverse map only exists for Segal types.
 #def yon
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
-  : C a -> ((z : A) -> hom A a z -> C z)
-  := \ u z f -> covariant-transport A a z f C is-covariant-C u
+  : C a → ((z : A) → hom A a z → C z)
+  := \ u z f → covariant-transport A a z f C is-covariant-C u
 ```
 
 ## The Yoneda composites
@@ -101,7 +101,7 @@ straightforward:
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C a)
   : (evid A a C) ((yon A is-segal-A a C is-covariant-C) u) = u
@@ -118,12 +118,12 @@ in two steps.
 #variable A : U
 #variable is-segal-A : is-segal A
 #variable a : A
-#variable C : A -> U
+#variable C : A → U
 #variable is-covariant-C : is-covariant A C
 
 -- The composite yon-evid of ϕ equals ϕ at all x : A and f : hom A a x.
 #def yon-evid-twice-pointwise
-  (ϕ : (z : A) -> hom A a z -> C z)
+  (ϕ : (z : A) → hom A a z → C z)
   (x : A)
   (f : hom A a x)
   : ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f = ϕ x f
@@ -145,27 +145,27 @@ in two steps.
 
 -- By funext, these are equals as functions of f pointwise in x.
 #def yon-evid-once-pointwise uses (funext)
-  (ϕ : (z : A) -> hom A a z -> C z)
+  (ϕ : (z : A) → hom A a z → C z)
   (x : A)
   : ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x = ϕ x
   :=
     eq-htpy funext
       ( hom A a x)
-      ( \ f -> C x)
-      ( \ f -> ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f)
-      ( \ f -> (ϕ x f))
-      ( \ f -> yon-evid-twice-pointwise ϕ x f)
+      ( \ f → C x)
+      ( \ f → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f)
+      ( \ f → (ϕ x f))
+      ( \ f → yon-evid-twice-pointwise ϕ x f)
 
 -- By funext again, these are equal as functions of x and f.
 #def yon-evid uses (funext)
-  (ϕ : (z : A) -> hom A a z -> C z)
+  (ϕ : (z : A) → hom A a z → C z)
   : ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) = ϕ
   := eq-htpy funext
       ( A)
-      ( \ x -> (hom A a x -> C x))
-      ( \ x -> ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x)
-      ( \ x -> (ϕ x))
-      ( \ x -> yon-evid-once-pointwise ϕ x)
+      ( \ x → (hom A a x → C x))
+      ( \ x → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x)
+      ( \ x → (ϕ x))
+      ( \ x → yon-evid-once-pointwise ϕ x)
 
 #end yon-evid
 ```
@@ -179,9 +179,9 @@ The Yoneda lemma says that evaluation at the identity defines an equivalence.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
-  : is-equiv ((z : A) -> hom A a z -> C z) (C a) (evid A a C)
+  : is-equiv ((z : A) → hom A a z → C z) (C a) (evid A a C)
   :=
     ( ( ( yon A is-segal-A a C is-covariant-C),
         ( yon-evid A is-segal-A a C is-covariant-C)),
@@ -205,14 +205,14 @@ automatic.
   (a x y : A)
   (f : hom A y a)
   (g : hom A x y)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
-  (ϕ : (z : A) -> hom A z a -> C z)
+  (ϕ : (z : A) → hom A z a → C z)
   : (contravariant-transport A x y g C is-contravariant-C (ϕ y f)) =
     (ϕ x (Segal-comp A is-segal-A x y a g f))
   :=
     naturality-contravariant-fiberwise-transformation A x y g
-      ( \ z -> hom A z a) C
+      ( \ z → hom A z a) C
       ( is-segal-representable-is-contravariant A is-segal-A a)
       ( is-contravariant-C)
       ( ϕ)
@@ -233,19 +233,19 @@ map makes use of the contravariant transport operation.
 #def contra-evid
   (A : U)
   (a : A)
-  (C : A -> U)
-  : ( (z : A) -> hom A z a -> C z) -> C a
-  := \ ϕ -> ϕ a (id-arr A a)
+  (C : A → U)
+  : ( (z : A) → hom A z a → C z) → C a
+  := \ ϕ → ϕ a (id-arr A a)
 
 -- The inverse map only exists for Segal types and contravariant families.
 #def contra-yon
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
-  : C a -> ((z : A) -> hom A z a -> C z)
-  := \ v z f -> contravariant-transport A z a f C is-contravariant-C v
+  : C a → ((z : A) → hom A z a → C z)
+  := \ v z f → contravariant-transport A z a f C is-contravariant-C v
 ```
 
 It remains to show that the Yoneda maps are inverses. One retraction is
@@ -256,7 +256,7 @@ straightforward:
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (v : C a)
   : contra-evid A a C ((contra-yon A is-segal-A a C is-contravariant-C) v) = v
@@ -273,12 +273,12 @@ in two steps.
 #variable A : U
 #variable is-segal-A : is-segal A
 #variable a : A
-#variable C : A -> U
+#variable C : A → U
 #variable is-contravariant-C : is-contravariant A C
 
 -- The composite yon-evid of ϕ equals ϕ at all x : A and f : hom A x a.
 #def contra-yon-evid-twice-pointwise
-  (ϕ : (z : A) -> hom A z a -> C z)
+  (ϕ : (z : A) → hom A z a → C z)
   (x : A)
   (f : hom A x a)
   : ((contra-yon A is-segal-A a C is-contravariant-C)
@@ -302,33 +302,33 @@ in two steps.
 
 -- By funext, these are equals as functions of f pointwise in x.
 #def contra-yon-evid-once-pointwise uses (funext)
-  (ϕ : (z : A) -> hom A z a -> C z)
+  (ϕ : (z : A) → hom A z a → C z)
   (x : A)
   : ((contra-yon A is-segal-A a C is-contravariant-C)
         ((contra-evid A a C) ϕ )) x = ϕ x
   :=
     eq-htpy funext
       ( hom A x a)
-      ( \ f -> C x)
-      ( \ f ->
+      ( \ f → C x)
+      ( \ f →
         ( (contra-yon A is-segal-A a C is-contravariant-C)
           ( (contra-evid A a C) ϕ )) x f)
-      ( \ f -> (ϕ x f))
-      ( \ f -> contra-yon-evid-twice-pointwise ϕ x f)
+      ( \ f → (ϕ x f))
+      ( \ f → contra-yon-evid-twice-pointwise ϕ x f)
 
 -- By funext again, these are equal as functions of x and f.
 #def contra-yon-evid uses (funext)
-  (ϕ : (z : A) -> hom A z a -> C z)
+  (ϕ : (z : A) → hom A z a → C z)
   : (contra-yon A is-segal-A a C is-contravariant-C)((contra-evid A a C) ϕ) = ϕ
   :=
     eq-htpy funext
       ( A)
-      ( \ x -> (hom A x a -> C x))
-      ( \ x ->
+      ( \ x → (hom A x a → C x))
+      ( \ x →
         ( (contra-yon A is-segal-A a C is-contravariant-C)
               ((contra-evid A a C) ϕ )) x)
-      ( \ x -> (ϕ x))
-      ( \ x -> contra-yon-evid-once-pointwise ϕ x)
+      ( \ x → (ϕ x))
+      ( \ x → contra-yon-evid-once-pointwise ϕ x)
 
 #end contra-yon-evid
 ```
@@ -341,9 +341,9 @@ equivalence.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
-  : is-equiv ((z : A) -> hom A z a -> C z) (C a) (contra-evid A a C)
+  : is-equiv ((z : A) → hom A z a → C z) (C a) (contra-evid A a C)
   :=
     ( ( ( contra-yon A is-segal-A a C is-contravariant-C),
         ( contra-yon-evid A is-segal-A a C is-contravariant-C)),
@@ -367,7 +367,7 @@ contractible.
   (A : U)
   (a : A)
   : U
-  := (x : A) -> is-contr (hom A a x)
+  := (x : A) → is-contr (hom A a x)
 ```
 
 Initial objects satisfy an induction principle relative to covariant families.
@@ -378,7 +378,7 @@ Initial objects satisfy an induction principle relative to covariant families.
 #variable A : U
 #variable a : A
 #variable is-initial-a : is-initial A a
-#variable C : A -> U
+#variable C : A → U
 #variable is-covariant-C : is-covariant A C
 
 #def arrows-from-initial
@@ -392,15 +392,15 @@ Initial objects satisfy an induction principle relative to covariant families.
 
 #def ind-initial uses (is-initial-a)
   (u : C a)
-  : (x : A) -> C x
+  : (x : A) → C x
   :=
-    \ x -> covariant-transport A a x (arrows-from-initial x) C is-covariant-C u
+    \ x → covariant-transport A a x (arrows-from-initial x) C is-covariant-C u
 
 #def has-cov-section-ev-pt uses (is-initial-a)
-  : has-section ((x : A) -> C x) (C a) (ev-pt A a C)
+  : has-section ((x : A) → C x) (C a) (ev-pt A a C)
   :=
     ( ( ind-initial),
-      ( \ u ->
+      ( \ u →
         concat
           ( C a)
           ( covariant-transport A a a
@@ -413,13 +413,13 @@ Initial objects satisfy an induction principle relative to covariant families.
             ( C a)
             ( arrows-from-initial a)
             ( id-arr A a)
-            ( \ f ->
+            ( \ f →
               covariant-transport A a a f C is-covariant-C u)
             ( identity-component-arrows-from-initial))
           ( id-arr-covariant-transport A a C is-covariant-C u)))
 
 #def ind-initial-ev-pt-pointwise uses (is-initial-a)
-  (s : (x : A) -> C x)
+  (s : (x : A) → C x)
   (b : A)
   : ind-initial (ev-pt A a C s) b = s b
   :=
@@ -431,7 +431,7 @@ Initial objects satisfy an induction principle relative to covariant families.
       ( C)
       ( is-covariant-C)
       ( ev-pt A a C s)
-      ( ( s b, \ t -> s (arrows-from-initial b t)))
+      ( ( s b, \ t → s (arrows-from-initial b t)))
 
 #end initial-evaluation-equivalence
 ```
@@ -444,12 +444,12 @@ family defines an inverse equivalence to evaluation at the element.
   (A : U)
   (a : A)
   (is-initial-a : is-initial A a)
-  (C : A -> U)
+  (C : A → U)
   (is-covariant-C : is-covariant A C)
-  : is-equiv ((x : A) -> C x) (C a) (ev-pt A a C)
+  : is-equiv ((x : A) → C x) (C a) (ev-pt A a C)
   :=
     ( ( ( ind-initial A a is-initial-a C is-covariant-C ),
-        ( \ s -> eq-htpy
+        ( \ s → eq-htpy
                   funext
                     ( A)
                     ( C)
@@ -483,13 +483,13 @@ given by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A a x)
   : Equiv
     ( hom (coslice A a) (a, id-arr A a) (x, f))
-    ( (t : Δ¹) -> hom A a (f t) [t === 0_2 |-> id-arr A a])
+    ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
   :=
-    ( \ h t s -> (second (h s)) t,
-      (( \ k s -> ( k 1_2 s, \ t -> k t s),
-        \ h -> refl),
-      ( \ k s -> ( k 1_2 s, \ t -> k t s),
-        \ k -> refl)))
+    ( \ h t s → (second (h s)) t,
+      (( \ k s → ( k 1_2 s, \ t → k t s),
+        \ h → refl),
+      ( \ k s → ( k 1_2 s, \ t → k t s),
+        \ k → refl)))
 ```
 
 Since $hom A a$ is covariant when $A$ is Segal, this latter type is
@@ -501,10 +501,10 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A a x)
-  : is-contr ( (t : Δ¹) -> hom A a (f t) [t === 0_2 |-> id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
-                A (\ z -> hom A a z)))
+                A (\ z → hom A a z)))
       ( is-segal-representable-is-covariant A is-segal-A a)
       ( a)
       ( x)
@@ -521,10 +521,10 @@ This proves the initiality of identity arrows in the coslice of a Segal type.
   (a : A)
   : is-initial (coslice A a) (a, id-arr A a)
   :=
-    \ (x, f) ->
+    \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (coslice A a) (a, id-arr A a) (x, f))
-      ( (t : Δ¹) -> hom A a (f t) [t === 0_2 |-> id-arr A a])
+      ( (t : Δ¹) → hom A a (f t) [t === 0_2 ↦ id-arr A a])
       ( equiv-hom-in-coslice A a x f)
       ( is-contr-is-segal-hom-in-coslice A is-segal-A a x f)
 ```
@@ -537,18 +537,18 @@ The dependent Yoneda lemma now follows by specializing these results.
 #def dependent-ev-id
   (A : U)
   (a : A)
-  (C : (coslice A a) -> U)
-  : ((p : coslice A a) -> C p) -> C (a, id-arr A a)
-  := \ s -> s (a, id-arr A a)
+  (C : (coslice A a) → U)
+  : ((p : coslice A a) → C p) → C (a, id-arr A a)
+  := \ s → s (a, id-arr A a)
 
 #def dependent-yoneda-lemma' uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : (coslice A a) -> U)
+  (C : (coslice A a) → U)
   (is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
-      ( (p : coslice A a) -> C p)
+      ( (p : coslice A a) → C p)
       ( C (a, id-arr A a))
       ( dependent-ev-id A a C)
   :=
@@ -568,20 +568,20 @@ an equivalent type in the domain of the evaluation map.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : (coslice A a) -> U)
+  (C : (coslice A a) → U)
   (is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
-      ( (x : A) -> (f : hom A a x) -> C (x, f))
+      ( (x : A) → (f : hom A a x) → C (x, f))
       ( C (a, id-arr A a))
-      ( \ s -> s a (id-arr A a))
+      ( \ s → s a (id-arr A a))
   :=
     LeftCancel-is-equiv
-      ( (p : coslice A a) -> C p)
-      ( (x : A) -> (f : hom A a x) -> C (x, f))
+      ( (p : coslice A a) → C p)
+      ( (x : A) → (f : hom A a x) → C (x, f))
       ( C (a, id-arr A a))
-      ( first (equiv-dependent-curry A (\ z -> hom A a z)(\ x f -> C (x, f))))
-      ( second (equiv-dependent-curry A (\ z -> hom A a z)(\ x f -> C (x, f))))
-      ( \ s -> s a (id-arr A a))
+      ( first (equiv-dependent-curry A (\ z → hom A a z)(\ x f → C (x, f))))
+      ( second (equiv-dependent-curry A (\ z → hom A a z)(\ x f → C (x, f))))
+      ( \ s → s a (id-arr A a))
       ( dependent-yoneda-lemma' A is-segal-A a C is-covariant-C)
 ```
 
@@ -595,7 +595,7 @@ contractible.
   (A : U)
   (a : A)
   : U
-  := (x : A) -> is-contr (hom A x a)
+  := (x : A) → is-contr (hom A x a)
 ```
 
 Final objects satisfy an induction principle relative to contravariant families.
@@ -606,7 +606,7 @@ Final objects satisfy an induction principle relative to contravariant families.
 #variable A : U
 #variable a : A
 #variable is-final-a : is-final A a
-#variable C : A -> U
+#variable C : A → U
 #variable is-contravariant-C : is-contravariant A C
 
 #def arrows-to-final
@@ -620,16 +620,16 @@ Final objects satisfy an induction principle relative to contravariant families.
 
 #def ind-final uses (is-final-a)
   (u : C a)
-  : (x : A) -> C x
+  : (x : A) → C x
   :=
-    \ x ->
+    \ x →
     contravariant-transport A x a (arrows-to-final x) C is-contravariant-C u
 
 #def has-contra-section-ev-pt uses (is-final-a)
-  : has-section ((x : A) -> C x) (C a) (ev-pt A a C)
+  : has-section ((x : A) → C x) (C a) (ev-pt A a C)
   :=
     ( ( ind-final),
-      ( \ u ->
+      ( \ u →
         concat
           ( C a)
           ( contravariant-transport A a a
@@ -642,13 +642,13 @@ Final objects satisfy an induction principle relative to contravariant families.
             ( C a)
             ( arrows-to-final a)
             ( id-arr A a)
-            ( \ f ->
+            ( \ f →
               contravariant-transport A a a f C is-contravariant-C u)
             ( identity-component-arrows-to-final))
           ( id-arr-contravariant-transport A a C is-contravariant-C u)))
 
 #def ind-final-ev-pt-pointwise uses (is-final-a)
-  (s : (x : A) -> C x)
+  (s : (x : A) → C x)
   (b : A)
   : ind-final (ev-pt A a C s) b = s b
   :=
@@ -660,7 +660,7 @@ Final objects satisfy an induction principle relative to contravariant families.
       ( C)
       ( is-contravariant-C)
       ( ev-pt A a C s)
-      ( ( s b, \ t -> s (arrows-to-final b t)))
+      ( ( s b, \ t → s (arrows-to-final b t)))
 
 #end final-evaluation-equivalence
 ```
@@ -673,12 +673,12 @@ family defines an inverse equivalence to evaluation at the element.
   (A : U)
   (a : A)
   (is-final-a : is-final A a)
-  (C : A -> U)
+  (C : A → U)
   (is-contravariant-C : is-contravariant A C)
-  : is-equiv ((x : A) -> C x) (C a) (ev-pt A a C)
+  : is-equiv ((x : A) → C x) (C a) (ev-pt A a C)
   :=
     ( ( ( ind-final A a is-final-a C is-contravariant-C ),
-        ( \ s -> eq-htpy
+        ( \ s → eq-htpy
                   funext
                     ( A)
                     ( C)
@@ -712,13 +712,13 @@ by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A x a)
   : Equiv
     ( hom (slice A a) (x, f) (a, id-arr A a))
-    ( (t : Δ¹) -> hom A (f t) a [t === 1_2 |-> id-arr A a])
+    ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
   :=
-    ( \ h t s -> (second (h s)) t,
-      (( \ k s -> ( k 0_2 s, \ t -> k t s),
-        \ h -> refl),
-      ( \ k s -> ( k 0_2 s, \ t -> k t s),
-        \ k -> refl)))
+    ( \ h t s → (second (h s)) t,
+      (( \ k s → ( k 0_2 s, \ t → k t s),
+        \ h → refl),
+      ( \ k s → ( k 0_2 s, \ t → k t s),
+        \ k → refl)))
 ```
 
 Since $\ z → hom A z a$ is contravariant when $A$ is Segal, this latter type is
@@ -730,10 +730,10 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A x a)
-  : is-contr ( (t : Δ¹) -> hom A (f t) a [t === 1_2 |-> id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
-                A (\ z -> hom A z a)))
+                A (\ z → hom A z a)))
       ( is-segal-representable-is-contravariant A is-segal-A a)
       ( x)
       ( a)
@@ -750,10 +750,10 @@ This proves the finality of identity arrows in the slice of a Segal type.
   (a : A)
   : is-final (slice A a) (a, id-arr A a)
   :=
-    \ (x, f) ->
+    \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (slice A a) (x, f) (a, id-arr A a))
-      ( (t : Δ¹) -> hom A (f t) a [t === 1_2 |-> id-arr A a])
+      ( (t : Δ¹) → hom A (f t) a [t === 1_2 ↦ id-arr A a])
       ( equiv-hom-in-slice A a x f)
       ( is-contr-is-segal-hom-in-slice A is-segal-A a x f)
 ```
@@ -767,18 +767,18 @@ specializing these results.
 #def contra-dependent-ev-id
   (A : U)
   (a : A)
-  (C : (slice A a) -> U)
-  : ((p : slice A a) -> C p) -> C (a, id-arr A a)
-  := \ s -> s (a, id-arr A a)
+  (C : (slice A a) → U)
+  : ((p : slice A a) → C p) → C (a, id-arr A a)
+  := \ s → s (a, id-arr A a)
 
 #def contra-dependent-yoneda-lemma' uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : (slice A a) -> U)
+  (C : (slice A a) → U)
   (is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
-      ( (p : slice A a) -> C p)
+      ( (p : slice A a) → C p)
       ( C (a, id-arr A a))
       ( contra-dependent-ev-id A a C)
   :=
@@ -798,20 +798,20 @@ proven, just with an equivalent type in the domain of the evaluation map.
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  (C : (slice A a) -> U)
+  (C : (slice A a) → U)
   (is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
-      ( (x : A) -> (f : hom A x a) -> C (x, f))
+      ( (x : A) → (f : hom A x a) → C (x, f))
       ( C (a, id-arr A a))
-      ( \ s -> s a (id-arr A a))
+      ( \ s → s a (id-arr A a))
   :=
     LeftCancel-is-equiv
-      ( (p : slice A a) -> C p)
-      ( (x : A) -> (f : hom A x a) -> C (x, f))
+      ( (p : slice A a) → C p)
+      ( (x : A) → (f : hom A x a) → C (x, f))
       ( C (a, id-arr A a))
-      ( first (equiv-dependent-curry A (\ z -> hom A z a)(\ x f -> C (x, f))))
-      ( second (equiv-dependent-curry A (\ z -> hom A z a)(\ x f -> C (x, f))))
-      ( \ s -> s a (id-arr A a))
+      ( first (equiv-dependent-curry A (\ z → hom A z a)(\ x f → C (x, f))))
+      ( second (equiv-dependent-curry A (\ z → hom A z a)(\ x f → C (x, f))))
+      ( \ s → s a (id-arr A a))
       ( contra-dependent-yoneda-lemma'
           A is-segal-A a C is-contravariant-C)
 ```

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -483,12 +483,12 @@ given by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A a x)
   : Equiv
     ( hom (coslice A a) (a, id-arr A a) (x, f))
-    ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
+    ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
   :=
     ( \ h t s → (second (h s)) t,
-      (( \ k s → ( k 1_2 s, \ t → k t s),
+      (( \ k s → ( k 1₂ s, \ t → k t s),
         \ h → refl),
-      ( \ k s → ( k 1_2 s, \ t → k t s),
+      ( \ k s → ( k 1₂ s, \ t → k t s),
         \ k → refl)))
 ```
 
@@ -501,7 +501,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A a x)
-  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
                 A (\ z → hom A a z)))
@@ -524,7 +524,7 @@ This proves the initiality of identity arrows in the coslice of a Segal type.
     \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (coslice A a) (a, id-arr A a) (x, f))
-      ( (t : Δ¹) → hom A a (f t) [t ≡ 0_2 ↦ id-arr A a])
+      ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
       ( equiv-hom-in-coslice A a x f)
       ( is-contr-is-segal-hom-in-coslice A is-segal-A a x f)
 ```
@@ -712,12 +712,12 @@ by the identity arrow at $a$. This makes use of the following equivalence.
   (f : hom A x a)
   : Equiv
     ( hom (slice A a) (x, f) (a, id-arr A a))
-    ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
+    ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
   :=
     ( \ h t s → (second (h s)) t,
-      (( \ k s → ( k 0_2 s, \ t → k t s),
+      (( \ k s → ( k 0₂ s, \ t → k t s),
         \ h → refl),
-      ( \ k s → ( k 0_2 s, \ t → k t s),
+      ( \ k s → ( k 0₂ s, \ t → k t s),
         \ k → refl)))
 ```
 
@@ -730,7 +730,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A x a)
-  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
   :=
     ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
                 A (\ z → hom A z a)))
@@ -753,7 +753,7 @@ This proves the finality of identity arrows in the slice of a Segal type.
     \ (x, f) →
     is-contr-is-equiv-to-contr
       ( hom (slice A a) (x, f) (a, id-arr A a))
-      ( (t : Δ¹) → hom A (f t) a [t ≡ 1_2 ↦ id-arr A a])
+      ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
       ( equiv-hom-in-slice A a x f)
       ( is-contr-is-segal-hom-in-slice A is-segal-A a x f)
 ```

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -77,17 +77,17 @@ Some of the definitions in this file rely on extension extensionality:
     (is-segal-A : is-segal A)
     (x y : A)
     (f : hom A x y)
-    : (arrow-has-inverse A is-segal-A x y f) -> (arrow-is-iso A is-segal-A x y f)
-    := (\ (g , (p , q)) -> ((g , p) , (g , q)))
+    : (arrow-has-inverse A is-segal-A x y f) → (arrow-is-iso A is-segal-A x y f)
+    := (\ (g , (p , q)) → ((g , p) , (g , q)))
 
 #def arrow-iso-to-inverse uses (extext)
     (A : U)
     (is-segal-A : is-segal A)
     (x y : A)
     (f : hom A x y)
-    : (arrow-is-iso A is-segal-A x y f) -> (arrow-has-inverse A is-segal-A x y f)
+    : (arrow-is-iso A is-segal-A x y f) → (arrow-has-inverse A is-segal-A x y f)
     := (\ ((g , p) , (h , q))
-        -> (g , (p ,
+        → (g , (p ,
             (concat
             (hom A y y)
             (Segal-comp A is-segal-A y x y g f)
@@ -139,13 +139,13 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (g : hom A y x)
   (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) -> has-retraction (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → has-retraction (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (Segal-postcomp A is-segal-A y x g z) ,
-        \ k ->
+        \ k →
       (triple-concat
-        (hom A z x) -- k is an arrow z -> x
+        (hom A z x) -- k is an arrow z → x
         (Segal-comp A is-segal-A z y x (Segal-comp A is-segal-A z x y k f) g) -- g(fk)
         (Segal-comp A is-segal-A z x x k (Segal-comp A is-segal-A x y x f g)) -- (gf)k
         (Segal-comp A is-segal-A z x x k (id-arr A x)) -- id_x k
@@ -163,11 +163,11 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) -> has-section (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → has-section (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (Segal-postcomp A is-segal-A y x h z) ,
-        \ k ->
+        \ k →
       (triple-concat
         (hom A z y) -- k is an arrow z to y
         (Segal-comp A is-segal-A z x y (Segal-comp A is-segal-A z y x k h) f) -- f(hk)
@@ -189,9 +189,9 @@ Some of the definitions in this file rely on extension extensionality:
   (gg : arrow-has-retraction A is-segal-A x y f g)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) -> is-equiv (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → is-equiv (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (if-iso-then-postcomp-has-retraction A is-segal-A x y f g gg z) ,
       (if-iso-then-postcomp-has-section A is-segal-A x y f h hh z))
 
@@ -202,13 +202,13 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) -> has-retraction (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → has-retraction (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (Segal-precomp A is-segal-A y x h z) ,
-        \ k ->
+        \ k →
       (triple-concat
-        (hom A y z) -- k is an arrow y -> z
+        (hom A y z) -- k is an arrow y → z
         (Segal-comp A is-segal-A y x z h (Segal-comp A is-segal-A x y z f k)) -- (kf)h
         (Segal-comp A is-segal-A y y z (Segal-comp A is-segal-A y x y h f) k) -- k(fh)
         (Segal-comp A is-segal-A y y z (id-arr A y) k) -- k id_y
@@ -231,13 +231,13 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (g : hom A y x)
   (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) -> has-section (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → has-section (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (Segal-precomp A is-segal-A y x g z) ,
-        \ k ->
+        \ k →
       (triple-concat
-        (hom A x z) -- k is an arrow x -> z
+        (hom A x z) -- k is an arrow x → z
         (Segal-comp A is-segal-A x y z f (Segal-comp A is-segal-A y x z g k)) -- (kg)f
         (Segal-comp A is-segal-A x x z (Segal-comp A is-segal-A x y x f g) k) -- k(gf)
         (Segal-comp A is-segal-A x x z (id-arr A x) k) -- k id_x
@@ -261,9 +261,9 @@ Some of the definitions in this file rely on extension extensionality:
   (gg : arrow-has-retraction A is-segal-A x y f g)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) -> is-equiv (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → is-equiv (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
   :=
-    \ z ->
+    \ z →
     ( (if-iso-then-precomp-has-retraction A is-segal-A x y f h hh z) ,
     (if-iso-then-precomp-has-section A is-segal-A x y f g gg z))
 
@@ -317,16 +317,16 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
    : (is-prop (arrow-is-iso A is-segal-A x y f))
   := (is-prop-is-contr-is-inhabited (arrow-is-iso A is-segal-A x y f)
-      (\ is-isof -> (iso-inhabited-implies-iso-contr A is-segal-A x y f (first (first is-isof)) (second (first is-isof))
+      (\ is-isof → (iso-inhabited-implies-iso-contr A is-segal-A x y f (first (first is-isof)) (second (first is-isof))
         (first (second is-isof)) (second (second is-isof))))
     )
 
 #def id-iso
   (A : U)
   (is-segal-A : is-segal A)
-  : (x : A) -> Iso A is-segal-A x x
+  : (x : A) → Iso A is-segal-A x x
   :=
-    \ x ->
+    \ x →
     (
     (id-arr A x) ,
     (
@@ -345,13 +345,13 @@ Some of the definitions in this file rely on extension extensionality:
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
-  : (x = y) -> Iso A is-segal-A x y
-  := \ p -> idJ (A , x , \ y' p' -> Iso A is-segal-A x y' , (id-iso A is-segal-A x) , y , p)
+  : (x = y) → Iso A is-segal-A x y
+  := \ p → idJ (A , x , \ y' p' → Iso A is-segal-A x y' , (id-iso A is-segal-A x) , y , p)
 
 #def is-rezk
   (A : U)
   : U
-  := Σ (is-segal-A : is-segal A) , (x : A) -> (y : A) -> is-equiv (x = y) (Iso A is-segal-A x y) (idtoiso A is-segal-A x y)
+  := Σ (is-segal-A : is-segal A) , (x : A) → (y : A) → is-equiv (x = y) (Iso A is-segal-A x y) (idtoiso A is-segal-A x y)
 #end isomorphisms
 ```
 

--- a/src/simplicial-hott/12-cocartesian.rzk.md
+++ b/src/simplicial-hott/12-cocartesian.rzk.md
@@ -33,21 +33,21 @@ families.
 ```rzk
 #def totalType
   (B : U)
-  (P : B -> U)
+  (P : B → U)
   : U
   := Σ (b : B) , P b
 
 #def isInnerFam
   (B : U)
-  (P : B -> U)
+  (P : B → U)
   : U
-  := product (product (is-segal B) (is-segal (totalType B P))) ((b : B) -> (is-segal (P b)))
+  := product (product (is-segal B) (is-segal (totalType B P))) ((b : B) → (is-segal (P b)))
 
 #def is-isoInnerFam
   (B : U)
-  (P : B -> U)
+  (P : B → U)
   : U
-  := product (product (is-rezk B) (is-rezk (totalType B P))) ((b : B) -> (is-segal (P b)))
+  := product (product (is-rezk B) (is-rezk (totalType B P))) ((b : B) → (is-segal (P b)))
 ```
 
 ## Cocartesian arrows
@@ -61,18 +61,18 @@ this is preferred for usage.
   (B : U)
   (b b' : B)
   (u : hom B b b')
-  (P : B -> U)
+  (P : B → U)
   (e : P b)
   (e' : P b')
   (f : dhom B b b' u P e e')
   : U
   := (b'' : B)
-  -> (v : hom B b' b'')
-  -> (w : hom B b b'')
-  -> (sigma : hom2 B b b' b'' u v w)
-  -> (e'' : P b'')
-  -> (h : dhom B b b'' w P e e'')
-  -> is-contr
+  → (v : hom B b' b'')
+  → (w : hom B b b'')
+  → (sigma : hom2 B b b' b'' u v w)
+  → (e'' : P b'')
+  → (h : dhom B b b'' w P e e'')
+  → is-contr
       ( Σ ( g : dhom B b' b'' v P e' e'') ,
           ( dhom2 B b b' b'' u v w sigma P e e' e'' f g h))
 ```
@@ -87,17 +87,17 @@ a given starting point in the fiber.
     (B : U)
     (b b' : B)
     (u : hom B b b')
-    (P : B -> U)
+    (P : B → U)
     (e : P b)
     : U
     := Σ (e' : P b') , Σ (f : dhom B b b' u P e e') , isCocartArr B b b' u P e e' f
 ```
 
 #def cocart-is-prop (B : U) (Bis-rezk : is-rezk B) (b b' : B) (u : hom B b b')
-(P : B -> U) (TPis-rezk : is-rezk (totalType B P)) (PisfibRezk : (b : B) ->
+(P : B → U) (TPis-rezk : is-rezk (totalType B P)) (PisfibRezk : (b : B) →
 is-rezk (P b)) (e : P b) (e' : P b') (f : dhom B b b' u P e e') (fiscocart :
 isCocartArr B b b' u P e e' f) : is-contr (CocartLift B b b' u P e) := ( (e' , f
-, fiscocart) , \ d -> \ g ->
+, fiscocart) , \ d → \ g →
 
 ```
 


### PR DESCRIPTION
Closes #29.

- [x] `->` is changed to `→` (`\to`)
- [x] `|->` is changed to `↦` (`\mapsto`)
- [x] `===` is changed to `≡` (`\equiv`)
- [x] `<=` is changed to `≤` (`\<=`)
- [x] `/\` is changed to `∧` (`\and`)
- [x] `\/` is changed to `∨` (`\or`)
- [x] `0_2` is changed to `0₂` (`0\2`)
- [x] `1_2` is changed to `1₂` (`1\2`)
- [x] `I * J` is changed to `I × J` (`\x` or `\times`)

For now I've kept `TOP` and `BOT` as I'm not sure `⊤` and `⊥` read better in the code.
Same for `first` and `second`, except I think a lot of uses for projections should go away by using pattern matching (and `let`/`where` in the future).