### PR TITLE
Naturality for Yoneda lemma

### DIFF
--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -257,6 +257,18 @@ implication could be proven similarly.
       ( is-contr-map-is-equiv
         ( Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map-family-of-maps A B C f) totalequiv) a)
+
+#def family-equiv-total-equiv
+  ( A : U)
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))
+  ( totalequiv : is-equiv
+                ( Σ (x : A) , B x)
+                ( Σ (x : A) , C x)
+                ( total-map-family-of-maps A B C f))
+  ( a : A)
+  : Equiv (B a) (C a)
+  := ( f a , total-equiv-family-of-equiv A B C f totalequiv a)
 ```
 
 In summary, a family of maps is an equivalence iff the map on total spaces is an
@@ -662,45 +674,48 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
 
 ## 2-of-3 for equivalences
 
+The following functions refine `right-cancel-equiv` and `left-cancel-equiv` by
+providing control over the underlying maps of the equivalence.
+
 ```rzk
 -- It might be better to redo this without appealing to results about
 -- embeddings so that this could go earlier.
-#def RightCancel-is-equiv
+#def right-cancel-is-equiv
   (A B C : U)
   (f : A → B)
   (g : B → C)
   (is-equiv-g : is-equiv B C g)
-  (gfisequiv : is-equiv A C (composition A B C g f))
+  (is-equiv-gf : is-equiv A C (composition A B C g f))
   : is-equiv A B f
   :=
     ( ( composition B C A
-        (is-equiv-retraction A C (composition A B C g f) gfisequiv) g ,
-        (second (first gfisequiv))) ,
+        (is-equiv-retraction A C (composition A B C g f) is-equiv-gf) g ,
+        (second (first is-equiv-gf))) ,
       ( composition B C A
-        (is-equiv-section A C (composition A B C g f) gfisequiv) g ,
+        (is-equiv-section A C (composition A B C g f) is-equiv-gf) g ,
         \ b →
           inv-ap-is-emb
             B C g
             ( is-emb-is-equiv B C g is-equiv-g)
-            ( f ((is-equiv-section A C (composition A B C g f) gfisequiv) (g b)))
+            ( f ((is-equiv-section A C (composition A B C g f) is-equiv-gf) (g b)))
             b
-            ( (second (second gfisequiv)) (g b))))
+            ( (second (second is-equiv-gf)) (g b))))
 
-#def LeftCancel-is-equiv
+#def left-cancel-is-equiv
   (A B C : U)
   (f : A → B)
   (is-equiv-f : is-equiv A B f)
   (g : B → C)
-  (gfisequiv : is-equiv A C (composition A B C g f))
+  (is-equiv-gf : is-equiv A C (composition A B C g f))
   : is-equiv B C g
   :=
     ( ( composition C A B
-          f (is-equiv-retraction A C (composition A B C g f) gfisequiv) ,
+          f (is-equiv-retraction A C (composition A B C g f) is-equiv-gf) ,
         \ b →
           triple-concat B
-            ( f ((is-equiv-retraction A C (composition A B C g f) gfisequiv)
+            ( f ((is-equiv-retraction A C (composition A B C g f) is-equiv-gf)
               (g b)))
-            ( f ((is-equiv-retraction A C (composition A B C g f) gfisequiv)
+            ( f ((is-equiv-retraction A C (composition A B C g f) is-equiv-gf)
               (g (f ((is-equiv-section A B f is-equiv-f) b)))))
             ( f ((is-equiv-section A B f is-equiv-f) b))
             ( b)
@@ -709,22 +724,22 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
               ( f ((is-equiv-section A B f is-equiv-f) b))
               ( \ b0 →
                 ( f ((is-equiv-retraction A C
-                      ( composition A B C g f) gfisequiv) (g b0))))
+                      ( composition A B C g f) is-equiv-gf) (g b0))))
               ( rev B (f ((is-equiv-section A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
             ( ( homotopy-whisker B A A B
                 ( \ a →
                   ( is-equiv-retraction A C
-                    ( composition A B C g f) gfisequiv) (g (f a)))
+                    ( composition A B C g f) is-equiv-gf) (g (f a)))
                 ( \ a → a)
-                ( second (first gfisequiv))
+                ( second (first is-equiv-gf))
                 ( is-equiv-section A B f is-equiv-f)
                 f) b)
             ( (second (second is-equiv-f)) b)) ,
       ( composition C A B
         ( f)
-        ( is-equiv-section A C (composition A B C g f) gfisequiv) ,
-        ( second (second gfisequiv))))
+        ( is-equiv-section A C (composition A B C g f) is-equiv-gf) ,
+        ( second (second is-equiv-gf))))
 ```
 
 ## Maps over product types
@@ -757,7 +772,7 @@ types over a product type.
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( \ (a , (b , c)) → (a , (g b , h a b c)))
   :=
-    RightCancel-is-equiv
+    right-cancel-is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
@@ -783,7 +798,7 @@ types over a product type.
     ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
     ( \ (a , (b , c)) → (a , (b , h a b c)))
   :=
-    RightCancel-is-equiv
+    right-cancel-is-equiv
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -17,6 +17,12 @@ This is a literate `rzk` file:
 - `5-segal-types.md` - We make use of the notion of Segal types and their
   structures.
 
+Some of the definitions in this file rely on extension extensionality:
+
+```rzk
+#assume extext : ExtExt
+```
+
 ## Dependent hom types
 
 In a type family over a base type, there is a dependent hom type of arrows that
@@ -103,7 +109,7 @@ contractibility of the type of extensions along the domain inclusion into the
 1-simplex.
 
 ```rzk
-#def has-unique-lifts-with-fixed-domain
+#def has-unique-fixed-domain-lifts
   (A : U)
   (C : A → U)
   : U
@@ -137,11 +143,11 @@ By the equivalence-invariance of contractibility, this proves the desired
 logical equivalence
 
 ```rzk title="RS17, Proposition 8.4"
-#def has-unique-lifts-with-fixed-domain-iff-is-covariant
+#def has-unique-fixed-domain-lifts-iff-is-covariant
   (A : U)
   (C : A → U)
   : iff
-      (has-unique-lifts-with-fixed-domain A C)
+      (has-unique-fixed-domain-lifts A C)
       (is-covariant A C)
   :=
     ( \ C-has-unique-lifts x y f u →
@@ -842,6 +848,150 @@ with the covariant lifts.
           A x y f C D is-covariant-C ϕ u)
 ```
 
+## Covariant equivalence
+
+A family of types that is equivalent to a covariant family is itself covariant.
+
+To prove this we first show that the corresponding types of lifts with fixed
+domain are equivalent:
+
+```rzk
+#def equiv-covariant-total-dhom
+  (A : U)
+  (C : A → U)
+  (x y : A)
+  (f : hom A x y)
+  : Equiv
+    ( (t : Δ¹) → C (f t))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    ( \ h → (h 0₂ , \ t → h t) ,
+      ( ( \ k t → (second k) t , \ h → refl) ,
+        ( ( \ k t → (second k) t , \ h → refl))))
+```
+
+```rzk
+#section dhom-from-equivalence
+
+#variable A : U
+#variables B C : A → U
+#variable equiv-BC : (a : A) → Equiv (B a) (C a)
+#variables x y : A
+#variable f : hom A x y
+
+#def equiv-total-dhom-equiv uses (A x y)
+  : Equiv ((t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
+  :=
+    equiv-extension-equiv-fibered
+      ( extext)
+      ( 2)
+      ( Δ¹)
+      ( \ t → B (f t))
+      ( \ t → C (f t))
+      ( \ t → equiv-BC (f t))
+
+#def equiv-total-covariant-dhom-equiv uses (extext equiv-BC)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    triple-comp-equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( (t : Δ¹) → B (f t))
+    ( (t : Δ¹) → C (f t))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+    ( inv-equiv
+      ( (t : Δ¹) → B (f t))
+      ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+      ( equiv-covariant-total-dhom A B x y f))
+    ( equiv-total-dhom-equiv)
+    ( equiv-covariant-total-dhom A C x y f)
+
+#def equiv-pullback-total-covariant-dhom-equiv uses (A y)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    total-equiv-pullback-is-equiv
+      ( B x)
+      ( C x)
+      ( first (equiv-BC x))
+      ( second (equiv-BC x))
+      ( \ u → ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+
+#def is-equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
+  : is-equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)))
+  :=
+    right-cancel-is-equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)))
+    ( first (equiv-pullback-total-covariant-dhom-equiv))
+    ( second (equiv-pullback-total-covariant-dhom-equiv))
+    ( second (equiv-total-covariant-dhom-equiv))
+
+#def equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+  :=
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)),
+      is-equiv-to-pullback-total-covariant-dhom-equiv)
+
+#def family-equiv-dhom-family-equiv uses (extext A y)
+  (i : B x)
+  : Equiv
+    ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i])
+    ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+  :=
+    family-equiv-total-equiv
+    ( B x)
+    ( \ii → ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ ii]))
+    ( \ii → ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) ii]))
+    ( \ii h t → (first (equiv-BC (f t))) (h t))
+    ( is-equiv-to-pullback-total-covariant-dhom-equiv)
+    ( i)
+
+#end dhom-from-equivalence
+```
+
+Now we introduce the hypothesis that $C$ is covariant in the form of
+`has-unique-fixed-domain-lifts`.
+
+```rzk
+#def equiv-has-unique-fixed-domain-lifts uses (extext)
+  (A : U)
+  (B C : A → U)
+  (equiv-BC : (a : A) → Equiv (B a) (C a))
+  (has-unique-fixed-domain-lifts-C :
+    has-unique-fixed-domain-lifts A C)
+  : has-unique-fixed-domain-lifts A B
+  :=
+    \ x y f i →
+    is-contr-is-equiv-to-contr
+    ( (t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i])
+    ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+    ( family-equiv-dhom-family-equiv A B C equiv-BC x y f i)
+    ( has-unique-fixed-domain-lifts-C x y f ((first (equiv-BC x)) i))
+
+#def equiv-is-covariant uses (extext)
+  (A : U)
+  (B C : A → U)
+  (equiv-BC : (a : A) → Equiv (B a) (C a))
+  (is-covariant-C : is-covariant A C)
+  : is-covariant A B
+  :=
+    ( first (has-unique-fixed-domain-lifts-iff-is-covariant A B))
+      ( equiv-has-unique-fixed-domain-lifts
+        A B C equiv-BC
+        ( (second (has-unique-fixed-domain-lifts-iff-is-covariant A C))
+          is-covariant-C))
+```
+
 ## Contravariant families
 
 A family of types over a base type is contravariant if every arrow in the base
@@ -877,7 +1027,7 @@ by contractibility of the type of extensions along the codomain inclusion into
 the 1-simplex.
 
 ```rzk
-#def has-unique-lifts-with-fixed-codomain
+#def has-unique-fixed-codomain-lifts
   (A : U)
   (C : A → U)
   : U
@@ -911,11 +1061,11 @@ By the equivalence-invariance of contractibility, this proves the desired
 logical equivalence
 
 ```rzk title="RS17, Proposition 8.4"
-#def has-unique-lifts-with-fixed-codomain-iff-is-contravariant
+#def has-unique-fixed-codomain-lifts-iff-is-contravariant
   (A : U)
   (C : A → U)
   : iff
-      (has-unique-lifts-with-fixed-codomain A C)
+      (has-unique-fixed-codomain-lifts A C)
       (is-contravariant A C)
   :=
     ( \ C-has-unique-lifts x y f v →

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -19,10 +19,12 @@ This is a literate `rzk` file:
 - `5-segal-types.md` - We make heavy use of the notion of Segal types
 - `8-covariant.md` - We use covariant type families.
 
-Some of the definitions in this file rely on function extensionality:
+Some of the definitions in this file rely on function extensionality and
+extension extensionality:
 
 ```rzk
 #assume funext : FunExt
+#assume extext : ExtExt
 ```
 
 ## Natural transformations involving a representable functor
@@ -196,13 +198,54 @@ The equivalence of the Yoneda lemma is natural in both $a : A$ and $C : A → U$
 
 Naturality in $a$ follows from the fact that the maps `evid` and `yon` are
 fiberwise equivalences between covariant families over $A$, though it requires
-some work, which has not yet been formalized, to prove that the domain is
-covariant.
+some work, to prove that the domain is covariant.
+
+```rzk
+#def is-covariant-yoneda-domain uses (funext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (C : A → U)
+  (is-covariant-C : is-covariant A C)
+  : is-covariant A (\ a → (z : A) → hom A a z → C z)
+  :=
+    equiv-is-covariant
+    ( extext)
+    ( A)
+    ( \ a -> (z : A) → hom A a z → C z)
+    ( C)
+    ( \ a -> (evid A a C, Yoneda-lemma A is-segal-A a C is-covariant-C))
+    ( is-covariant-C)
+
+#def is-natural-in-object-evid uses (funext extext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a b : A)
+  (f : hom A a b)
+  (C : A -> U)
+  (is-covariant-C : is-covariant A C)
+  (ϕ : (z : A) → hom A a z → C z)
+  : (covariant-transport A a b f C is-covariant-C (evid A a C ϕ)) =
+    (evid A b C (covariant-transport A a b f ( \ x -> (z : A) → hom A x z → C z)     (is-covariant-yoneda-domain A is-segal-A C is-covariant-C) ϕ))
+  :=
+    naturality-covariant-fiberwise-transformation
+    ( A)
+    ( a)
+    ( b)
+    ( f)
+    ( \ x -> (z : A) → hom A x z → C z)
+    ( C)
+    ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+    ( is-covariant-C)
+    ( \ x -> evid A x C)
+    ( ϕ)
+
+
+```
 
 Naturality in $C$ is not automatic but can be proven easily:
 
 ```rzk title="RS17, Lemma 9.2(i)"
-#def is-natural-evid
+#def is-natural-in-family-evid
   (A : U)
   (a : A)
   (C D : A → U)
@@ -215,7 +258,7 @@ Naturality in $C$ is not automatic but can be proven easily:
 ```
 
 ```rzk title="RS17, Lemma 9.2(ii)"
-#def is-natural-yon-twice-pointwise
+#def is-natural-in-family-yon-twice-pointwise
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -233,7 +276,7 @@ Naturality in $C$ is not automatic but can be proven easily:
   := naturality-covariant-fiberwise-transformation
       A a x f C D is-covariant-C is-covariant-D ψ u
 
-#def is-natural-yon-once-pointwise uses (funext)
+#def is-natural-in-family-yon-once-pointwise uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -258,10 +301,10 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( composition (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x f)
       ( \ f →
-        is-natural-yon-twice-pointwise
+        is-natural-in-family-yon-twice-pointwise
           A is-segal-A a C D is-covariant-C is-covariant-D ψ u x f)
 
-#def is-natural-yon uses (funext)
+#def is-natural-in-family-yon uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -285,7 +328,7 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( composition (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x)
       ( \ x →
-        is-natural-yon-once-pointwise
+        is-natural-in-family-yon-once-pointwise
           A is-segal-A a C D is-covariant-C is-covariant-D ψ u x)
 ```
 
@@ -463,7 +506,7 @@ is contravariant.
 Naturality in $C$ is not automatic but can be proven easily:
 
 ```rzk title="RS17, Lemma 9.2(i), dual"
-#def is-natural-contra-evid
+#def is-natural-in-family-contra-evid
   (A : U)
   (a : A)
   (C D : A → U)
@@ -477,7 +520,7 @@ Naturality in $C$ is not automatic but can be proven easily:
 ```
 
 ```rzk title="RS17, Lemma 9.2(ii), dual"
-#def is-natural-contra-yon-twice-pointwise
+#def is-natural-in-family-contra-yon-twice-pointwise
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -496,7 +539,7 @@ Naturality in $C$ is not automatic but can be proven easily:
   := naturality-contravariant-fiberwise-transformation
       A x a f C D is-contravariant-C is-contravariant-D ψ u
 
-#def is-natural-contra-yon-once-pointwise uses (funext)
+#def is-natural-in-family-contra-yon-once-pointwise uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -523,10 +566,10 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x f)
       ( \ f →
-        is-natural-contra-yon-twice-pointwise
+        is-natural-in-family-contra-yon-twice-pointwise
           A is-segal-A a C D is-contravariant-C is-contravariant-D ψ u x f)
 
-#def is-natural-contra-yon uses (funext)
+#def is-natural-in-family-contra-yon uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -552,7 +595,7 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x)
       ( \ x →
-        is-natural-contra-yon-once-pointwise
+        is-natural-in-family-contra-yon-once-pointwise
           A is-segal-A a C D is-contravariant-C is-contravariant-D ψ u x)
 ```
 
@@ -708,7 +751,7 @@ contractible.
   (f : hom A a x)
   : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
   :=
-    ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
+    ( second (has-unique-fixed-domain-lifts-iff-is-covariant
                 A (\ z → hom A a z)))
       ( is-segal-representable-is-covariant A is-segal-A a)
       ( a)
@@ -780,7 +823,7 @@ an equivalent type in the domain of the evaluation map.
       ( C (a, id-arr A a))
       ( \ s → s a (id-arr A a))
   :=
-    LeftCancel-is-equiv
+    left-cancel-is-equiv
       ( (p : coslice A a) → C p)
       ( (x : A) → (f : hom A a x) → C (x, f))
       ( C (a, id-arr A a))
@@ -937,7 +980,7 @@ contractible.
   (f : hom A x a)
   : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
   :=
-    ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
+    ( second (has-unique-fixed-codomain-lifts-iff-is-contravariant
                 A (\ z → hom A z a)))
       ( is-segal-representable-is-contravariant A is-segal-A a)
       ( x)
@@ -1010,7 +1053,7 @@ proven, just with an equivalent type in the domain of the evaluation map.
       ( C (a, id-arr A a))
       ( \ s → s a (id-arr A a))
   :=
-    LeftCancel-is-equiv
+    left-cancel-is-equiv
       ( (p : slice A a) → C p)
       ( (x : A) → (f : hom A x a) → C (x, f))
       ( C (a, id-arr A a))

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -239,7 +239,33 @@ some work, to prove that the domain is covariant.
     ( \ x -> evid A x C)
     ( ϕ)
 
-
+#def is-natural-in-object-yon uses (funext extext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a b : A)
+  (f : hom A a b)
+  (C : A -> U)
+  (is-covariant-C : is-covariant A C)
+  (u : C a)
+  : ( covariant-transport
+      A a b f
+      ( \ x -> (z : A) → hom A x z → C z)
+      ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+      ( yon A is-segal-A a C is-covariant-C u)) =
+    ( yon A is-segal-A b C is-covariant-C
+      ( covariant-transport A a b f C is-covariant-C u))
+  :=
+    naturality-covariant-fiberwise-transformation
+    ( A)
+    ( a)
+    ( b)
+    ( f)
+    ( C)
+    ( \ x -> (z : A) → hom A x z → C z)
+    ( is-covariant-C)
+    ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+    ( \ x -> yon A is-segal-A x C is-covariant-C)
+    ( u)
 ```
 
 Naturality in $C$ is not automatic but can be proven easily:


### PR DESCRIPTION
I don't recommend merging this now but wanted feedback from @fizruk. 

In this pull request I've

(a) added a proof that given a fiberwise equivalence `(a : A) -> Equiv (B a) (C a)` where `C` is a covariant family then `B` is too.

Using this, naturality of the evid and yon maps of the Yoneda lemma are formal consequences of `naturality-covariant-fiberwise-transformation`. (Note this is not the optimal formulation of these naturality statements. For that, we'll need to calculate the action by covariant transport in the family  `\ a -> (z : A) → hom A a z → C z`.)

The typechecking of `is-natural-in-object-evid` is slow but terminates within a few seconds. On machine, the typechecking of `is-natural-in-object-yon` has not terminated (and thus the construction might be wrong).

I'm curious what's going on here. Any insight would be welcome.