### PR TITLE
Use literate features instead of code comments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,14 +6,8 @@
     {
       "label": "typecheck",
       "type": "shell",
-      "command": "stack",
-      "args": [
-        "exec",
-        "rzk",
-        "typecheck",
-        "src/hott/*",
-        "src/simplicial-hott/*"
-      ],
+      "command": "rzk",
+      "args": ["typecheck", "src/hott/*", "src/simplicial-hott/*"],
       "problemMatcher": [],
       "group": {
         "kind": "build",

--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -68,9 +68,7 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 
 ## Substitution
 
-### Reindexing a type family along a function into the base type
-
-```rzk
+```rzk title="Reindexing a type family along a function into the base type"
 #def reindex
   ( A B : U)
   ( f : B → A)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -286,8 +286,11 @@ Prewhiskering paths of paths is much harder.
       ( concat A x y z p q)
       ( concat' A x y z p q)
       ( concat-concat' p q)
+```
 
--- this is easier to prove for concat' than for concat
+This is easier to prove for `concat'` than for `concat`.
+
+```rzk
 #def alt-triangle-rotation
   ( p : x = z)
   ( q : x = y)
@@ -358,13 +361,13 @@ The following needs to be outside the previous section because of the usage of
   : (ap A B y x f (rev A x y p)) = (rev B (f x) (f y) (ap A B x y f p))
   :=
     idJ
-    ( A ,
-      x ,
-      \ y' p' →
-        ap A B y' x f (rev A x y' p') = rev B (f x) (f y') (ap A B x y' f p') ,
-      refl ,
-      y ,
-      p)
+    ( ( A) ,
+      ( x) ,
+      ( \ y' p' →
+        ap A B y' x f (rev A x y' p') = rev B (f x) (f y') (ap A B x y' f p')) ,
+      ( refl) ,
+      ( y) ,
+      ( p))
 
 #def ap-concat
   ( A B : U)
@@ -376,14 +379,14 @@ The following needs to be outside the previous section because of the usage of
     ( concat B (f x) (f y) (f z) (ap A B x y f p) (ap A B y z f q))
   :=
     idJ
-    ( A ,
-      y ,
-      \ z' q' →
-        (ap A B x z' f (concat A x y z' p q')) =
-        (concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q')) ,
-      refl ,
-      z ,
-      q)
+    ( ( A) ,
+      ( y) ,
+      ( \ z' q' →
+        ( ap A B x z' f (concat A x y z' p q')) =
+        ( concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q'))) ,
+      ( refl) ,
+      ( z) ,
+      ( q))
 
 #def rev-ap-rev
   ( A B : U)
@@ -393,16 +396,19 @@ The following needs to be outside the previous section because of the usage of
   : (rev B (f y) (f x) (ap A B y x f (rev A x y p))) = (ap A B x y f p)
   :=
     idJ
-    ( A ,
-      x ,
-      \ y' p' →
+    ( ( A) ,
+      ( x) ,
+      ( \ y' p' →
         (rev B (f y') (f x) (ap A B y' x f (rev A x y' p'))) =
-        (ap A B x y' f p') ,
-      refl ,
-      y ,
-      p)
+        (ap A B x y' f p')) ,
+      ( refl) ,
+      ( y) ,
+      ( p))
+```
 
--- For specific use
+The following is for a specific use.
+
+```rzk
 #def concat-ap-rev-ap-id
   ( A B : U)
   ( x y : A)
@@ -432,8 +438,11 @@ The following needs to be outside the previous section because of the usage of
   ( p : x = y)
   : (ap A A x y (identity A) p) = p
     := idJ (A , x , \ y' p' → (ap A A x y' (\ z → z) p') = p' , refl , y , p)
+```
 
--- application of a function to homotopic paths yields homotopic paths
+Application of a function to homotopic paths yields homotopic paths.
+
+```rzk
 #def ap-htpy
   ( A B : U)
   ( x y : A)
@@ -492,16 +501,22 @@ The following needs to be outside the previous section because of the usage of
 
 #variable A : U
 #variable B : A → U
+```
 
--- transport in a type family along a path in the base
+### Transport in a type family along a path in the base
+
+```rzk
 #def transport
   ( x y : A)
   ( p : x = y)
   ( u : B x)
   : B y
   := idJ (A , x , \ y' p' → B y' , u , y , p)
+```
 
--- The lift of a base path to a path from a term in the total space to its transport.
+### The lift of a base path to a path from a term in the total space to its transport
+
+```rzk
 #def transport-lift
   ( x y : A)
   ( p : x = y)
@@ -515,8 +530,11 @@ The following needs to be outside the previous section because of the usage of
       refl ,
       y ,
       p)
+```
 
--- transport along concatenated paths
+### Transport along concatenated paths
+
+```rzk
 #def transport-concat
   ( x y z : A)
   ( p : x = y)
@@ -552,8 +570,11 @@ The following needs to be outside the previous section because of the usage of
       refl ,
       z ,
       q)
+```
 
--- A path between transportation along homotopic paths
+### Transport along homotopic paths
+
+```rzk
 #def transport2
   ( x y : A)
   ( p q : x = y)
@@ -568,13 +589,19 @@ The following needs to be outside the previous section because of the usage of
       refl ,
       q ,
       H)
+```
 
+### Transport along a loop
+
+```rzk
 #def transport-loop
   ( a : A)
   ( b : B a)
   : (a = a) → B a
   := \ p → (transport a a p b)
+```
 
+```rzk
 #end transport
 ```
 
@@ -599,6 +626,8 @@ The following needs to be outside the previous section because of the usage of
 ```
 
 ## Higher-order concatenation
+
+For convenience, we record lemmas for higher-order concatenation here.
 
 ```rzk
 #section higher-concatenation
@@ -666,8 +695,11 @@ The following needs to be outside the previous section because of the usage of
         ( quadruple-concat
           a8 a9 a10 a11 a12
           p9 p10 p11 p12))
+```
 
--- Same as above but with alternating arguments
+The following is the same as above but with alternating arguments.
+
+```rzk
 #def alternating-12ary-concat
   ( a0 : A)
   ( a1 : A) (p1 : a0 = a1)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -139,8 +139,8 @@ choice of definition.
 
 ### Concatenation of two paths with common codomain
 
-Concatenation of two paths with common codomain; defined using `concat` and
-`rev`.
+Concatenation of two paths with common codomain; defined using `#!rzk concat`
+and `#!rzk rev`.
 
 ```rzk
 #def zig-zag-concat
@@ -152,7 +152,8 @@ Concatenation of two paths with common codomain; defined using `concat` and
 
 ### Concatenation of two paths with common domain
 
-Concatenation of two paths with common domain; defined using `concat` and `rev`.
+Concatenation of two paths with common domain; defined using `#!rzk concat` and
+`#!rzk rev`.
 
 ```rzk
 #def zag-zig-concat
@@ -288,7 +289,7 @@ Prewhiskering paths of paths is much harder.
       ( concat-concat' p q)
 ```
 
-This is easier to prove for `concat'` than for `concat`.
+This is easier to prove for `#!rzk concat'` than for `#!rzk concat`.
 
 ```rzk
 #def alt-triangle-rotation
@@ -311,7 +312,7 @@ This is easier to prove for `concat'` than for `concat`.
 ```
 
 The following needs to be outside the previous section because of the usage of
-`concat-concat' A y x`.
+`#!rzk concat-concat' A y x`.
 
 ```rzk
 #end derived-path-coherence

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -12,28 +12,36 @@ This is a literate `rzk` file:
 #section homotopies
 
 #variables A B : U
+```
 
--- The type of homotopies between parallel functions.
+```rzk title="The type of homotopies between parallel functions"
 #def homotopy
   (f g : A → B)
   : U
   := (a : A) → (f a = g a)
+```
 
--- The reversal of a homotopy
+```rzk title="The reversal of a homotopy"
 #def homotopy-rev
   (f g : A → B)
   (H : homotopy f g)
   : homotopy g f
   := \ a → rev B (f a) (g a) (H a)
+```
 
--- Homotopy composition is defined in diagrammatic order like concat but unlike composition.
+```rzk
 #def homotopy-composition
   (f g h : A → B)
   (H : homotopy f g)
   (K : homotopy g h)
   : homotopy f h
   := \ a → concat B (f a) (g a) (h a) (H a) (K a)
+```
 
+Homotopy composition is defined in diagrammatic order like `concat` but unlike
+composition.
+
+```rzk
 #end homotopies
 ```
 
@@ -84,8 +92,7 @@ This is a literate `rzk` file:
 
 ## Naturality
 
-```rzk
--- The naturality square associated to a homotopy and a path.
+```rzk title="The naturality square associated to a homotopy and a path"
 #def nat-htpy
   (A B : U)
   (f g : A → B)
@@ -104,8 +111,9 @@ This is a literate `rzk` file:
       left-unit-concat B (f x) (g x) (H x) ,
       y ,
       p)
+```
 
--- Naturality in another form
+```rzk title="Naturality in another form"
 #def triple-concat-nat-htpy
   (A B : U)
   (f g : A → B)
@@ -145,15 +153,22 @@ This is a literate `rzk` file:
 #variable f : A → A
 #variable H : homotopy A A f (identity A)
 #variable a : A
+```
 
--- In the case of a homotopy H from f to the identity the previous square applies to the path H a to produce the following naturality square.
+In the case of a homotopy `H` from `f` to the identity the previous square
+applies to the path `H a` to produce the following naturality square.
+
+```rzk
 #def cocone-naturality
   : (concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
     (concat A (f (f a)) (f a) (a) (H (f a)) (ap A A (f a) a (identity A) (H a)))
   := nat-htpy A A f (identity A) H (f a) a (H a)
+```
 
--- After composing with ap-id, this naturality square transforms to the
--- following:
+After composing with `ap-id`, this naturality square transforms to the
+following:
+
+```rzk
 #def reduced-cocone-naturality
   : (concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
     (concat A (f (f a)) (f a) (a) (H (f a)) (H a))
@@ -179,8 +194,11 @@ This is a literate `rzk` file:
         ( ap A A (f a) a (identity A) (H a))
         ( H a)
         ( ap-id A (f a) a (H a)))
+```
 
--- Cancelling the path (H a) on the right and reversing yields a path we need:
+Cancelling the path `H a` on the right and reversing yields a path we need:
+
+```rzk
 #def cocone-naturality-coherence
   : (H (f a)) = (ap A A (f a) a f (H a))
   :=
@@ -203,27 +221,26 @@ This is a literate `rzk` file:
 ## Conjugation with higher homotopies
 
 ```rzk
--- Conjugation between higher homotopies
 #def triple-concat-higher-homotopy
-  (A B : U)
-  (f g : A → B)
-  (H K : homotopy A B f g)
-  (α : (a : A) → H a = K a)
-  (x y : A)
-  (p : f x = f y)
+  ( A B : U)
+  ( f g : A → B)
+  ( H K : homotopy A B f g)
+  ( α : (a : A) → H a = K a)
+  ( x y : A)
+  ( p : f x = f y)
   : triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (H x)) p (H y) =
     triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (K x)) p (K y)
   :=
     idJ
-    ( f y = g y ,
-      H y ,
-      \ Ky α' →
+    ( ( f y = g y) ,
+      ( H y) ,
+      ( \ Ky α' →
         triple-concat
           ( B) (g x) (f x) (f y) (g y)
           ( rev B (f x) (g x) (H x)) (p) (H y) =
         triple-concat
           ( B) (g x) (f x) (f y) (g y)
-          ( rev B (f x) (g x) (K x)) (p) (Ky) ,
+          ( rev B (f x) (g x) (K x)) (p) (Ky)) ,
       homotopy-triple-concat
         B
         ( g x)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -38,8 +38,8 @@ This is a literate `rzk` file:
   := \ a → concat B (f a) (g a) (h a) (H a) (K a)
 ```
 
-Homotopy composition is defined in diagrammatic order like `concat` but unlike
-composition.
+Homotopy composition is defined in diagrammatic order like `#!rzk concat` but
+unlike composition.
 
 ```rzk
 #end homotopies
@@ -155,8 +155,9 @@ composition.
 #variable a : A
 ```
 
-In the case of a homotopy `H` from `f` to the identity the previous square
-applies to the path `H a` to produce the following naturality square.
+In the case of a homotopy `#!rzk H` from `#!rzk f` to the identity the previous
+square applies to the path `#!rzk H a` to produce the following naturality
+square.
 
 ```rzk
 #def cocone-naturality
@@ -165,7 +166,7 @@ applies to the path `H a` to produce the following naturality square.
   := nat-htpy A A f (identity A) H (f a) a (H a)
 ```
 
-After composing with `ap-id`, this naturality square transforms to the
+After composing with `#!rzk ap-id`, this naturality square transforms to the
 following:
 
 ```rzk
@@ -196,7 +197,8 @@ following:
         ( ap-id A (f a) a (H a)))
 ```
 
-Cancelling the path `H a` on the right and reversing yields a path we need:
+Cancelling the path `#!rzk H a` on the right and reversing yields a path we
+need:
 
 ```rzk
 #def cocone-naturality-coherence

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -157,7 +157,7 @@ maps.
   := composition B A B f has-inverse-inverse
 ```
 
-This composite is parallel to `f`; we won't need the dual notion.
+This composite is parallel to `#!rzk f`; we won't need the dual notion.
 
 ```rzk
 #def has-inverse-triple-composite uses (has-inverse-f)
@@ -165,7 +165,8 @@ This composite is parallel to `f`; we won't need the dual notion.
   := triple-composition A B A B f has-inverse-inverse f
 ```
 
-This composite is also parallel to `f`; again we won't need the dual notion.
+This composite is also parallel to `#!rzk f`; again we won't need the dual
+notion.
 
 ```rzk
 #def has-inverse-quintuple-composite uses (has-inverse-f)
@@ -176,8 +177,8 @@ This composite is also parallel to `f`; again we won't need the dual notion.
 
 ## Composing equivalences
 
-The type of equivalences between types uses `is-equiv` rather than
-`has-inverse`.
+The type of equivalences between types uses `#!rzk is-equiv` rather than
+`#!rzk has-inverse`.
 
 ```rzk
 #def Equiv
@@ -416,7 +417,7 @@ extensionality:
 ```
 
 Whenever a definition (implicitly) uses function extensionality, we write
-`uses (funext)`. In particular, the following definitions rely on function
+`#!rzk uses (funext)`. In particular, the following definitions rely on function
 extensionality:
 
 ```rzk title="The equivalence provided by function extensionality"
@@ -429,7 +430,8 @@ extensionality:
 ```
 
 In particular, function extensionality implies that homotopies give rise to
-identifications. This defines `eq-htpy` to be the retraction to `htpy-eq`.
+identifications. This defines `#!rzk eq-htpy` to be the retraction to
+`#!rzk htpy-eq`.
 
 ```rzk
 #def eq-htpy uses (funext)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -22,8 +22,11 @@ This is a literate `rzk` file:
   ( f : A → B)
   : U
   := Σ (r : B → A) , (homotopy A A (composition A B A r f) (identity A))
+```
 
--- equivalences are bi-invertible maps
+We define equivalences to be bi-invertible maps.
+
+```rzk
 #def is-equiv
   ( f : A → B)
   : U
@@ -48,8 +51,9 @@ This is a literate `rzk` file:
 #def is-equiv-retraction uses (f)
   : B → A
   := first (first is-equiv-f)
+```
 
--- the homotopy between the section and retraction of an equivalence
+```rzk title="The homotopy between the section and retraction of an equivalence"
 #def homotopic-inverses-is-equiv uses (f)
   : homotopy B A is-equiv-section is-equiv-retraction
   :=
@@ -76,8 +80,9 @@ This is a literate `rzk` file:
 
 ## Invertible maps
 
+The following type of more coherent equivalences is not a proposition.
+
 ```rzk
--- the following type of more coherent equivalences is not a proposition
 #def has-inverse
   ( A B : U)
   ( f : A → B)
@@ -86,15 +91,12 @@ This is a literate `rzk` file:
     Σ ( g : B → A) ,
       ( product
         ( homotopy A A (composition A B A g f) (identity A))
-        -- The retracting homotopy
         ( homotopy B B (composition B A B f g) (identity B)))
-        -- The section homotopy
 ```
 
 ## Equivalences are invertible maps
 
-```rzk
--- invertible maps are equivalences
+```rzk title="Invertible maps are equivalences"
 #def is-equiv-has-inverse
   ( A B : U)
   ( f : A → B)
@@ -103,8 +105,9 @@ This is a literate `rzk` file:
   :=
     ( ( first has-inverse-f , first (second has-inverse-f)) ,
       ( first has-inverse-f , second (second has-inverse-f)))
+```
 
--- equivalences are invertible
+```rzk title="Equivalences are invertible"
 #def has-inverse-is-equiv
   ( A B : U)
   ( f : A → B)
@@ -133,13 +136,18 @@ This is a literate `rzk` file:
 #variables A B : U
 #variable f : A → B
 #variable has-inverse-f : has-inverse A B f
+```
 
--- The inverse of a map with an inverse
+```rzk title="The inverse of a map with an inverse"
 #def has-inverse-inverse uses (f)
   : B → A
   := first (has-inverse-f)
+```
 
--- Some iterated composites associated to a pair of invertible maps.
+The following are some iterated composites associated to a pair of invertible
+maps.
+
+```rzk
 #def has-inverse-retraction-composite uses (B has-inverse-f)
   : A → A
   := composition A B A has-inverse-inverse f
@@ -147,13 +155,19 @@ This is a literate `rzk` file:
 #def has-inverse-section-composite uses (A has-inverse-f)
   : B → B
   := composition B A B f has-inverse-inverse
+```
 
--- This composite is parallel to f; we won't need the dual notion.
+This composite is parallel to `f`; we won't need the dual notion.
+
+```rzk
 #def has-inverse-triple-composite uses (has-inverse-f)
   : A → B
   := triple-composition A B A B f has-inverse-inverse f
+```
 
--- This composite is also parallel to f; again we won't need the dual notion.
+This composite is also parallel to `f`; again we won't need the dual notion.
+
+```rzk
 #def has-inverse-quintuple-composite uses (has-inverse-f)
   : A → B
   := \ a → f (has-inverse-inverse (f (has-inverse-inverse (f a))))
@@ -162,7 +176,8 @@ This is a literate `rzk` file:
 
 ## Composing equivalences
 
-The type of equivalences between types uses is-equiv rather than has-inverse.
+The type of equivalences between types uses `is-equiv` rather than
+`has-inverse`.
 
 ```rzk
 #def Equiv
@@ -172,7 +187,7 @@ The type of equivalences between types uses is-equiv rather than has-inverse.
 ```
 
 The data of an equivalence is not symmetric so we promote an equivalence to an
-invertible map to prove symmetry.
+invertible map to prove symmetry:
 
 ```rzk
 #def inv-equiv
@@ -187,9 +202,7 @@ invertible map to prove symmetry.
         first (second (has-inverse-is-equiv A B (first e) (second e))))))
 ```
 
-Composition of equivalences in diagrammatic order.
-
-```rzk
+```rzk title="Composition of equivalences in diagrammatic order"
 #def comp-equiv
   ( A B C : U)
   ( A≃B : Equiv A B)
@@ -208,8 +221,7 @@ Composition of equivalences in diagrammatic order.
               ( a)
               ( ap B A
                 ( (first (first (second B≃C))) ((first B≃C) ((first A≃B) a)))
-                  -- should be inferred
-                ( (first A≃B) a) -- should be inferred
+                ( (first A≃B) a)
                 ( first (first (second A≃B)))
                 ( (second (first (second B≃C))) ((first A≃B) a)))
               ( (second (first (second A≃B))) a))) ,
@@ -218,20 +230,29 @@ Composition of equivalences in diagrammatic order.
                   ( (first (second (second (B≃C)))) c) ,
           ( \ c →
             concat C
-              ( (first B≃C) ((first A≃B) ((first (second (second A≃B)))
-                ((first (second (second B≃C))) c))))
-              ( (first B≃C) ((first (second (second B≃C))) c))
+              ( first B≃C
+                ( first A≃B
+                  ( first
+                    ( second (second A≃B))
+                    ( first (second (second B≃C)) c))))
+              ( first B≃C (first (second (second B≃C)) c))
               ( c)
               ( ap B C
-                ( (first A≃B) ((first (second (second A≃B)))
-                  ((first (second (second B≃C))) c))) -- should be inferred
-                ( (first (second (second B≃C))) c) -- should be inferred
+                ( first A≃B
+                  ( first
+                    ( second (second A≃B))
+                    ( first (second (second B≃C)) c)))
+                ( first (second (second B≃C)) c)
                 ( first B≃C)
-                ( (second (second (second A≃B)))
-                  ((first (second (second B≃C))) c)))
-              ( (second (second (second B≃C))) c)))))
+                ( second
+                  ( second (second A≃B))
+                  ( first (second (second B≃C)) c)))
+              ( second (second (second B≃C)) c)))))
+```
 
--- now we compose the functions that are equivalences
+Now we compose the functions that are equivalences.
+
+```rzk
 #def compose-is-equiv
   ( A B C : U)
   ( f : A → B)
@@ -241,20 +262,20 @@ Composition of equivalences in diagrammatic order.
   : is-equiv A C (composition A B C g f)
   :=
     ( ( composition C B A
-      ( is-equiv-retraction A B f is-equiv-f)
-      ( is-equiv-retraction B C g is-equiv-g) ,
-      ( \ a →
-        concat A
-          ( (is-equiv-retraction A B f is-equiv-f)
-            ((is-equiv-retraction B C g is-equiv-g) (g (f a))))
-          ( (is-equiv-retraction A B f is-equiv-f) (f a))
-          ( a)
-          ( ap B A
-            ( (is-equiv-retraction B C g is-equiv-g) (g (f a))) -- should be inferred
-            ( f a) -- should be inferred
-            ( is-equiv-retraction A B f is-equiv-f)
-            ( (second (first is-equiv-g)) (f a)))
-          ( (second (first is-equiv-f)) a))) ,
+        ( is-equiv-retraction A B f is-equiv-f)
+        ( is-equiv-retraction B C g is-equiv-g) ,
+        ( \ a →
+          concat A
+            ( (is-equiv-retraction A B f is-equiv-f)
+              ((is-equiv-retraction B C g is-equiv-g) (g (f a))))
+            ( (is-equiv-retraction A B f is-equiv-f) (f a))
+            ( a)
+            ( ap B A
+              ( (is-equiv-retraction B C g is-equiv-g) (g (f a)))
+              ( f a)
+              ( is-equiv-retraction A B f is-equiv-f)
+              ( (second (first is-equiv-g)) (f a)))
+            ( (second (first is-equiv-f)) a))) ,
       ( composition C B A
         ( is-equiv-section A B f is-equiv-f)
         ( is-equiv-section B C g is-equiv-g) ,
@@ -265,29 +286,31 @@ Composition of equivalences in diagrammatic order.
             ( c)
             ( ap B C
               ( f ((first (second is-equiv-f)) ((first (second is-equiv-g)) c)))
-                                -- should be inferred
-              ( (first (second is-equiv-g)) c) -- should be inferred
+              ( (first (second is-equiv-g)) c)
               ( g)
               ( (second (second is-equiv-f)) ((first (second is-equiv-g)) c)))
                 ((second (second is-equiv-g)) c))))
+```
 
--- Right cancellation of equivalences in diagrammatic order.
+```rzk title="Right cancellation of equivalences in diagrammatic order"
 #def right-cancel-equiv
   ( A B C : U)
   ( A≃C : Equiv A C)
   ( B≃C : Equiv B C)
   : Equiv A B
   := comp-equiv A C B (A≃C) (inv-equiv B C B≃C)
+```
 
--- Left cancellation of equivalences in diagrammatic order.
+```rzk title="Left cancellation of equivalences in diagrammatic order"
 #def left-cancel-equiv
   ( A B C : U)
   ( A≃B : Equiv A B)
   ( A≃C : Equiv A C)
   : Equiv B C
   := comp-equiv B A C (inv-equiv A B A≃B) (A≃C)
+```
 
--- a composition of three equivalences
+```rzk title="A composition of three equivalences"
 #def triple-comp-equiv
   ( A B C D : U)
   ( A≃B : Equiv A B)
@@ -353,7 +376,7 @@ If a map is homotopic to an equivalence it is an equivalence.
 
 ## Function extensionality
 
-By path induction, an identification between functions defines a homotopy
+By path induction, an identification between functions defines a homotopy.
 
 ```rzk
 #def htpy-eq
@@ -375,8 +398,7 @@ By path induction, an identification between functions defines a homotopy
 The function extensionality axiom asserts that this map defines a family of
 equivalences.
 
-```rzk
--- The type that encodes the function extensionality axiom.
+```rzk title="The type that encodes the function extensionality axiom"
 #def FunExt : U
   :=
     ( X : U) →
@@ -397,24 +419,31 @@ Whenever a definition (implicitly) uses function extensionality, we write
 `uses (funext)`. In particular, the following definitions rely on function
 extensionality:
 
-```rzk
--- The equivalence provided by function extensionality.
+```rzk title="The equivalence provided by function extensionality"
 #def FunExt-equiv uses (funext)
   ( X : U)
   ( A : X → U)
   ( f g : (x : X) → A x)
   : Equiv (f = g) ((x : X) → f x = g x)
   := (htpy-eq X A f g , funext X A f g)
+```
 
--- In particular, function extensionality implies that homotopies give rise to identifications. This defines eq-htpy to be the retraction to htpy-eq.
+In particular, function extensionality implies that homotopies give rise to
+identifications. This defines `eq-htpy` to be the retraction to `htpy-eq`.
+
+```rzk
 #def eq-htpy uses (funext)
   ( X : U)
   ( A : X → U)
   ( f g : (x : X) → A x)
   : ((x : X) → f x = g x) → (f = g)
   := first (first (funext X A f g))
+```
 
--- Using function extensionality, a fiberwise equivalence defines an equivalence of dependent function types
+Using function extensionality, a fiberwise equivalence defines an equivalence of
+dependent function types.
+
+```rzk
 #def equiv-function-equiv-fibered uses (funext)
   ( X : U)
   ( A B : X → U)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -8,8 +8,10 @@ This is a literate `rzk` file:
 
 ## Half adjoint equivalences
 
+We'll require a more coherent notion of equivalence. Namely, the notion of
+**half adjoint equivalences**.
+
 ```rzk
--- We'll require a more coherent notion of equivalence
 #def is-half-adjoint-equiv
   ( A B : U)
   ( f : A → B)
@@ -18,23 +20,30 @@ This is a literate `rzk` file:
     Σ ( has-inverse-f : (has-inverse A B f)) ,
       ( ( a : A) →
         ( second (second has-inverse-f) (f a)) =
-        ( ap A B ( has-inverse-retraction-composite A B f has-inverse-f a) a
-          ( f) ( ( ( first ( second has-inverse-f))) a)))
+        ( ap A B
+          ( has-inverse-retraction-composite A B f has-inverse-f a)
+          ( a)
+          ( f)
+          ( first (second has-inverse-f) a)))
+```
 
--- By function extensionality, the previous definition coincides with the
--- following one:
+By function extensionality, the previous definition coincides with the following
+one:
+
+```rzk
 #def is-half-adjoint-equiv'
   (A B : U)
   (f : A → B)
   : U
-  := Σ ( has-inverse-f : (has-inverse A B f)) ,
-       ( ( a : A) →
-         ( second (second has-inverse-f) (f a)) =
-           ( ap A B
-            ( has-inverse-retraction-composite A B f has-inverse-f a)
-            ( a)
-            ( f)
-            ( first (second has-inverse-f) a)))
+  :=
+    Σ ( has-inverse-f : (has-inverse A B f)) ,
+      ( ( a : A) →
+        ( second (second has-inverse-f) (f a)) =
+          ( ap A B
+          ( has-inverse-retraction-composite A B f has-inverse-f a)
+          ( a)
+          ( f)
+          ( first (second has-inverse-f) a)))
 ```
 
 ## Coherence data from an invertible map
@@ -96,8 +105,11 @@ following naturality square.
     ( has-inverse-retraction-composite A B f has-inverse-f a)
     ( a)
     ( has-inverse-kept-htpy A B f has-inverse-f a)
+```
 
--- building a path that will be whiskered into the naturality square above
+We build a path that will be whiskered into the naturality square above:
+
+```rzk
 #def has-inverse-cocone-homotopy-coherence
   : has-inverse-kept-htpy A B f has-inverse-f
       ( has-inverse-retraction-composite A B f has-inverse-f a) =
@@ -180,9 +192,12 @@ following naturality square.
         ( has-inverse-retraction-composite A B f has-inverse-f)
         ( f)
         ( has-inverse-kept-htpy A B f has-inverse-f a))
+```
 
--- This morally gives the half adjoint inverse coherence.
--- It just requires rotation.
+This morally gives the half adjoint inverse coherence. It just requires
+rotation.
+
+```rzk
 #def has-inverse-replaced-naturality-square
   : concat B
     ( has-inverse-quintuple-composite A B f has-inverse-f a)
@@ -205,7 +220,8 @@ following naturality square.
     ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
-    concat (has-inverse-quintuple-composite A B f has-inverse-f a = f a)
+    concat
+      ( has-inverse-quintuple-composite A B f has-inverse-f a = f a)
       ( concat B
         ( has-inverse-quintuple-composite A B f has-inverse-f a)
         ( has-inverse-triple-composite A B f has-inverse-f a)
@@ -249,8 +265,11 @@ following naturality square.
         ( has-inverse-cocone-coherence)
         ( has-inverse-discarded-htpy A B f has-inverse-f (f a)))
       ( has-inverse-discarded-naturality-square)
+```
 
--- This will replace the discarded homotopy
+This will replace the discarded homotopy.
+
+```rzk
 #def has-inverse-corrected-htpy
   : homotopy B B (has-inverse-section-composite A B f has-inverse-f) (\ b → b)
   :=
@@ -278,8 +297,11 @@ following naturality square.
             ( (first (second has-inverse-f))
               (has-inverse-inverse A B f has-inverse-f b)))
           ( (has-inverse-discarded-htpy A B f has-inverse-f b)))
+```
 
--- this is the half adjoint coherence
+The following is the half adjoint coherence.
+
+```rzk
 #def has-inverse-coherence
   : ( has-inverse-corrected-htpy (f a)) =
     ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
@@ -307,14 +329,17 @@ following naturality square.
       ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
         ( has-inverse-kept-htpy A B f has-inverse-f a))
       ( has-inverse-replaced-naturality-square)
+```
 
+```rzk
 #end has-inverse-coherence
 ```
 
 ## Invertible maps are half adjoint equivalences
 
 To promote an invertible map to a half adjoint equivalence we change the data of
-the invertible map by replacing the discarded homotopy with the corrected one.
+the invertible map by discarding the homotopy and replacing it with a corrected
+one.
 
 ```rzk
 #def corrected-has-inverse-has-inverse
@@ -326,8 +351,9 @@ the invertible map by replacing the discarded homotopy with the corrected one.
     ( has-inverse-inverse A B f has-inverse-f ,
       ( has-inverse-kept-htpy A B f has-inverse-f ,
         has-inverse-corrected-htpy A B f has-inverse-f))
+```
 
--- Invertible maps are half adjoint equivalences!
+```rzk title="Invertible maps are half adjoint equivalences!"
 #def is-half-adjoint-equiv-has-inverse
   ( A B : U)
   ( f : A → B)
@@ -336,8 +362,9 @@ the invertible map by replacing the discarded homotopy with the corrected one.
   :=
     ( corrected-has-inverse-has-inverse A B f has-inverse-f ,
       has-inverse-coherence A B f has-inverse-f)
+```
 
--- Equivalences are half adjoint equivalences!
+```rzk title="Equivalences are half adjoint equivalences!"
 #def is-half-adjoint-equiv-is-equiv
   ( A B : U)
   ( f : A → B)
@@ -364,17 +391,17 @@ have equivalent identity types.
   ( x y : A)
   : iff (x = y) (f x = f y)
   :=
-    (ap A B x y f ,
+    ( ap A B x y f ,
       \ q →
-        triple-concat A
-          ( x)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-          ( (has-inverse-inverse A B f (first fisHAE)) (f y))
-          ( y)
-          ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
-            ( (first (second (first fisHAE))) x))
-          ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q)
-          ( (first (second (first fisHAE))) y))
+      triple-concat A
+        ( x)
+        ( (has-inverse-inverse A B f (first fisHAE)) (f x))
+        ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+        ( y)
+        ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+          ( (first (second (first fisHAE))) x))
+        ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q)
+        ( (first (second (first fisHAE))) y))
 
 #def has-retraction-ap-is-half-adjoint-equiv
   (x y : A)

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -235,8 +235,10 @@ similarly for induction purposes.
             ( second (second t))))
 ```
 
-**Warning:** The following is the lazy definition with bad computational
-properties.
+!!! warning
+
+    The following definition of `triple-eq`
+    is the lazy definition with bad computational properties.
 
 ```rzk
 #def triple-eq

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -84,16 +84,22 @@ This is a literate `rzk` file:
   ( e : s = t)
   : Eq-Σ s t
   := (first-path-Σ s t e , second-path-Σ s t e)
+```
 
--- A path in a fiber defines a path in the total space
+A path in a fiber defines a path in the total space.
+
+```rzk
 #def eq-eq-fiber-Σ
   ( x : A)
   ( u v : B x)
   ( p : u = v)
   : (x , u) =_{Σ (a : A) , B a} (x , v)
   := idJ (B x , u , \ v' p' → (x , u) = (x , v') , refl , v , p)
+```
 
--- Essentially eq-pair but with explicit arguments.
+The following is essentially `eq-pair` but with explicit arguments.
+
+```rzk
 #def path-of-pairs-pair-of-paths
   ( x y : A)
   ( p : x = y)
@@ -111,8 +117,9 @@ This is a literate `rzk` file:
       ( \ u' v' q' → (eq-eq-fiber-Σ x u' v' q')) ,
       ( y) ,
       ( p))
+```
 
--- The inverse to `pair-eq`.
+```rzk title="The inverse to pair-eq"
 #def eq-pair
   ( s t : Σ (a : A) , B a)
   ( e : Eq-Σ s t)
@@ -134,9 +141,12 @@ This is a literate `rzk` file:
       refl ,
       t ,
       e)
+```
 
--- Here we've decomposed e : Eq-Σ s t as (e0, e1) and decomposed s and t
--- similarly for induction purposes
+Here we've decomposed `e : Eq-Σ s t` as `(e0, e1)` and decomposed `s` and `t`
+similarly for induction purposes.
+
+```rzk
 #def pair-eq-eq-pair-split
   ( s0 : A)
   ( s1 : B s0)
@@ -223,8 +233,12 @@ This is a literate `rzk` file:
             ( first s) (first t)
             ( first (second s)) (first (second t)) p q (second (second s)) =
             ( second (second t))))
+```
 
--- ! This is the lazy definition with bad computational properties.
+**Warning:** The following is the lazy definition with bad computational
+properties.
+
+```rzk
 #def triple-eq
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
   ( e : s = t)
@@ -237,11 +251,13 @@ This is a literate `rzk` file:
       ( refl , (refl , refl)) ,
       t ,
       e)
+```
 
--- The inverse with explicit arguments.
--- It's surprising this typechecks since we defined product-transport by a dual
--- path induction over both p and q , rather than by saying that when p is refl
--- this is ordinary transport
+It's surprising that the following typechecks since we defined product-transport
+by a dual path induction over both `p` and `q`, rather than by saying that when
+`p` is `refl` this is ordinary transport.
+
+```rzk title="The inverse with explicit arguments"
 #def path-of-triples-to-triple-of-paths
   ( a a' : A)
   ( u u' : B)
@@ -291,8 +307,11 @@ This is a literate `rzk` file:
       ( refl) ,
       ( t) ,
       ( e))
+```
 
--- Here we've decomposed s t e for induction purposes
+Here we've decomposed `s`, `t` and `e` for induction purposes:
+
+```rzk
 #def triple-eq-eq-triple-split
   ( a a' : A)
   ( b b' : B)
@@ -384,7 +403,7 @@ This is a literate `rzk` file:
 
 ## Fubini
 
-Given a family over a pair of independent types , the order of summation is
+Given a family over a pair of independent types, the order of summation is
 unimportant.
 
 ```rzk
@@ -400,9 +419,7 @@ unimportant.
           \ t → refl)))
 ```
 
-Products distribute inside Sigma types:
-
-```rzk
+```rzk title="Products distribute inside Sigma types"
 #def distributive-product-Σ
   ( A B : U)
   ( C : B → U)
@@ -442,9 +459,9 @@ This is the dependent version of the currying equivalence.
       ((p : Σ (a : A), B a) → C (first p) (second p))
       ((a : A) → (b : B a) → C a b)
   :=
-    ( ( \ s a b → s (a, b)),
-      ( ( ( \ f (a, b) → f a b,
-            \ f → refl ),
-          ( \ f (a, b) → f a b,
+    ( ( \ s a b → s (a , b)) ,
+      ( ( ( \ f (a , b) → f a b ,
+            \ f → refl ) ,
+          ( \ f (a , b) → f a b ,
             \ s → refl ))))
 ```

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -97,7 +97,7 @@ A path in a fiber defines a path in the total space.
   := idJ (B x , u , \ v' p' → (x , u) = (x , v') , refl , v , p)
 ```
 
-The following is essentially `eq-pair` but with explicit arguments.
+The following is essentially `#!rzk eq-pair` but with explicit arguments.
 
 ```rzk
 #def path-of-pairs-pair-of-paths
@@ -143,8 +143,8 @@ The following is essentially `eq-pair` but with explicit arguments.
       e)
 ```
 
-Here we've decomposed `e : Eq-Σ s t` as `(e0, e1)` and decomposed `s` and `t`
-similarly for induction purposes.
+Here we've decomposed `#!rzk e : Eq-Σ s t` as `#!rzk (e0, e1)` and decomposed
+`#!rzk s` and `#!rzk t` similarly for induction purposes.
 
 ```rzk
 #def pair-eq-eq-pair-split
@@ -237,7 +237,7 @@ similarly for induction purposes.
 
 !!! warning
 
-    The following definition of `triple-eq`
+    The following definition of `#!rzk triple-eq`
     is the lazy definition with bad computational properties.
 
 ```rzk
@@ -256,8 +256,8 @@ similarly for induction purposes.
 ```
 
 It's surprising that the following typechecks since we defined product-transport
-by a dual path induction over both `p` and `q`, rather than by saying that when
-`p` is `refl` this is ordinary transport.
+by a dual path induction over both `#!rzk p` and `#!rzk q`, rather than by
+saying that when `#!rzk p` is `#!rzk refl` this is ordinary transport.
 
 ```rzk title="The inverse with explicit arguments"
 #def path-of-triples-to-triple-of-paths
@@ -311,7 +311,7 @@ by a dual path induction over both `p` and `q`, rather than by saying that when
       ( e))
 ```
 
-Here we've decomposed `s`, `t` and `e` for induction purposes:
+Here we've decomposed `#!rzk s`, `#!rzk t` and `#!rzk e` for induction purposes:
 
 ```rzk
 #def triple-eq-eq-triple-split

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -221,14 +221,14 @@ A retract of contractible types is contractible.
   := second (second is-retract-of-A-B)
 ```
 
-```rzk title="If $A$ is a retract of a contractible type it has a term"
+```rzk title="If A is a retract of a contractible type it has a term"
 #def is-retract-of-is-contr-isInhabited uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : A
   := is-retract-of-retraction (contraction-center B is-contr-B)
 ```
 
-```rzk title="If $A$ is a retract of a contractible type it has a contracting homotopy"
+```rzk title="If A is a retract of a contractible type it has a contracting homotopy"
 #def is-retract-of-is-contr-hasHtpy uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   ( a : A)
@@ -244,7 +244,7 @@ A retract of contractible types is contractible.
       ( is-retract-of-homotopy a)
 ```
 
-```rzk title="If $A$ is a retract of a contractible type it is contractible"
+```rzk title="If A is a retract of a contractible type it is contractible"
 #def is-contr-is-retract-of-is-contr uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : is-contr A
@@ -297,7 +297,7 @@ A retract of contractible types is contractible.
 
 For example, we prove that based path spaces are contractible.
 
-```rzk title="Transport in the space of paths starting at $a$ is concatenation"
+```rzk title="Transport in the space of paths starting at a is concatenation"
 #def concat-as-based-transport
   ( A : U)
   ( a x y : A)

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -315,7 +315,7 @@ For example, we prove that based path spaces are contractible.
       q)
 ```
 
-The center of contraction in the based path space is `(a , refl)`.
+The center of contraction in the based path space is `#!rzk (a , refl)`.
 
 ```rzk title="The center of contraction in the based path space"
 #def center-based-paths

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -8,8 +8,7 @@ This is a literate `rzk` file:
 
 ## Contractible types
 
-```rzk
--- contractible types
+```rzk title="The type of contractibility proofs"
 #def is-contr (A : U) : U
   := Σ (x : A) , ((y : A) → x = y)
 ```
@@ -25,8 +24,9 @@ This is a literate `rzk` file:
 #def contraction-center
   : A
   := (first is-contr-A)
+```
 
--- The path from the contraction center to any point.
+```rzk title="The path from the contraction center to any point"
 #def contracting-htpy
   : ( z : A) → contraction-center = z
   := second is-contr-A
@@ -45,8 +45,9 @@ This is a literate `rzk` file:
   :=
     ( left-inverse-concat A contraction-center contraction-center
       ( contracting-htpy contraction-center))
+```
 
--- A path between an arbitrary pair of types in a contractible type.
+```rzk title="A path between any pair of terms in a contractible type"
 #def contractible-connecting-htpy uses (is-contr-A)
   (x y : A)
   : x = y
@@ -73,8 +74,9 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
   ( x y : Unit)
   : x = y
   := refl
+```
 
--- Terminal projection as a constant map
+```rzk title="The terminal projection as a constant map"
 #def terminal-map
   ( A : U)
   : A → Unit
@@ -159,7 +161,7 @@ A type is contractible if and only if its terminal map is an equivalence.
       ( second
         ( comp-equiv B A Unit
           ( inv-equiv A B f)
-          ( (terminal-map A) ,
+          ( ( terminal-map A) ,
             ( contr-implies-terminal-map-is-equiv A is-contr-A)))))
 
 #def equiv-with-contractible-codomain-implies-contractible-domain
@@ -195,9 +197,7 @@ A type is contractible if and only if its terminal map is an equivalence.
 
 A retract of contractible types is contractible.
 
-```rzk
--- A type that records a proof that A is a retract of B.
--- Very similar to has-retraction.
+```rzk title="The type of proofs that A is a retract of B"
 #def is-retract-of
   ( A B : U)
   : U
@@ -206,28 +206,30 @@ A retract of contractible types is contractible.
 #section retraction-data
 
 #variables A B : U
-#variable AretractB : is-retract-of A B
+#variable is-retract-of-A-B : is-retract-of A B
 
 #def is-retract-of-section
   : A → B
-  := first AretractB
+  := first is-retract-of-A-B
 
 #def is-retract-of-retraction
   : B → A
-  := first (second AretractB)
+  := first (second is-retract-of-A-B)
 
 #def is-retract-of-homotopy
   : homotopy A A (composition A B A is-retract-of-retraction is-retract-of-section) (identity A)
-  := second (second AretractB)
+  := second (second is-retract-of-A-B)
+```
 
--- If A is a retract of a contractible type it has a term.
-#def is-retract-of-is-contr-isInhabited uses (AretractB)
+```rzk title="If $A$ is a retract of a contractible type it has a term"
+#def is-retract-of-is-contr-isInhabited uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : A
   := is-retract-of-retraction (contraction-center B is-contr-B)
+```
 
--- If A is a retract of a contractible type it has a contracting homotopy.
-#def is-retract-of-is-contr-hasHtpy uses (AretractB)
+```rzk title="If $A$ is a retract of a contractible type it has a contracting homotopy"
+#def is-retract-of-is-contr-hasHtpy uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   ( a : A)
   : ( is-retract-of-is-contr-isInhabited is-contr-B) = a
@@ -240,23 +242,24 @@ A retract of contractible types is contractible.
         ( is-retract-of-retraction)
         ( contracting-htpy B is-contr-B (is-retract-of-section a)))
       ( is-retract-of-homotopy a)
+```
 
--- If A is a retract of a contractible type it is contractible.
-#def is-retract-of-is-contr-is-contr uses (AretractB)
+```rzk title="If $A$ is a retract of a contractible type it is contractible"
+#def is-contr-is-retract-of-is-contr uses (is-retract-of-A-B)
   ( is-contr-B : is-contr B)
   : is-contr A
   :=
     ( is-retract-of-is-contr-isInhabited is-contr-B ,
       is-retract-of-is-contr-hasHtpy is-contr-B)
+```
 
+```rzk
 #end retraction-data
 ```
 
 ## Functions between contractible types
 
-A function between contractible types is an equivalence
-
-```rzk
+```rzk title="Any function between contractible types is an equivalence"
 #def is-equiv-are-contr
   ( A B : U)
   ( is-contr-A : is-contr A)
@@ -271,23 +274,21 @@ A function between contractible types is an equivalence
                 (f (contraction-center A is-contr-A)) b))
 ```
 
-A type equivalent to a contractible type is contractible.
-
-```rzk
+```rzk title="A type equivalent to a contractible type is contractible"
 #def is-contr-is-equiv-to-contr
   ( A B : U)
   ( e : Equiv A B)
   ( is-contr-B : is-contr B)
   : is-contr A
   :=
-    is-retract-of-is-contr-is-contr A B (first e , first (second e)) is-contr-B
+    is-contr-is-retract-of-is-contr A B (first e , first (second e)) is-contr-B
 
 #def is-contr-is-equiv-from-contr
   ( A B : U)
   ( e : Equiv A B)
   ( is-contr-A : is-contr A)
   : is-contr B
-  := is-retract-of-is-contr-is-contr B A
+  := is-contr-is-retract-of-is-contr B A
       ( first (second (second e)) , (first e , second (second (second e))))
       ( is-contr-A)
 ```
@@ -296,13 +297,12 @@ A type equivalent to a contractible type is contractible.
 
 For example, we prove that based path spaces are contractible.
 
-```rzk
--- Transport in the space of paths starting at a is concatenation.
+```rzk title="Transport in the space of paths starting at $a$ is concatenation"
 #def concat-as-based-transport
-  ( A : U)             -- The ambient type.
-  ( a x y : A)         -- The basepoint and two other points.
-  ( p : a = x)         -- An element of the based path space.
-  ( q : x = y)         -- A path in the base.
+  ( A : U)
+  ( a x y : A)
+  ( p : a = x)
+  ( q : x = y)
   : ( transport A (\ z → (a = z)) x y q p) = (concat A a x y p q)
   :=
     idJ
@@ -313,37 +313,42 @@ For example, we prove that based path spaces are contractible.
       refl ,
       y ,
       q)
+```
 
--- The center of contraction in the based path space is `(a , refl)`
-#def based-paths-center
-  ( A : U)         -- The ambient type.
-  ( a : A)         -- The basepoint.
+The center of contraction in the based path space is `(a , refl)`.
+
+```rzk title="The center of contraction in the based path space"
+#def center-based-paths
+  ( A : U)
+  ( a : A)
   : Σ (x : A) , (a = x)
-  := ( a , refl)
+  := (a , refl)
+```
 
--- The contracting homotopy.
-#def based-paths-contracting-homotopy
-  ( A : U)                     -- The ambient type.
-  ( a : A)                     -- The basepoint.
-  ( p : Σ (x : A) , a = x)      -- Another based path.
-  : (based-paths-center A a) = p
+```rzk title="The contracting homotopy in the based path space"
+#def contracting-homotopy-based-paths
+  ( A : U)
+  ( a : A)
+  ( p : Σ (x : A) , a = x)
+  : (center-based-paths A a) = p
   :=
     path-of-pairs-pair-of-paths
       A ( \ z → a = z) a (first p) (second p) (refl) (second p)
-        (concat
-          ( a = (first p))
-          ( transport A (\ z → (a = z)) a (first p) (second p) (refl))
-          ( concat A a a (first p) (refl) (second p))
-          ( second p)
-          ( concat-as-based-transport A a a (first p) (refl) (second p))
-          ( left-unit-concat A a (first p) (second p)))
+      ( concat
+        ( a = (first p))
+        ( transport A (\ z → (a = z)) a (first p) (second p) (refl))
+        ( concat A a a (first p) (refl) (second p))
+        ( second p)
+        ( concat-as-based-transport A a a (first p) (refl) (second p))
+        ( left-unit-concat A a (first p) (second p)))
+```
 
--- Based path spaces are contractible
+```rzk title="Based path spaces are contractible"
 #def is-contr-based-paths
-  ( A : U)         -- The ambient type.
-  ( a : A)         -- The basepoint.
+  ( A : U)
+  ( a : A)
   : is-contr (Σ (x : A) , a = x)
-  := ( based-paths-center A a , based-paths-contracting-homotopy A a)
+  := (center-based-paths A a , contracting-homotopy-based-paths A a)
 ```
 
 ## Contractible products
@@ -430,12 +435,21 @@ A type is contractible if and only if it has singleton induction.
   ( a : A)
   ( B : A → U)
   ( singleton-ind-A : has-singleton-induction-pointed A a B)
-  : ( homotopy (B a) (B a) (composition (B a) ((x : A) → B x) (B a) (ev-pt A a B) (ind-sing A a B singleton-ind-A)) (identity (B a)))
+  : ( homotopy
+      ( B a)
+      ( B a)
+      ( composition
+        ( B a)
+        ( (x : A) → B x)
+        ( B a)
+        ( ev-pt A a B)
+        ( ind-sing A a B singleton-ind-A))
+      ( identity (B a)))
   := (second singleton-ind-A)
 
 #def contr-implies-singleton-induction-ind
   ( A : U)
-  (is-contr-A : is-contr A)
+  ( is-contr-A : is-contr A)
   : (has-singleton-induction A)
   :=
     ( ( contraction-center A is-contr-A) ,

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -112,7 +112,7 @@ Contractible maps are equivalences:
 
 We now show that half adjoint equivalences are contractible maps.
 
-```rzk title="If $f$ is a half adjoint equivalence, its fibers are inhabited"
+```rzk title="If f is a half adjoint equivalence, its fibers are inhabited"
 #def is-surj-is-half-adjoint-equiv
   (A B : U)
   (f : A → B)

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -148,7 +148,7 @@ this homotopy is straightforward.
       ( (first (second (first fisHAE))) (first z))
 ```
 
-Specializing the above to `isHAE-fib-base-path`:
+Specializing the above to `#!rzk isHAE-fib-base-path`:
 
 ```rzk
 #def isHAE-fib-base-path-transport

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -10,16 +10,18 @@ This is a literate `rzk` file:
 
 The homotopy fiber of a map is the following type:
 
-```rzk
--- The fiber of a map
+```rzk title="The fiber of a map"
 #def fib
   (A B : U)
   (f : A → B)
   (b : B)
   : U
   := Σ (a : A) , (f a) = b
+```
 
--- We calculate the transport of (a , q) : fib b along p : a = a'
+We calculate the transport of (a , q) : fib b along p : a = a':
+
+```rzk
 #def transport-in-fiber
   (A B : U)
   (f : A → B)
@@ -46,8 +48,7 @@ The homotopy fiber of a map is the following type:
 
 A map is contractible just when its fibers are contractible.
 
-```rzk
--- Contractible maps
+```rzk title="Contractible maps"
 #def is-contr-map
   (A B : U)
   (f : A → B)
@@ -63,8 +64,9 @@ Contractible maps are equivalences:
 #variables A B : U
 #variable f : A → B
 #variable is-contr-f : is-contr-map A B f
+```
 
--- The inverse to a contractible map
+```rzk title="The inverse to a contractible map"
 #def is-contr-map-inverse
   : B → A
   := \ b → first (contraction-center (fib A B f b) (is-contr-f b))
@@ -106,16 +108,15 @@ Contractible maps are equivalences:
 #end is-contr-map-is-equiv
 ```
 
-## Half adjoint equivalences are contractible.
+## Half adjoint equivalences are contractible
 
 We now show that half adjoint equivalences are contractible maps.
 
-```rzk
--- If f is a half adjoint equivalence, its fibers are inhabited.
+```rzk title="If $f$ is a half adjoint equivalence, its fibers are inhabited"
 #def is-surj-is-half-adjoint-equiv
   (A B : U)
   (f : A → B)
-  (fisHAE : is-half-adjoint-equiv A B f) -- first fisHAE : has-inverse A B f
+  (fisHAE : is-half-adjoint-equiv A B f)
   (b : B)
   : fib A B f b
   :=
@@ -145,8 +146,11 @@ this homotopy is straightforward.
       ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
         ( rev B (f (first z)) b (second z)))
       ( (first (second (first fisHAE))) (first z))
+```
 
--- Specializing the above to isHAE-fib-base-path
+Specializing the above to `isHAE-fib-base-path`:
+
+```rzk
 #def isHAE-fib-base-path-transport
   : transport A (\ x → (f x) = b)
       ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -15,14 +15,14 @@ maps.
 #def total-map-family-of-maps
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
-  : (Σ (x : A) , B x) → (Σ (x : A) , C x)      -- the induced map on total spaces
+  (f : (a : A) → (B a) → (C a))
+  : (Σ (x : A) , B x) → (Σ (x : A) , C x)
   := \ z → (first z , f (first z) (second z))
 
 #def total-map-to-fiber
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : fib (B (first w)) (C (first w)) (f (first w)) (second w) →
     ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
@@ -34,7 +34,7 @@ maps.
 #def total-map-from-fiber
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : (fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
     → fib (B (first w)) (C (first w)) (f (first w)) (second w)
@@ -74,7 +74,7 @@ maps.
 #def total-map-to-fiber-section
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : has-section
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -97,7 +97,7 @@ maps.
 #def total-map-to-fiber-is-equiv
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : is-equiv
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -111,7 +111,7 @@ maps.
 #def total-map-fiber-equiv
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))             -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (w : (Σ (x : A) , C x))
   : Equiv
     ( fib (B (first w)) (C (first w)) (f (first w)) (second w))
@@ -224,7 +224,7 @@ implication could be proven similarly.
 #def total-contr-map-family-of-contr-maps
   ( A : U)
   ( B C : A → U)
-  ( f : (a : A) → (B a) → (C a))                         -- a family of maps
+  ( f : (a : A) → (B a) → (C a))
   ( totalcontrmap :
     is-contr-map
       ( Σ (x : A) , B x)
@@ -244,7 +244,7 @@ implication could be proven similarly.
 #def total-equiv-family-of-equiv
   (A : U)
   (B C : A → U)
-  (f : (a : A) → (B a) → (C a))                         -- a family of maps
+  (f : (a : A) → (B a) → (C a))
   (totalequiv : is-equiv
                 ( Σ (x : A) , B x)
                 ( Σ (x : A) , C x)
@@ -282,18 +282,20 @@ equivalence.
   (x y : A)
   : Equiv (x = y) (y = x)
   := (rev A x y , ((rev A y x , rev-rev A x y) , (rev A y x , rev-rev A y x)))
+```
 
--- An equivalence between the based path spaces.
+```rzk title="An equivalence between the based path spaces"
 #def equiv-based-paths
   ( A : U)
   (a : A)
   : Equiv (Σ (x : A) , x = a) (Σ (x : A) , a = x)
   := total-equiv-family-equiv A (\ x → x = a) (\ x → a = x) (\ x → equiv-rev A x a)
+```
 
--- Codomain based path spaces are contractible
+```rzk title="Codomain based path spaces are contractible"
 #def is-contr-codomain-based-paths
-  (A : U)         -- The ambient type.
-  (a : A)         -- The basepoint.
+  (A : U)
+  (a : A)
   : is-contr (Σ (x : A) , x = a)
   :=
     is-contr-is-equiv-to-contr (Σ (x : A) , x = a) (Σ (x : A) , a = x)
@@ -582,9 +584,12 @@ equivalence of total spaces.
             ( is-contr-based-paths A a) is-contr-B
             ( total-map-family-of-maps A ( \ x' → (a = x')) B f))
           x)))
+```
 
--- This allows us to apply "based path induction"
--- to a family satisfying the fundamental theorem.
+This allows us to apply "based path induction" to a family satisfying the
+fundamental theorem:
+
+```rzk
 -- Please suggest a better name.
 #def ind-based-path
   (familyequiv : (z : A) → (is-equiv (a = z) (B z) (f z)))
@@ -619,39 +624,47 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
   :=
     ( e ,
       \ x y →
-          ( fund-id-sum-over-codomain-contr-implies-fam-of-eqs
-  -- By the fundamental theorem of identity types, it will suffice to show
-  -- contractibility of sigma_{t : A} e x = e t
-  -- for the family of maps ap_e, which is of type
-  -- (\t:A) → (x = t) → (e x = e t)
-            A
-            x
-            ( \ t → (e x = e t))
-            ( \ t → (ap A B x t e)) -- the family of maps ap_e
-            ( (is-contr-is-equiv-to-contr
-  -- Contractibility of sigma_{t : A} e x = e t will follow since
-  -- total (\ t → rev B (e x) = (e t)), mapping from sigma_{t : A} e x = e t to
-  -- sigma_{t : A} e t = e x
-  -- is an equivalence, and `Σ_{t : A} e t = e x ~ fib (e , e x)` is
-  -- contractible since e is an equivalence.
-                (Σ (y' : A) , (e x = e y')) -- source type
-                (Σ (y' : A) , (e y' = e x)) -- target type
-                ((total-map-family-of-maps A
-                  ( \ y' → (e x) = (e y'))
-                  ( \ y' → (e y') = (e x))
-                  ( \ y' → (rev B (e x) (e y')))) , -- a) total map
+      ( fund-id-sum-over-codomain-contr-implies-fam-of-eqs
+```
 
-                ( -- b) proof that total map is equivalence
-                  ( first
-                    ( total-equiv-iff-family-of-equiv A
-                    ( \ y' → (e x) = (e y'))
-                    ( \ y' → (e y') = (e x))
-                    ( \ y' → (rev B (e x) (e y')))))
-                  ( \ y' → (is-equiv-rev B (e x) (e y')))))
-                ( -- fiber of e at e(x) is contractible
-                  (is-contr-map-is-equiv A B e is-equiv-e) (e x))))) (y))
-                  -- evaluate at y
+By the fundamental theorem of identity types, it will suffice to show
+contractibility of `Σ_{t : A} e x = e t` for the family of maps `ap_e`, which is
+of type `(t : A) → (x = t) → (e x = e t)`:
 
+```rzk
+        ( A)
+        ( x)
+        ( \ t → (e x = e t))
+        ( \ t → (ap A B x t e))
+        ( ( is-contr-is-equiv-to-contr
+```
+
+Contractibility of `Σ_{t : A} e x = e t` will follow since
+`total (\ t → rev B (e x) = (e t))`, mapping from `Σ_{t : A} e x = e t` to
+`Σ_{t : A} e t = e x` is an equivalence, and
+`Σ_{t : A} e t = e x ~ fib (e , e x)` is contractible since `e` is an
+equivalence.
+
+```rzk
+            ( Σ (y' : A) , (e x = e y')) -- source type
+            ( Σ (y' : A) , (e y' = e x)) -- target type
+            ( ( total-map-family-of-maps A
+                ( \ y' → (e x) = (e y'))
+                ( \ y' → (e y') = (e x))
+                ( \ y' → (rev B (e x) (e y')))) , -- a) total map
+        ( -- b) proof that total map is equivalence
+          ( first
+            ( total-equiv-iff-family-of-equiv A
+              ( \ y' → (e x) = (e y'))
+              ( \ y' → (e y') = (e x))
+              ( \ y' → (rev B (e x) (e y')))))
+          ( \ y' → (is-equiv-rev B (e x) (e y')))))
+        ( -- fiber of e at e(x) is contractible
+          ( is-contr-map-is-equiv A B e is-equiv-e) (e x))))) (y))
+          -- evaluate at y
+```
+
+```rzk
 #def is-emb-is-equiv
   (A B : U)
   (e : A → B)

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -613,7 +613,8 @@ fundamental theorem:
 #end fundamental-thm-id-types
 ```
 
-For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
+For all `#!rzk x` , `#!rzk y` in `#!rzk A`, `#!rzk ap_{e ,x ,y}` is an
+equivalence.
 
 ```rzk
 #def emb-is-equiv
@@ -628,8 +629,8 @@ For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
 ```
 
 By the fundamental theorem of identity types, it will suffice to show
-contractibility of `Σ_{t : A} e x = e t` for the family of maps `ap_e`, which is
-of type `(t : A) → (x = t) → (e x = e t)`:
+contractibility of `#!rzk Σ_{t : A} e x = e t` for the family of maps
+`#!rzk ap_e`, which is of type `#!rzk (t : A) → (x = t) → (e x = e t)`:
 
 ```rzk
         ( A)
@@ -639,11 +640,11 @@ of type `(t : A) → (x = t) → (e x = e t)`:
         ( ( is-contr-is-equiv-to-contr
 ```
 
-Contractibility of `Σ_{t : A} e x = e t` will follow since
-`total (\ t → rev B (e x) = (e t))`, mapping from `Σ_{t : A} e x = e t` to
-`Σ_{t : A} e t = e x` is an equivalence, and
-`Σ_{t : A} e t = e x ~ fib (e , e x)` is contractible since `e` is an
-equivalence.
+Contractibility of `#!rzk Σ_{t : A} e x = e t` will follow since
+`#!rzk total (\ t → rev B (e x) = (e t))`, mapping from
+`#!rzk Σ_{t : A} e x = e t` to `#!rzk Σ_{t : A} e t = e x` is an equivalence,
+and `#!rzk Σ_{t : A} e t = e x ~ fib (e , e x)` is contractible since `#!rzk e`
+is an equivalence.
 
 ```rzk
             ( Σ (y' : A) , (e x = e y')) -- source type

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -59,7 +59,7 @@ The following type asserts that the fibers of a type family are contractible.
 ```
 
 This can be used to define the retraction homotopy for the total space
-projection, called `first` here:
+projection, called `#!rzk first` here:
 
 ```rzk
 #def contractible-fibers-retraction-htpy

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -32,30 +32,36 @@ The following type asserts that the fibers of a type family are contractible.
 
 #variable A : U
 #variable B : A → U
-#variable ABcontrfib : contractible-fibers A B
+#variable contractible-fibers-A-B : contractible-fibers A B
+```
 
--- The center of contraction in a contractible fibers
+```rzk title="The center of contraction in contractible fibers"
 #def contractible-fibers-section
   : (x : A) → B x
-  := \ x → contraction-center (B x) (ABcontrfib x)
+  := \ x → contraction-center (B x) (contractible-fibers-A-B x)
+```
 
--- The section of the total space projection built from the contraction centers
-#def contractible-fibers-actual-section uses (ABcontrfib)
+```rzk title="The section of the total space projection built from the contraction centers"
+#def contractible-fibers-actual-section uses (contractible-fibers-A-B)
   : (a : A) → Σ (x : A) , B x
   := \ a → (a , contractible-fibers-section a)
 
-#def contractible-fibers-section-htpy uses (ABcontrfib)
+#def contractible-fibers-section-htpy uses (contractible-fibers-A-B)
   : homotopy A A
     ( composition A (Σ (x : A) , B x) A
       ( total-space-projection A B) (contractible-fibers-actual-section))
     ( identity A)
   := \ x → refl
 
-#def contractible-fibers-section-is-section uses (ABcontrfib)
+#def contractible-fibers-section-is-section uses (contractible-fibers-A-B)
   : has-section (Σ (x : A) , B x) A (total-space-projection A B)
-  := ( contractible-fibers-actual-section , contractible-fibers-section-htpy)
+  := (contractible-fibers-actual-section , contractible-fibers-section-htpy)
+```
 
--- This can be used to define the retraction homotopy for the total space projection, called "first" here
+This can be used to define the retraction homotopy for the total space
+projection, called `first` here:
+
+```rzk
 #def contractible-fibers-retraction-htpy
   : (z : Σ (x : A) , B x) →
       (contractible-fibers-actual-section) (first z) = z
@@ -64,18 +70,21 @@ The following type asserts that the fibers of a type family are contractible.
         ( first z)
         ( (contractible-fibers-section) (first z))
         ( second z)
-        ( contracting-htpy (B (first z)) (ABcontrfib (first z)) (second z))
+        ( contracting-htpy (B (first z)) (contractible-fibers-A-B (first z)) (second z))
 
-#def contractible-fibers-retraction uses (ABcontrfib)
+#def contractible-fibers-retraction uses (contractible-fibers-A-B)
   : has-retraction (Σ (x : A) , B x) A (total-space-projection A B)
   := (contractible-fibers-actual-section , contractible-fibers-retraction-htpy)
+```
 
--- The first half of our main result:
-#def is-equiv-projection-contractible-fibers uses (ABcontrfib)
+The first half of our main result:
+
+```rzk
+#def is-equiv-projection-contractible-fibers uses (contractible-fibers-A-B)
   : is-equiv (Σ (x : A) , B x) A (total-space-projection A B)
   := (contractible-fibers-retraction , contractible-fibers-section-is-section)
 
-#def equiv-projection-contractible-fibers uses (ABcontrfib)
+#def equiv-projection-contractible-fibers uses (contractible-fibers-A-B)
   : Equiv (Σ (x : A) , B x) A
   := (total-space-projection A B , is-equiv-projection-contractible-fibers)
 
@@ -84,39 +93,49 @@ The following type asserts that the fibers of a type family are contractible.
 
 ## Projection equivalences
 
+From a projection equivalence, it's not hard to inhabit fibers:
+
 ```rzk
--- From a projection equivalence, it's not hard to inhabit fibers
 #def inhabited-fibers-is-equiv-projection
-  (A : U)
-  (B : A → U)
-  (ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
-  (a : A)
+  ( A : U)
+  ( B : A → U)
+  ( ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
+  ( a : A)
   : B a
   :=
     transport A B (first ((first (second ABprojequiv)) a)) a
       ( (second (second ABprojequiv)) a)
       ( second ((first (second ABprojequiv)) a))
+```
 
--- This is great but we need more coherence to show that the inhabited fibers
--- are contractible; the following proof fails
--- #def is-equiv-projection-implies-contractible-fibers
---    (A : U)
---    (B : A → U)
---    (ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
---    : contractible-fibers A B
---    :=
---      \ x → (second ((first (first ABprojequiv)) x) ,
---      \ u → second-path-Σ A B ((first (first ABprojequiv)) x) (x , u)
---             ( (second (first ABprojequiv)) (x , u)) )
+This is great but we need more coherence to show that the inhabited fibers are
+contractible; the following proof fails:
 
+```text
+#def is-equiv-projection-implies-contractible-fibers
+  ( A : U)
+  ( B : A → U)
+  ( ABprojequiv : is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
+  : contractible-fibers A B
+  :=
+    ( \ x → (second (first (first ABprojequiv) x) ,
+      ( \ u →
+        second-path-Σ A B (first (first ABprojequiv) x) (x , u)
+          ( second (first ABprojequiv) (x , u)))))
+```
+
+```rzk
 #section projection-hae-data
 #variable A : U
 #variable B : A → U
 #variable ABprojHAE :
   is-half-adjoint-equiv (Σ (x : A) , B x) A (total-space-projection A B)
 #variable w : (Σ (x : A) , B x)
+```
 
--- We start over from a stronger hypothesis of a half adjoint equivalence
+We start over from a stronger hypothesis of a half adjoint equivalence.
+
+```rzk
 #def projection-hae-inverse
   (a : A)
   : Σ (x : A) , B x
@@ -185,8 +204,11 @@ The following type asserts that the fibers of a type family are contractible.
       ( projection-hae-fibered-htpy)
 
 #end projection-hae-data
+```
 
--- Finally we have
+Finally, we have:
+
+```rzk
 #def contractible-fibers-is-half-adjoint-equiv-projection
   (A : U)
   (B : A → U)
@@ -196,8 +218,9 @@ The following type asserts that the fibers of a type family are contractible.
     \ x →
       ( (projection-hae-section A B ABprojHAE x) ,
         \ u → (projection-hae-fibered-contracting-htpy A B ABprojHAE (x , u)))
+```
 
--- The converse to our first result
+```rzk title="The converse to our first result"
 #def contractible-fibers-is-equiv-projection
   (A : U)
   (B : A → U)
@@ -207,8 +230,9 @@ The following type asserts that the fibers of a type family are contractible.
     contractible-fibers-is-half-adjoint-equiv-projection A B
       ( is-half-adjoint-equiv-is-equiv (Σ (x : A) , B x) A
         ( total-space-projection A B) ABprojequiv)
+```
 
--- The main theorem
+```rzk title="The main theorem"
 #def projection-theorem
   (A : U)
   (B : (a : A) → U)
@@ -216,6 +240,8 @@ The following type asserts that the fibers of a type family are contractible.
     ( is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
     ( contractible-fibers A B)
   :=
-    ( \ ABprojequiv → contractible-fibers-is-equiv-projection A B ABprojequiv ,
-      \ ABcontrfib → is-equiv-projection-contractible-fibers A B ABcontrfib)
+    ( \ ABprojequiv →
+      contractible-fibers-is-equiv-projection A B ABprojequiv ,
+      \ contractible-fibers-A-B →
+      is-equiv-projection-contractible-fibers A B contractible-fibers-A-B)
 ```

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -12,28 +12,29 @@ This is a literate `rzk` file:
 
 ### Simplices
 
-```rzk
--- the 1-simplex
+```rzk title="The 1-simplex"
 #def Δ¹ : 2 → TOPE
   := \ t → TOP
+```
 
--- the 2-simplex
+```rzk title="The 2-simplex"
 #def Δ² : (2 × 2) → TOPE
   := \ (t , s) → s ≤ t
+```
 
--- the 3-simplex
+```rzk title="The 3-simplex"
 #def Δ³ : (2 × 2 × 2) → TOPE
   := \ ((t1 , t2) , t3) → t3 ≤ t2 ∧ t2 ≤ t1
 ```
 
 ### Boundaries of simplices
 
-```rzk
--- the boundary of a 1-simplex
+```rzk title="The boundary of a 1-simplex"
 #def ∂Δ¹ : Δ¹ → TOPE
   := \ t → (t ≡ 0₂ ∨ t ≡ 1₂)
+```
 
--- the boundary of a 2-simplex
+```rzk title="The boundary of a 2-simplex"
 #def ∂Δ² : Δ² → TOPE
   :=
     \ (t, s) → (s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
@@ -57,31 +58,36 @@ The product of topes defines the product of shapes.
   ( χ : J → TOPE)
   : (I × J) → TOPE
   := \ (t , s) → ψ t ∧ χ s
+```
 
--- the square as a product
+```rzk title="The square as a product"
 #def Δ¹×Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ Δ¹
+```
 
--- the total boundary of the square
+```rzk title="The total boundary of the square"
 #def ∂□ : (2 × 2) → TOPE
   := \ (t ,s) → ((∂Δ¹ t) ∧ (Δ¹ s)) ∨ ((Δ¹ t) ∧ (∂Δ¹ s))
+```
 
--- the vertical boundary of the square
+```rzk title="The vertical boundary of the square"
 #def ∂Δ¹×Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 ∂Δ¹ Δ¹
+```
 
--- the horizontal boundary of the square
+```rzk title="The horizontal boundary of the square"
 #def Δ¹×∂Δ¹ : (2 × 2) → TOPE
   := shape-prod 2 2 Δ¹ ∂Δ¹
+```
 
--- the prism from a 2-simplex in an arrow type
+```rzk title="The prism from a 2-simplex in an arrow type"
 #def Δ²×Δ¹ : (2 × 2 × 2) → TOPE
   := shape-prod (2 × 2) 2 Δ² Δ¹
 ```
 
 ### Intersections
 
-The intersection of shapes is defined by conjunction on topes:
+The intersection of shapes is defined by conjunction on topes.
 
 ```rzk
 #def shape-intersection
@@ -91,7 +97,7 @@ The intersection of shapes is defined by conjunction on topes:
 
 ### Unions
 
-The union of shapes is defined by disjunction on topes:
+The union of shapes is defined by disjunction on topes.
 
 ```rzk
 #def shapeUnion

--- a/src/simplicial-hott/03-simplicial-type-theory.rzk.md
+++ b/src/simplicial-hott/03-simplicial-type-theory.rzk.md
@@ -36,8 +36,7 @@ This is a literate `rzk` file:
 -- the boundary of a 2-simplex
 #def ∂Δ² : Δ² → TOPE
   :=
-    \ (t, s) →
-    ( s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
+    \ (t, s) → (s ≡ 0₂ ∨ t ≡ 1₂ ∨ s ≡ t)
 ```
 
 ### The inner horn
@@ -53,9 +52,9 @@ The product of topes defines the product of shapes.
 
 ```rzk
 #def shape-prod
-  (I J : CUBE)
-  (ψ : I → TOPE)
-  (χ : J → TOPE)
+  ( I J : CUBE)
+  ( ψ : I → TOPE)
+  ( χ : J → TOPE)
   : (I × J) → TOPE
   := \ (t , s) → ψ t ∧ χ s
 

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -242,8 +242,9 @@ footnote 8, we assert this as an "extension extensionality" axiom
       ( ext-htpy-eq I ψ ϕ A a f g)
 
 #assume extext : ExtExt
+```
 
--- The equivalence provided by extension extensionality.
+```rzk title="The equivalence provided by extension extensionality"
 #def equiv-ExtExt uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)
@@ -272,11 +273,9 @@ identifications. This definition defines `eq-ext-htpy` to be the retraction to
 ```
 
 By extension extensionality, fiberwise equivalences of extension types define
-equivalences of extension types.
+equivalences of extension types. For simplicity, we extend from `BOT`.
 
 ```rzk
--- A fiberwise equivalence defines an equivalence of extension types, for
--- simplicity extending from BOT
 #def equiv-extension-equiv-fibered uses (extext)
   ( I : CUBE)
   ( ψ : I → TOPE)

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -45,10 +45,10 @@ This is a literate `rzk` file:
     ( (x : X) → (t : ψ) → Y t x [ ϕ t ↦ f t x])
     ( (t : ψ) → ((x : X) → Y t x) [ ϕ t ↦ f t ])
   :=
-    ( \ h t x → (h x) t , -- the one-way map
-      ( ( \ g x t → g t x , -- the retraction
-          \ h → refl) , -- the retracting homotopy
-        ( \ g x t → g t x , -- the section
+    ( \ h t x → (h x) t ,
+      ( ( \ g x t → g t x ,
+          \ h → refl) ,
+        ( \ g x t → g t x ,
           \ g → refl)))
 ```
 
@@ -67,11 +67,11 @@ This is a literate `rzk` file:
     ( ((t , s) : I × J | ψ t ∧ ζ s) → X t s
       [(ϕ t ∧ ζ s) ∨ (ψ t ∧ χ s) ↦ f (t , s)])
   :=
-    ( \ g (t , s) → (g t) s , -- the one way map
-      ( ( \ h t s → h (t , s) , -- its retraction
-          \ g → refl) , -- the retracting homotopy
-        ( \ h t s → h (t , s) , -- its section
-          \ h → refl)))  -- the section homotopy
+    ( \ g (t , s) → (g t) s ,
+      ( ( \ h t s → h (t , s) ,
+          \ g → refl) ,
+        ( \ h t s → h (t , s) ,
+          \ h → refl)))
 
 #def uncurry-opcurry
   ( I J : CUBE)
@@ -143,26 +143,9 @@ This is a literate `rzk` file:
 
 ## Composites and unions of cofibrations
 
-```rzk title="RS17, Theorem 4.4"
--- Reformulated via tope disjunction instead of inclusion.
--- See https://github.com/rzk-lang/rzk/issues/8
-#def cofibration-composition'
-  ( I : CUBE)
-  ( χ ψ ϕ : I → TOPE)
-  ( X : χ → U)
-  ( a : (t : I | χ t ∧ ψ t ∧ ϕ t) → X t )
-  : Equiv
-      ( (t : χ) → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ])
-      ( Σ ( f : (t : I | χ t ∧ ψ t) → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ]) ,
-          ( (t : χ) → X t [ χ t ∧ ψ t ↦ f t ]))
-  :=
-    ( \ h → (\ t → h t , \ t → h t) ,
-      ( ( \ (_f, g) t → g t , \ h → refl) ,
-        ( \ (_f, g) t → g t , \ h → refl)))
-```
+The original form.
 
 ```rzk title="RS17, Theorem 4.4"
--- original form
 #def cofibration-composition
   ( I : CUBE)
   ( χ : I → TOPE)
@@ -178,6 +161,25 @@ This is a literate `rzk` file:
     ( \ h → (\ t → h t , \ t → h t) ,
       ( ( \ (_f, g) t → g t , \ h → refl) ,
         ( ( \ (_f, g) t → g t , \ h → refl))))
+```
+
+A reformulated version via tope disjunction instead of inclusion (see
+<https://github.com/rzk-lang/rzk/issues/8>).
+
+```rzk title="RS17, Theorem 4.4"
+#def cofibration-composition'
+  ( I : CUBE)
+  ( χ ψ ϕ : I → TOPE)
+  ( X : χ → U)
+  ( a : (t : I | χ t ∧ ψ t ∧ ϕ t) → X t )
+  : Equiv
+      ( (t : χ) → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ])
+      ( Σ ( f : (t : I | χ t ∧ ψ t) → X t [ χ t ∧ ψ t ∧ ϕ t ↦ a t ]) ,
+          ( (t : χ) → X t [ χ t ∧ ψ t ↦ f t ]))
+  :=
+    ( \ h → (\ t → h t , \ t → h t) ,
+      ( ( \ (_f, g) t → g t , \ h → refl) ,
+        ( \ (_f, g) t → g t , \ h → refl)))
 ```
 
 ```rzk title="RS17, Theorem 4.5"

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -10,7 +10,8 @@ This is a literate `rzk` file:
 
 ## Prerequisites
 
-- `hott/4-equivalences.rzk` — contains the definitions of `Eq` and `comp-equiv`
+- `hott/4-equivalences.rzk` — contains the definitions of `#!rzk Equiv` and
+  `#!rzk comp-equiv`
 - the file `hott/4-equivalences.rzk` relies in turn on the previous files in
   `hott/`
 
@@ -257,8 +258,8 @@ footnote 8, we assert this as an "extension extensionality" axiom
 ```
 
 In particular, extension extensionality implies that homotopies give rise to
-identifications. This definition defines `eq-ext-htpy` to be the retraction to
-`ext-htpy-eq`.
+identifications. This definition defines `#!rzk eq-ext-htpy` to be the
+retraction to `#!rzk ext-htpy-eq`.
 
 ```rzk
 #def eq-ext-htpy uses (extext)
@@ -273,7 +274,7 @@ identifications. This definition defines `eq-ext-htpy` to be the retraction to
 ```
 
 By extension extensionality, fiberwise equivalences of extension types define
-equivalences of extension types. For simplicity, we extend from `BOT`.
+equivalences of extension types. For simplicity, we extend from `#!rzk BOT`.
 
 ```rzk
 #def equiv-extension-equiv-fibered uses (extext)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -13,8 +13,9 @@ This is a literate `rzk` file:
 - `hott/1-paths.md` - We require basic path algebra.
 - `hott/2-contractible.md` - We require the notion of contractible types and
   their data.
-- `hott/total-space.md` — We rely on `is-equiv-projection-contractible-fibers`
-  and `total-space-projection` in the proof of Theorem 5.5.
+- `hott/total-space.md` — We rely on
+  `#!rzk is-equiv-projection-contractible-fibers` and
+  `#!rzk total-space-projection` in the proof of Theorem 5.5.
 - `3-simplicial-type-theory.md` — We rely on definitions of simplicies and their
   subshapes.
 - `4-extension-types.md` — We use the fubini theorem and extension
@@ -96,7 +97,7 @@ also requires homotopical uniqueness of higher-order composites.
 
 Segal types have a composition functor and witnesses to the composition
 relation. Composition is written in diagrammatic order to match the order of
-arguments in `is-segal`.
+arguments in `#!rzk is-segal`.
 
 ```rzk
 #def Segal-comp
@@ -172,8 +173,8 @@ composite equals $h$.
 
 ## Characterizing Segal types
 
-Our aim is to prove that a type is Segal if and only if the `horn-restriction`
-map, defined below, is an equivalence.
+Our aim is to prove that a type is Segal if and only if the
+`#!rzk horn-restriction` map, defined below, is an equivalence.
 
 <svg style="float: right" viewBox="0 0 200 180" width="150" height="150">
   <polyline points="40,30 160,30" stroke="black" stroke-width="3" marker-end="url(#arrow)"></polyline>
@@ -297,8 +298,8 @@ witnesses of the equivalence).
               ( \ t → k (t , 0₂)) (\ t → k (1₂ , t)))))
 ```
 
-We verify that the mapping in `Segal-equiv-horn-restriction A is-segal-A` is
-exactly `horn-restriction A`.
+We verify that the mapping in `#!rzk Segal-equiv-horn-restriction A is-segal-A`
+is exactly `#!rzk horn-restriction A`.
 
 ```rzk
 #def test-Segal-equiv-horn-restriction
@@ -673,7 +674,7 @@ For use in the proof of associativity:
   := unfolding-square A (Segal-comp-witness A is-segal-A x y z f g)
 ```
 
-The `Segal-comp-witness-square` as an arrow in the arrow type:
+The `#!rzk Segal-comp-witness-square` as an arrow in the arrow type:
 
 <svg style="float: right" viewBox="0 0 200 200" width="150" height="150">
   <polyline points="170,45 170,160" stroke="black" stroke-width="3" marker-end="url(#arrow)"></polyline>
@@ -765,9 +766,9 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
   <text x="140" y="205">h</text>
 </svg>
 
-The `Segal-associativity-witness` curries to define a diagram $Δ²×Δ¹ → A$. The
-`Segal-associativity-tetrahedron` is extracted via the middle-simplex map
-$((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
+The `#!rzk Segal-associativity-witness` curries to define a diagram $Δ²×Δ¹ → A$.
+The `#!rzk Segal-associativity-tetrahedron` is extracted via the middle-simplex
+map $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
 
 ```rzk
 #def Segal-associativity-tetrahedron uses (extext)
@@ -802,7 +803,7 @@ $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
 </svg>
 
 The diagonal composite of three arrows extracted from the
-`Segal-associativity-tetrahedron`.
+`#!rzk Segal-associativity-tetrahedron`.
 
 ```rzk
 #def Segal-triple-composite uses (extext)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1268,7 +1268,7 @@ composition:
 
 #def is-segal-Unit uses (extext)
   : is-segal Unit
-  := \ x y z f g → is-retract-of-is-contr-is-contr
+  := \ x y z f g → is-contr-is-retract-of-is-contr
     (Σ (h : hom Unit x z) , hom2 Unit x y z f g h)
     (Δ² → Unit)
     (\ (_ , k) → k , (\ k → (\ t → k (t , t) , k) , \ _ → refl))

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -575,7 +575,7 @@ In a Segal type, where composition is unique, it follows that composition with
 an identity arrow recovers the original arrow. Thus, an identity axiom was not
 needed in the definition of Segal types.
 
-```rzk title="If $A$ is Segal then the right unit law holds"
+```rzk title="If A is Segal then the right unit law holds"
 #def Segal-comp-id
   (A : U)
   (is-segal-A : is-segal A)
@@ -593,7 +593,7 @@ needed in the definition of Segal types.
       ( comp-id-witness A x y f)
 ```
 
-```rzk title="If $A$ is Segal then the left unit law holds"
+```rzk title="If A is Segal then the left unit law holds"
 #def Segal-id-comp
   (A : U)
   (is-segal-A : is-segal A)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -30,7 +30,7 @@ extension extensionality:
 
 ## Hom types
 
-Extension types are used ∂to define the type of arrows between fixed terms:
+Extension types are used to define the type of arrows between fixed terms:
 
 <svg style="float: right" viewBox="0 0 200 60" width="150" height="60">
   <polyline points="40,30 160,30" stroke="blue" stroke-width="3" marker-end="url(#arrow-blue)"></polyline>
@@ -39,7 +39,6 @@ Extension types are used ∂to define the type of arrows between fixed terms:
 </svg>
 
 ```rzk title="RS17, Definition 5.1"
--- The type of arrows in A from x to y.
 #def hom
   (A : U)
   (x y : A)
@@ -66,7 +65,6 @@ Extension types are also used to define the type of commutative triangles:
 </svg>
 
 ```rzk title="RS17, Definition 5.2"
--- the type of commutative triangles in A
 #def hom2
   (A : U)
   (x y z : A)
@@ -83,9 +81,9 @@ Extension types are also used to define the type of commutative triangles:
 
 ## The Segal condition
 
-A type is Segal if every composable pair of arrows has a unique composite. Note
-this is a considerable simplification of the usual Segal condition, which also
-requires homotopical uniqueness of higher-order composites.
+A type is **Segal** if every composable pair of arrows has a unique composite.
+Note this is a considerable simplification of the usual Segal condition, which
+also requires homotopical uniqueness of higher-order composites.
 
 ```rzk title="RS17, Definition 5.3"
 #def is-segal
@@ -297,19 +295,20 @@ witnesses of the equivalence).
             is-segal-A
               ( k (0₂ , 0₂)) (k (1₂ , 0₂)) (k (1₂ , 1₂))
               ( \ t → k (t , 0₂)) (\ t → k (1₂ , t)))))
+```
 
--- Verify that the mapping in (Segal-equiv-horn-restriction A is-segal-A)
--- is exactly (horn-restriction A)
-#def Segal-equiv-horn-restriction-test
+We verify that the mapping in `Segal-equiv-horn-restriction A is-segal-A` is
+exactly `horn-restriction A`.
+
+```rzk
+#def test-Segal-equiv-horn-restriction
   ( A : U)
   ( is-segal-A : is-segal A)
   : (first (Segal-equiv-horn-restriction A is-segal-A)) = (horn-restriction A)
   := refl
 ```
 
-Segal types are types that are local at the horn inclusion:
-
-```rzk
+```rzk title="Segal types are types that are local at the horn inclusion"
 #def is-local-horn-inclusion-is-segal
   ( A : U)
   ( is-segal-A : is-segal A)
@@ -317,9 +316,7 @@ Segal types are types that are local at the horn inclusion:
   := second (Segal-equiv-horn-restriction A is-segal-A)
 ```
 
-Types that are local at the horn inclusion are Segal types:
-
-```rzk
+```rzk title="Types that are local at the horn inclusion are Segal types"
 #def is-segal-is-local-horn-inclusion
   ( A : U)
   ( is-local-horn-inclusion-A : is-local-horn-inclusion A)
@@ -478,8 +475,7 @@ For later use, an equivalent characterization of the arrow type.
         ( \ (x , (y , f)) → f , \ xyf → refl)))
 ```
 
-```rzk title="RS17, Corollary 5.6(ii)"
--- special case using `is-local-horn-inclusion`
+```rzk title="RS17, Corollary 5.6(ii), special case for locality at the horn inclusion"
 #def Segal'-arrow-types uses (extext)
   (A : U)
   (is-segal-A : is-local-horn-inclusion A)
@@ -490,8 +486,9 @@ For later use, an equivalent characterization of the arrow type.
       ( Δ¹)
       ( \ t → A)
       ( \ t → is-segal-A)
+```
 
--- special case using `is-segal`
+```rzk title="RS17, Corollary 5.6(ii), special case for the Segal condition"
 #def Segal-arrow-types uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
@@ -517,7 +514,6 @@ All types have identity arrows and witnesses to the identity composition law.
 </svg>
 
 ```rzk title="RS17, Definition 5.7"
--- all types have identity arrows
 #def id-arr
   (A : U)
   (x : A)
@@ -542,7 +538,6 @@ Witness for the right identity law:
 </svg>
 
 ```rzk title="RS17, Proposition 5.8a"
--- the right unit law for identity
 #def comp-id-witness
   (A : U)
   (x y : A)
@@ -568,7 +563,6 @@ Witness for the left identity law:
 </svg>
 
 ```rzk title="RS17, Proposition 5.8b"
--- the left unit law for identity
 #def id-comp-witness
   (A : U)
   (x y : A)
@@ -581,8 +575,7 @@ In a Segal type, where composition is unique, it follows that composition with
 an identity arrow recovers the original arrow. Thus, an identity axiom was not
 needed in the definition of Segal types.
 
-```rzk
--- If A is Segal then the right unit law holds
+```rzk title="If $A$ is Segal then the right unit law holds"
 #def Segal-comp-id
   (A : U)
   (is-segal-A : is-segal A)
@@ -598,8 +591,9 @@ needed in the definition of Segal types.
       ( id-arr A y)
       ( f)
       ( comp-id-witness A x y f)
+```
 
--- If A is Segal then the left unit law holds
+```rzk title="If $A$ is Segal then the left unit law holds"
 #def Segal-id-comp
   (A : U)
   (is-segal-A : is-segal A)
@@ -1184,8 +1178,11 @@ composition:
             (p))),
         ( k),
         ( q))
+```
 
--- As a special case of the above:
+As a special case of the above:
+
+```rzk
 #def Segal-homotopy-postwhisker
   (A : U)
   (is-segal-A : is-segal A)
@@ -1195,8 +1192,11 @@ composition:
   (p : f = g)
   : (Segal-comp A is-segal-A x y z f h) = (Segal-comp A is-segal-A x y z g h)
   := Segal-homotopy-congruence A is-segal-A x y z f g h h p refl
+```
 
--- As a special case of the above:
+As a special case of the above:
+
+```rzk
 #def Segal-homotopy-prewhisker
   (A : U)
   (is-segal-A : is-segal A)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -23,11 +23,10 @@ Some of the definitions in this file rely on extension extensionality:
 
 ## Functors
 
-Functions between types induce an action on hom types , preserving sources and
-targets.
+Functions between types induce an action on hom types, preserving sources and
+targets. The action is called `ap-hom` to avoid conflicting with `ap`.
 
 ```rzk title="RS17, Section 6.1"
--- Action of maps on homs. Called "ap-hom" to avoid conflicting with "ap".
 #def ap-hom
   (A B : U)
   (F : A → B)
@@ -49,10 +48,11 @@ targets.
   := \ t → F (alpha t)
 ```
 
-Functions between types automatically preserve identity arrows.
+Functions between types automatically preserve identity arrows. Preservation of
+identities follows from extension extensionality because these arrows are
+pointwise equal.
 
 ```rzk title="RS17, Proposition 6.1.a"
--- Preservation of identities follows from extension extensionality because these arrows are pointwise equal.
 #def functors-pres-id uses (extext)
   (A B : U)
   (F : A → B)
@@ -72,8 +72,9 @@ Functions between types automatically preserve identity arrows.
       (\ t → refl)
 ```
 
+Preservation of composition requires the Segal hypothesis.
+
 ```rzk title="RS17, Proposition 6.1.b"
--- Preservation of composition requires the Segal hypothesis.
 #def functors-pres-comp
   (A B : U)
   (is-segal-A : is-segal A)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -24,7 +24,8 @@ Some of the definitions in this file rely on extension extensionality:
 ## Functors
 
 Functions between types induce an action on hom types, preserving sources and
-targets. The action is called `ap-hom` to avoid conflicting with `ap`.
+targets. The action is called `#!rzk ap-hom` to avoid conflicting with
+`#!rzk ap`.
 
 ```rzk title="RS17, Section 6.1"
 #def ap-hom
@@ -105,8 +106,9 @@ Preservation of composition requires the Segal hypothesis.
 
 This corresponds to Section 6.2 in [RS17].
 
-Given two simplicial maps `f g : (x : A) → B x` , a **natural transformation**
-from `f` to `g` is an arrow `η : hom ((x : A) → B x) f g` between them.
+Given two simplicial maps `#!rzk f g : (x : A) → B x` , a **natural
+transformation** from `#!rzk f` to `#!rzk g` is an arrow
+`#!rzk η : hom ((x : A) → B x) f g` between them.
 
 ```rzk
 #def nat-trans
@@ -118,7 +120,7 @@ from `f` to `g` is an arrow `η : hom ((x : A) → B x) f g` between them.
 ```
 
 Equivalently , natural transformations can be determined by their **components**
-, i.e. as a family of arrows `(x : A) → hom (B x) (f x) (g x)`.
+, i.e. as a family of arrows `#!rzk (x : A) → hom (B x) (f x) (g x)`.
 
 ```rzk
 #def nat-trans-components
@@ -175,8 +177,8 @@ Equivalently , natural transformations can be determined by their **components**
 ### Horizontal composition
 
 Horizontal composition of natural transformations makes sense over any type. In
-particular , contrary to what is written in [RS17] we do not need `C` to be
-Segal.
+particular , contrary to what is written in [RS17] we do not need `#!rzk C` to
+be Segal.
 
 ```rzk
 #def horizontal-comp-nat-trans

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -32,14 +32,14 @@ identity types.
 
 ```rzk title="RS17, Definition 7.1"
 #def arr-eq
-  (A : U)             -- A type.
-  (x y : A)           -- Two points of type A.
-  (p : x = y)         -- A path p from x to y in A.
-  : hom A x y         -- An arrow p from x to y in A.
+  (A : U)
+  (x y : A)
+  (p : x = y)
+  : hom A x y
   := idJ (A , x , \ y' → \ p' → hom A x y' , (id-arr A x) , y , p)
 
 #def is-discrete
-  (A : U)             -- A type.
+  (A : U)
   : U
   := (x : A) → (y : A) → is-equiv (x =_{A} y) (hom A x y) (arr-eq A x y)
 ```
@@ -236,8 +236,11 @@ Discrete types are automatically Segal types.
           ( \ α → refl)) ,
         ( ( \ σ → \ t → \ s → (second (second σ)) (t , s)) ,
           ( \ σ → refl))))
+```
 
--- The equivalence underlying Eq-arr.
+The equivalence underlying `Eq-arr`:
+
+```rzk
 #def fibered-arr-free-arr
   : (arr A) → (Σ (u : A) , (Σ (v : A) , hom A u v))
   := \ k → (k 0₂ , (k 1₂ , k))
@@ -328,10 +331,15 @@ Discrete types are automatically Segal types.
                     (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
         ( equiv-arr-eq-discrete)
         ( equiv-square-hom-arr))
+```
 
+We close the section so we can use path induction.
+
+```rzk
 #end discrete-arr-equivalences
+```
 
--- closing the section so I can use path induction
+```rzk
 #def fibered-map-square-sigma-over-product
   ( A : U)
   ( is-discrete-A : is-discrete A)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -238,7 +238,7 @@ Discrete types are automatically Segal types.
           ( \ σ → refl))))
 ```
 
-The equivalence underlying `Eq-arr`:
+The equivalence underlying `#!rzk Eq-arr`:
 
 ```rzk
 #def fibered-arr-free-arr
@@ -795,9 +795,9 @@ the second arrow is an identity.
       ( is-contr-horn-refl-refl-extension-type A is-discrete-A x y f)
 ```
 
-But since `A` is discrete, its hom type family is equivalent to its identity
-type family, and we can use "path induction" over arrows to reduce the general
-case to the one just proven:
+But since `#!rzk A` is discrete, its hom type family is equivalent to its
+identity type family, and we can use "path induction" over arrows to reduce the
+general case to the one just proven:
 
 ```rzk
 #def is-contr-hom2-is-discrete uses (extext)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -775,7 +775,7 @@ the second arrow is an identity.
   ( f : hom A x y)
   : is-contr ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
   :=
-    is-retract-of-is-contr-is-contr
+    is-contr-is-retract-of-is-contr
       ( Σ ( d : hom A x y) , (hom2 A x y y f (id-arr A y) d))
       ( Σ ( g : hom A x y) ,
           ( ((t , s) : Δ¹×Δ¹) → A

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -23,14 +23,13 @@ In a type family over a base type, there is a dependent hom type of arrows that
 live over a specified arrow in the base type.
 
 ```rzk title="RS17, Section 8 Prelim"
--- The type of dependent arrows in C over f from u to v
 #def dhom
-  (A : U)            -- The base type.
-  (x y : A)          -- Two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (C : A → U)        -- A type family.
-  (u : C x)          -- A lift of the domain.
-  (v : C y)          -- A lift of the codomain.
+  (A : U)
+  (x y : A)
+  (f : hom A x y)
+  (C : A → U)
+  (u : C x)
+  (v : C y)
   : U
   := (t : Δ¹) → C (f t) [
         t ≡ 0₂ ↦ u ,
@@ -43,11 +42,11 @@ but varying codomain.
 
 ```rzk
 #def dhom-from
-  (A : U)            -- The base type.
-  (x y : A)          -- Two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (C : A → U)        -- A type family.
-  (u : C x)          -- A lift of the domain.
+  (A : U)
+  (x y : A)
+  (f : hom A x y)
+  (C : A → U)
+  (u : C x)
   : U
   := (Σ (v : C y) , dhom A x y f C u v)
 ```
@@ -57,19 +56,19 @@ triangle.
 
 ```rzk
 #def dhom2
-  (A : U)              -- The base type.
-  (x y z : A)            -- Three points in the base.
-  (f : hom A x y)          -- An arrow in the base.
-  (g : hom A y z)          -- An arrow in the base.
-  (h : hom A x z)          -- An arrow in the base.
-  (alpha : hom2 A x y z f g h)  -- A composition witness in the base.
-  (C : A → U)          -- A type family.
-  (u : C x)            -- A lift of the initial point.
-  (v : C y)            -- A lift of the second point.
-  (w : C z)            -- A lift of the third point.
-  (ff : dhom A x y f C u v)    -- A lift of the first arrow.
-  (gg : dhom A y z g C v w)    -- A lift of the second arrow.
-  (hh : dhom A x z h C u w)    -- A lift of the diagonal arrow.
+  (A : U)
+  (x y z : A)
+  (f : hom A x y)
+  (g : hom A y z)
+  (h : hom A x z)
+  (alpha : hom2 A x y z f g h)
+  (C : A → U)
+  (u : C x)
+  (v : C y)
+  (w : C z)
+  (ff : dhom A x y f C u v)
+  (gg : dhom A y z g C v w)
+  (hh : dhom A x z h C u w)
   : U
   :=
     ( (t1 , t2) : Δ²) → C (alpha (t1 , t2)) [
@@ -92,8 +91,9 @@ unique lift with specified domain.
   :=
     (x : A) → (y : A) → (f : hom A x y) → (u : C x) →
       is-contr (dhom-from A x y f C u)
+```
 
--- Type of covariant families over a fixed type
+```rzk title="The type of covariant families over a fixed type"
 #def covariant-family (A : U) : U
   := (Σ (C : ((a : A) → U)) , is-covariant A C)
 ```
@@ -167,21 +167,24 @@ equivalences.
 
 ```rzk
 #def dhom-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
-  (v : hom A a y)        -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
+  (v : hom A a y)
   : U
   := dhom A x y f (\ z → hom A a z) u v
+```
 
--- By uncurrying (RS 4.2) we have an equivalence:
+By uncurrying (RS 4.2) we have an equivalence:
+
+```rzk
 #def uncurried-dhom-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
-  (v : hom A a y)        -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
+  (v : hom A a y)
   : Equiv
     ( dhom-representable A a x y f u v)
     ( ((t , s) : Δ¹×Δ¹) → A
@@ -199,19 +202,22 @@ equivalences.
           (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ))
 
 #def dhom-from-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)        .
+  (f : hom A x y)
+  (u : hom A a x)
   : U
   := dhom-from A x y f (\ z → hom A a z) u
+```
 
--- By uncurrying (RS 4.2) we have an equivalence:
+By uncurrying (RS 4.2) we have an equivalence:
+
+```rzk
 #def uncurried-dhom-from-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (v : hom A a y) , (((t , s) : Δ¹×Δ¹) → A
@@ -221,15 +227,15 @@ equivalences.
         (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
   :=
     total-equiv-family-equiv
-    ( hom A a y)
-    ( \ v → dhom-representable A a x y f u v)
-    ( \ v →
-      (((t , s) : Δ¹×Δ¹) → A
-        [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
-          (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
-          (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
-          (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
-    ( \ v → uncurried-dhom-representable A a x y f u v)
+      ( hom A a y)
+      ( \ v → dhom-representable A a x y f u v)
+      ( \ v →
+        (((t , s) : Δ¹×Δ¹) → A
+          [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
+            (t ≡ 1₂) ∧ (Δ¹ s) ↦ v s ,
+            (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
+            (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
+      ( \ v → uncurried-dhom-representable A a x y f u v)
 
 #def square-to-hom2-pushout
   (A : U)
@@ -284,10 +290,10 @@ equivalences.
         ( hom2-pushout-to-square A w x y z u f g v , \ alphas → refl)))
 
 #def representable-dhom-from-uncurry-hom2
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( Σ (v : hom A a y) ,
       ( ((t , s) : Δ¹×Δ¹) → A [
@@ -313,10 +319,10 @@ equivalences.
     ( \ v → Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
 
 #def representable-dhom-from-hom2
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
@@ -343,10 +349,10 @@ equivalences.
       ( \ v d → product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
 
 #def representable-dhom-from-hom2-dist
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
@@ -382,11 +388,11 @@ Now we introduce the hypothesis that A is Segal type.
 
 ```rzk
 #def Segal-representable-dhom-from-path-space
-  (A : U)            -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
@@ -422,10 +428,10 @@ Now we introduce the hypothesis that A is Segal type.
 
 
 #def codomain-based-paths-contraction
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   (d : hom A a y)
   : Equiv
     ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
@@ -437,11 +443,11 @@ Now we introduce the hypothesis that A is Segal type.
       ( \ alpha → is-contr-codomain-based-paths (hom A a y) d)
 
 #def is-segal-representable-dhom-from-hom2
-  (A : U)            -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv (dhom-from-representable A a x y f u)
     (Σ (d : hom A a y) , (hom2 A a x y u f d))
   :=
@@ -458,11 +464,11 @@ Now we introduce the hypothesis that A is Segal type.
       ( \ d → codomain-based-paths-contraction A a x y f u d))
 
 #def is-segal-representable-dhom-from-contractible
-  (A : U)            -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : is-contr (dhom-from-representable A a x y f u)
   :=
     is-contr-is-equiv-to-contr
@@ -530,10 +536,10 @@ types as follows.
 
 ```rzk
 #def cofibration-union-test
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( ((t , s) : ∂□) → A
       [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -555,10 +561,10 @@ types as follows.
           (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
 
 #def base-hom-rewriting
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     (((t , s) : 2 × 2 | (t ≡ 1₂) ∧ (Δ¹ s)) → A
       [ (t ≡ 1₂) ∧ (s ≡ 0₂) ↦ a ,
@@ -572,10 +578,10 @@ types as follows.
           \ v → refl)))
 
 #def base-hom-expansion
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     ( ((t , s) : ∂□) → A
       [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -596,10 +602,10 @@ types as follows.
     ( base-hom-rewriting A a x y f u)
 
 #def representable-dhom-from-expansion
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     (Σ (sq : ((t , s) : ∂□) → A
         [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -633,10 +639,10 @@ types as follows.
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
 
 #def representable-dhom-from-composite-expansion
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv (dhom-from-representable A a x y f u)
       (Σ (sq : ((t , s) : ∂□) → A
             [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -668,10 +674,10 @@ types as follows.
     ( representable-dhom-from-expansion A a x y f u)
 
 #def representable-dhom-from-cofibration-composition
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
     (((t , s) : Δ¹×Δ¹) → A
         [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -697,10 +703,10 @@ types as follows.
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t))
 
 #def representable-dhom-from-as-extension-type
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A a x)        -- A lift of the domain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A a x)
   : Equiv
       (dhom-from-representable A a x y f u)
       (((t , s) : Δ¹×Δ¹) → A
@@ -791,8 +797,7 @@ transport law.
   := \ t → u
 ```
 
-```rzk title="RS17, Proposition 8.16, Part 2"
--- Covariant families preserve identities
+```rzk title="RS17, Proposition 8.16, Part 2, Covariant families preserve identities"
 #def id-arr-covariant-transport
   (A : U)
   (x : A)
@@ -810,8 +815,7 @@ transport law.
 A fiberwise map between covariant families is automatically "natural" commuting
 with the covariant lifts.
 
-```rzk title="RS17, Proposition 8.17"
--- Covariant naturality
+```rzk title="RS17, Proposition 8.17, Covariant naturality"
 #def covariant-fiberwise-transformation-application
   (A : U)
   (x y : A)
@@ -849,11 +853,11 @@ has a unique lift with specified codomain.
 
 ```rzk
 #def dhom-to
-  (A : U)            -- The base type.
-  (x y : A)          -- Two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (C : A → U)        -- A type family.
-  (v : C y)          -- A lift of the domain.
+  (A : U)
+  (x y : A)
+  (f : hom A x y)
+  (C : A → U)
+  (v : C y)
   : U
   := (Σ (u : C x) , dhom A x y f C u v)
 ```
@@ -866,8 +870,9 @@ has a unique lift with specified codomain.
   :=
     (x : A) → (y : A) → (f : hom A x y) → (v : C y) →
       is-contr (dhom-to A x y f C v)
+```
 
--- Type of contravariant families over a fixed type
+```rzk title="The type of contravariant families over a fixed type"
 #def contravariant-family (A : U) : U
   := (Σ (C : A → U) , is-contravariant A C)
 ```
@@ -941,21 +946,24 @@ a rather lengthy composition of equivalences.
 
 ```rzk
 #def dhom-contra-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A x a)        -- A lift of the domain.
-  (v : hom A y a)        -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A x a)
+  (v : hom A y a)
   : U
   := dhom A x y f (\ z → hom A z a) u v
+```
 
--- By uncurrying (RS 4.2) we have an equivalence:
+By uncurrying (RS 4.2) we have an equivalence:
+
+```rzk
 #def uncurried-dhom-contra-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (u : hom A x a)        -- A lift of the domain.
-  (v : hom A y a)        -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (u : hom A x a)
+  (v : hom A y a)
   : Equiv
     (dhom-contra-representable A a x y f u v)
     (((t , s) : Δ¹×Δ¹) → A [
@@ -970,19 +978,22 @@ a rather lengthy composition of equivalences.
             (Δ¹ t) ∧ (s ≡ 1₂) ↦ a ))
 
 #def dhom-to-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)        -- The representing object and two points in the base.
-  (f : hom A x y)    -- An arrow in the base.
-  (v : hom A y a)    -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : U
   := dhom-to A x y f (\ z → hom A z a) v
+```
 
--- By uncurrying (RS 4.2) we have an equivalence:
+By uncurrying (RS 4.2) we have an equivalence:
+
+```rzk
 #def uncurried-dhom-to-representable
-  (A : U)            -- The ambient type.
-  (a x y : A)        -- The representing object and two points in the base.
-  (f : hom A x y)    -- An arrow in the base.
-  (v : hom A y a)    -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     (dhom-to-representable A a x y f v)
     (Σ (u : hom A x a) ,
@@ -1004,10 +1015,10 @@ a rather lengthy composition of equivalences.
     ( \ u → uncurried-dhom-contra-representable A a x y f u v)
 
 #def representable-dhom-to-uncurry-hom2
-  (A : U)            -- The ambient type.
-  (a x y : A)        -- The representing object and two points in the base.
-  (f : hom A x y)    -- An arrow in the base.
-  (v : hom A y a)    -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     (Σ (u : hom A x a) , (((t , s) : Δ¹×Δ¹) → A
                     [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -1031,10 +1042,10 @@ a rather lengthy composition of equivalences.
     ( \ u → Eq-square-hom2-pushout A x a y a u (id-arr A a) f v)
 
 #def representable-dhom-to-hom2
-  (A : U)          -- The ambient type.
-  (a x y : A)      -- The representing object and two points in the base.
-  (f : hom A x y)  -- An arrow in the base.
-  (v : hom A y a)  -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     (dhom-to-representable A a x y f v)
     (Σ (d : hom A x a) ,
@@ -1061,10 +1072,10 @@ a rather lengthy composition of equivalences.
       (\ u d → product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
 
 #def representable-dhom-to-hom2-swap
-  (A : U)          -- The ambient type.
-  (a x y : A)      -- The representing object and two points in the base.
-  (f : hom A x y)  -- An arrow in the base.
-  (v : hom A y a)  -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
@@ -1082,10 +1093,10 @@ a rather lengthy composition of equivalences.
           (\ u → sym-product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))))
 
 #def representable-dhom-to-hom2-dist
-  (A : U)            -- The ambient type.
-  (a x y : A)        -- The representing object and two points in the base.
-  (f : hom A x y)    -- An arrow in the base.
-  (v : hom A y a)    -- A lift of the codomain.
+  (A : U)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
       (dhom-to-representable A a x y f v)
       (Σ (d : hom A x a ) ,
@@ -1124,11 +1135,11 @@ Now we introduce the hypothesis that A is Segal type.
 
 ```rzk
 #def Segal-representable-dhom-to-path-space
-  (A : U)            -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (v : hom A y a)        -- A lift of the codomain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) ,
@@ -1162,11 +1173,11 @@ Now we introduce the hypothesis that A is Segal type.
             ( \ u → (Eq-Segal-homotopy-hom2' A is-segal-A x a u d)))))))
 
 #def is-segal-representable-dhom-to-hom2
-  (A : U)            -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)          -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (v : hom A y a)        -- A lift of the codomain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) , (hom2 A x y a f v d))
@@ -1185,11 +1196,11 @@ Now we introduce the hypothesis that A is Segal type.
       ( \ d → codomain-based-paths-contraction A x y a v f d))
 
 #def is-segal-representable-dhom-to-contractible
-  (A : U)                -- The ambient type.
-  (is-segal-A : is-segal A)    -- A proof that A is a Segal type.
-  (a x y : A)            -- The representing object and two points in the base.
-  (f : hom A x y)        -- An arrow in the base.
-  (v : hom A y a)        -- A lift of the codomain.
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a x y : A)
+  (f : hom A x y)
+  (v : hom A y a)
   : is-contr (dhom-to-representable A a x y f v)
   :=
     is-contr-is-equiv-to-contr
@@ -1308,8 +1319,7 @@ The contravariant transport operation defines a comtravariantly functorial
 action of arrows in the base on terms in the fibers. In particular, there is an
 identity transport law.
 
-```rzk title="RS17, Proposition 8.16, Part 2, dual"
--- Comtravariant families preserve identities
+```rzk title="RS17, Proposition 8.16, Part 2, dual, Contravariant families preserve identities"
 #def id-arr-contravariant-transport
   (A : U)
   (x : A)
@@ -1327,8 +1337,7 @@ identity transport law.
 A fiberwise map between contrvariant families is automatically "natural"
 commuting with the contravariant lifts.
 
-```rzk title="RS17, Proposition 8.17, dual"
--- Contravariant naturality
+```rzk title="RS17, Proposition 8.17, dual, Contravariant naturality"
 #def contravariant-fiberwise-transformation-application
   (A : U)
   (x y : A)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -203,7 +203,7 @@ By uncurrying (RS 4.2) we have an equivalence:
 
 #def dhom-from-representable
   (A : U)
-  (a x y : A)        .
+  (a x y : A)
   (f : hom A x y)
   (u : hom A a x)
   : U

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -64,23 +64,27 @@ naturality-covariant-fiberwise-transformation naturality is automatic.
 
 For any Segal type $A$ and term $a : A$, the Yoneda lemma provides an
 equivalence between the type `(z : A) → hom A a z → C z` of natural
-transformations out of the functor `hom A a` and valued in an arbitrary
+transformations out of the functor `hom A a` and values in an arbitrary
 covariant family $C$ and the type $C a$.
 
 One of the maps in this equivalence is evaluation at the identity. The inverse
 map makes use of the covariant transport operation.
 
+The following map, `evid`, evaluates a natural transformation out of a
+representable functor at the identity arrow.
+
 ```rzk
--- The map evid evaluates a natural transformation
--- out of a representable functor at the identity arrow.
 #def evid
   (A : U)
   (a : A)
   (C : A → U)
   : ((z : A) → hom A a z → C z) → C a
   := \ ϕ → ϕ a (id-arr A a)
+```
 
--- The inverse map only exists for Segal types.
+The inverse map only exists for Segal types.
+
+```rzk
 #def yon
   (A : U)
   (is-segal-A : is-segal A)
@@ -120,8 +124,11 @@ in two steps.
 #variable a : A
 #variable C : A → U
 #variable is-covariant-C : is-covariant A C
+```
 
--- The composite yon-evid of ϕ equals ϕ at all x : A and f : hom A a x.
+The composite `yon-evid` of `ϕ` equals `ϕ` at all `x : A` and `f : hom A a x`.
+
+```rzk
 #def yon-evid-twice-pointwise
   (ϕ : (z : A) → hom A a z → C z)
   (x : A)
@@ -142,8 +149,11 @@ in two steps.
         ( f)
         ( ϕ x)
         ( Segal-id-comp A is-segal-A a x f))
+```
 
--- By funext, these are equals as functions of f pointwise in x.
+By `funext`, these are equals as functions of `f` pointwise in `x`.
+
+```rzk
 #def yon-evid-once-pointwise uses (funext)
   (ϕ : (z : A) → hom A a z → C z)
   (x : A)
@@ -155,12 +165,16 @@ in two steps.
       ( \ f → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f)
       ( \ f → (ϕ x f))
       ( \ f → yon-evid-twice-pointwise ϕ x f)
+```
 
--- By funext again, these are equal as functions of x and f.
+By `funext` again, these are equal as functions of `x` and `f`.
+
+```rzk
 #def yon-evid uses (funext)
   (ϕ : (z : A) → hom A a z → C z)
   : ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) = ϕ
-  := eq-htpy funext
+  :=
+    eq-htpy funext
       ( A)
       ( \ x → (hom A a x → C x))
       ( \ x → ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x)
@@ -327,17 +341,21 @@ contravariant family $C$ and the type $C a$.
 One of the maps in this equivalence is evaluation at the identity. The inverse
 map makes use of the contravariant transport operation.
 
+The following map, `contra-evid` evaluates a natural transformation out of a
+representable functor at the identity arrow.
+
 ```rzk
--- The map evid evaluates a natural transformation
--- out of a representable functor at the identity arrow.
 #def contra-evid
   (A : U)
   (a : A)
   (C : A → U)
   : ( (z : A) → hom A z a → C z) → C a
   := \ ϕ → ϕ a (id-arr A a)
+```
 
--- The inverse map only exists for Segal types and contravariant families.
+The inverse map only exists for Segal types and contravariant families.
+
+```rzk
 #def contra-yon
   (A : U)
   (is-segal-A : is-segal A)
@@ -375,8 +393,12 @@ in two steps.
 #variable a : A
 #variable C : A → U
 #variable is-contravariant-C : is-contravariant A C
+```
 
--- The composite yon-evid of ϕ equals ϕ at all x : A and f : hom A x a.
+The composite `contra-yon-evid` of `ϕ` equals `ϕ` at all `x : A` and
+`f : hom A x a`.
+
+```rzk
 #def contra-yon-evid-twice-pointwise
   (ϕ : (z : A) → hom A z a → C z)
   (x : A)
@@ -399,8 +421,11 @@ in two steps.
         ( f)
         ( ϕ x)
         ( Segal-comp-id A is-segal-A x a f))
+```
 
--- By funext, these are equals as functions of f pointwise in x.
+By `funext`, these are equals as functions of `f` pointwise in `x`.
+
+```rzk
 #def contra-yon-evid-once-pointwise uses (funext)
   (ϕ : (z : A) → hom A z a → C z)
   (x : A)
@@ -415,8 +440,11 @@ in two steps.
           ( (contra-evid A a C) ϕ )) x f)
       ( \ f → (ϕ x f))
       ( \ f → contra-yon-evid-twice-pointwise ϕ x f)
+```
 
--- By funext again, these are equal as functions of x and f.
+By `funext` again, these are equal as functions of `x` and `f`.
+
+```rzk
 #def contra-yon-evid uses (funext)
   (ϕ : (z : A) → hom A z a → C z)
   : (contra-yon A is-segal-A a C is-contravariant-C)((contra-evid A a C) ϕ) = ϕ

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -28,12 +28,12 @@ Some of the definitions in this file rely on function extensionality:
 ## Natural transformations involving a representable functor
 
 Fix a Segal type $A$ and a term $a : A$. The Yoneda lemma characterizes natural
-transformations from the representable type family `hom A a : A → U` to a
-covariant type family `C : A → U`.
+transformations from the representable type family `#!rzk hom A a : A → U` to a
+covariant type family `#!rzk C : A → U`.
 
 Ordinarily, such a natural transformation would involve a family of maps
 
-`ϕ : (z : A) → hom A a z → C z`
+`#!rzk ϕ : (z : A) → hom A a z → C z`
 
 together with a proof of naturality of these components, but by
 naturality-covariant-fiberwise-transformation naturality is automatic.
@@ -63,14 +63,14 @@ naturality-covariant-fiberwise-transformation naturality is automatic.
 ## The Yoneda maps
 
 For any Segal type $A$ and term $a : A$, the Yoneda lemma provides an
-equivalence between the type `(z : A) → hom A a z → C z` of natural
-transformations out of the functor `hom A a` and values in an arbitrary
+equivalence between the type `#!rzk (z : A) → hom A a z → C z` of natural
+transformations out of the functor `#!rzk hom A a` and values in an arbitrary
 covariant family $C$ and the type $C a$.
 
 One of the maps in this equivalence is evaluation at the identity. The inverse
 map makes use of the covariant transport operation.
 
-The following map, `evid`, evaluates a natural transformation out of a
+The following map, `#!rzk evid`, evaluates a natural transformation out of a
 representable functor at the identity arrow.
 
 ```rzk
@@ -113,8 +113,8 @@ straightforward:
 ```
 
 The other composite carries $ϕ$ to an a priori distinct natural transformation.
-We first show that these are pointwise equal at all `x : A` and `f : hom A a x`
-in two steps.
+We first show that these are pointwise equal at all `#!rzk x : A` and
+`#!rzk f : hom A a x` in two steps.
 
 ```rzk
 #section yon-evid
@@ -126,7 +126,8 @@ in two steps.
 #variable is-covariant-C : is-covariant A C
 ```
 
-The composite `yon-evid` of `ϕ` equals `ϕ` at all `x : A` and `f : hom A a x`.
+The composite `#!rzk yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
+`#!rzk x : A` and `#!rzk f : hom A a x`.
 
 ```rzk
 #def yon-evid-twice-pointwise
@@ -151,7 +152,8 @@ The composite `yon-evid` of `ϕ` equals `ϕ` at all `x : A` and `f : hom A a x`.
         ( Segal-id-comp A is-segal-A a x f))
 ```
 
-By `funext`, these are equals as functions of `f` pointwise in `x`.
+By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
+`#!rzk x`.
 
 ```rzk
 #def yon-evid-once-pointwise uses (funext)
@@ -167,7 +169,8 @@ By `funext`, these are equals as functions of `f` pointwise in `x`.
       ( \ f → yon-evid-twice-pointwise ϕ x f)
 ```
 
-By `funext` again, these are equal as functions of `x` and `f`.
+By `#!rzk funext` again, these are equal as functions of `#!rzk x` and
+`#!rzk f`.
 
 ```rzk
 #def yon-evid uses (funext)
@@ -208,10 +211,10 @@ This is proven combining the previous steps.
 
 The equivalence of the Yoneda lemma is natural in both $a : A$ and $C : A → U$.
 
-Naturality in $a$ follows from the fact that the maps `evid` and `yon` are
-fiberwise equivalences between covariant families over $A$, though it requires
-some work, which has not yet been formalized, to prove that the domain is
-covariant.
+Naturality in $a$ follows from the fact that the maps `#!rzk evid` and
+`#!rzk yon` are fiberwise equivalences between covariant families over $A$,
+though it requires some work, which has not yet been formalized, to prove that
+the domain is covariant.
 
 Naturality in $C$ is not automatic but can be proven easily:
 
@@ -309,7 +312,7 @@ Dually, the Yoneda lemma for contravariant type families characterizes natural
 transformations from the contravariant family represented by a term $a : A$ in a
 Segal type to a contravariant type family $C : A → U$.
 
-By `naturality-contravariant-fiberwise-transformation` naturality is again
+By `#!rzk naturality-contravariant-fiberwise-transformation` naturality is again
 automatic.
 
 ```rzk
@@ -334,15 +337,15 @@ automatic.
 ```
 
 For any Segal type $A$ and term $a : A$, the contravariant Yoneda lemma provides
-an equivalence between the type `(z : A) → hom A z a → C z` of natural
-transformations out of the functor `\ z → hom A z a` and valued in an arbitrary
-contravariant family $C$ and the type $C a$.
+an equivalence between the type `#!rzk (z : A) → hom A z a → C z` of natural
+transformations out of the functor `#!rzk \ z → hom A z a` and valued in an
+arbitrary contravariant family $C$ and the type $C a$.
 
 One of the maps in this equivalence is evaluation at the identity. The inverse
 map makes use of the contravariant transport operation.
 
-The following map, `contra-evid` evaluates a natural transformation out of a
-representable functor at the identity arrow.
+The following map, `#!rzk contra-evid` evaluates a natural transformation out of
+a representable functor at the identity arrow.
 
 ```rzk
 #def contra-evid
@@ -382,8 +385,8 @@ straightforward:
 ```
 
 The other composite carries $ϕ$ to an a priori distinct natural transformation.
-We first show that these are pointwise equal at all `x : A` and `f : hom A x a`
-in two steps.
+We first show that these are pointwise equal at all `#!rzk x : A` and
+`#!rzk f : hom A x a` in two steps.
 
 ```rzk
 #section contra-yon-evid
@@ -395,8 +398,8 @@ in two steps.
 #variable is-contravariant-C : is-contravariant A C
 ```
 
-The composite `contra-yon-evid` of `ϕ` equals `ϕ` at all `x : A` and
-`f : hom A x a`.
+The composite `#!rzk contra-yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
+`#!rzk x : A` and `#!rzk f : hom A x a`.
 
 ```rzk
 #def contra-yon-evid-twice-pointwise
@@ -423,7 +426,8 @@ The composite `contra-yon-evid` of `ϕ` equals `ϕ` at all `x : A` and
         ( Segal-comp-id A is-segal-A x a f))
 ```
 
-By `funext`, these are equals as functions of `f` pointwise in `x`.
+By `#!rzk funext`, these are equals as functions of `#!rzk f` pointwise in
+`#!rzk x`.
 
 ```rzk
 #def contra-yon-evid-once-pointwise uses (funext)
@@ -442,7 +446,8 @@ By `funext`, these are equals as functions of `f` pointwise in `x`.
       ( \ f → contra-yon-evid-twice-pointwise ϕ x f)
 ```
 
-By `funext` again, these are equal as functions of `x` and `f`.
+By `#!rzk funext` again, these are equal as functions of `#!rzk x` and
+`#!rzk f`.
 
 ```rzk
 #def contra-yon-evid uses (funext)
@@ -483,10 +488,10 @@ equivalence.
 
 The equivalence of the Yoneda lemma is natural in both $a : A$ and $C : A → U$.
 
-Naturality in $a$ follows from the fact that the maps `evid` and `yon` are
-fiberwise equivalences between contravariant families over $A$, though it
-requires some work, which has not yet been formalized, to prove that the domain
-is contravariant.
+Naturality in $a$ follows from the fact that the maps `#!rzk evid` and
+`#!rzk yon` are fiberwise equivalences between contravariant families over $A$,
+though it requires some work, which has not yet been formalized, to prove that
+the domain is contravariant.
 
 Naturality in $C$ is not automatic but can be proven easily:
 
@@ -696,7 +701,7 @@ family defines an inverse equivalence to evaluation at the element.
 
 ## Initial objects in slice categories
 
-The type `coslice A a` is the type of arrows in $A$ with domain $a$.
+The type `#!rzk coslice A a` is the type of arrows in $A$ with domain $a$.
 
 ```rzk
 #def coslice
@@ -925,7 +930,7 @@ family defines an inverse equivalence to evaluation at the element.
 
 ## Final objects in slice categories
 
-The type `slice A a` is the type of arrows in $A$ with codomain $a$.
+The type `#!rzk slice A a` is the type of arrows in $A$ with codomain $a$.
 
 ```rzk
 #def slice

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -153,7 +153,7 @@ Some of the definitions in this file rely on extension extensionality:
       (Segal-associativity extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
       (Segal-homotopy-prewhisker A is-segal-A z x x k (Segal-comp A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
       (Segal-comp-id A is-segal-A z x k) -- id_x k = k
-       )
+      )
   )
 
 #def if-iso-then-postcomp-has-section uses (extext)
@@ -177,7 +177,7 @@ Some of the definitions in this file rely on extension extensionality:
       (Segal-associativity extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
       (Segal-homotopy-prewhisker A is-segal-A z y y k (Segal-comp A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
       (Segal-comp-id A is-segal-A z y k) -- id_y k = k
-       )
+      )
   )
 
 #def if-iso-then-postcomp-is-equiv uses (extext)
@@ -221,7 +221,7 @@ Some of the definitions in this file rely on extension extensionality:
 
       (Segal-homotopy-postwhisker A is-segal-A y y z (Segal-comp A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
       (Segal-id-comp A is-segal-A y z k) -- k id_y = k
-       )
+      )
   )
 
 #def if-iso-then-precomp-has-section uses (extext)
@@ -249,7 +249,7 @@ Some of the definitions in this file rely on extension extensionality:
       ) -- (kg)f = k(gf)
       (Segal-homotopy-postwhisker A is-segal-A x x z (Segal-comp A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
       (Segal-id-comp A is-segal-A x z k) -- k id_x = k
-       )
+      )
   )
 
 #def if-iso-then-precomp-is-equiv uses (extext)


### PR DESCRIPTION
This PR reduces the number of comments in the code by using the features of literate files instead. I tried using the title attribute of code blocks for some of these, let me know what you think. The PR reduces the number of code comments in the repository from over 400, to "just" 66. The code is still not entirely consistent with what kind of headers are used where, but I think this PR goes a step in the right direction at least.

Related to #14.