### PR TITLE
Replace `idJ` with `ind-path`

### DIFF
--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -38,7 +38,7 @@ it like any other function.
 #def rev
   ( p : x = y)
   : y = x
-  := idJ (A , x , (\ y' p' → y' = x) , refl , y , p)
+  := ind-path (A) (x) (\ y' p' → y' = x) (refl) (y) (p)
 ```
 
 ### Path concatenation
@@ -51,7 +51,7 @@ our main definition.
   ( p : x = y)
   ( q : y = z)
   : (x = z)
-  := idJ (A , y , \ z' q' → (x = z') , p , z , q)
+  := ind-path (A) (y) (\ z' q' → (x = z')) (p) (z) (q)
 ```
 
 We also introduce a version defined by induction on the first path variable, for
@@ -61,7 +61,7 @@ situations where it is easier to induct on the first path.
 #def concat'
   ( p : x = y)
   : (y = z) → (x = z)
-  := idJ (A , x , \ y' p' → (y' = z) → (x = z) , \ q' → q' , y , p)
+  := ind-path (A) (x) (\ y' p' → (y' = z) → (x = z)) (\ q' → q') (y) (p)
 
 #end path-algebra
 ```
@@ -77,7 +77,7 @@ situations where it is easier to induct on the first path.
 #def rev-rev
   ( p : x = y)
   : (rev A y x (rev A x y p)) = p
-  := idJ (A , x , \ y' p' → (rev A y' x (rev A x y' p')) = p' , refl , y , p)
+  := ind-path (A) (x) (\ y' p' → (rev A y' x (rev A x y' p')) = p') (refl) (y) (p)
 ```
 
 ### Left unit law for path concatenation
@@ -89,7 +89,7 @@ choice of definition.
 #def left-unit-concat
   ( p : x = y)
   : (concat A x x y refl p) = p
-  := idJ (A , x , \ y' p' → (concat A x x y' refl p') = p' , refl , y , p)
+  := ind-path (A) (x) (\ y' p' → (concat A x x y' refl p') = p') (refl) (y) (p)
 ```
 
 ### Associativity of path concatenation
@@ -102,15 +102,15 @@ choice of definition.
   : ( concat A w y z (concat A w x y p q) r) =
     ( concat A w x z p (concat A x y z q r))
   :=
-    idJ
-    ( ( A) ,
-      ( y) ,
+    ind-path
+      ( A)
+      ( y)
       ( \ z' r' →
         concat A w y z' (concat A w x y p q) r' =
-        concat A w x z' p (concat A x y z' q r')) ,
-      ( refl) ,
-      ( z) ,
-      ( r))
+        concat A w x z' p (concat A x y z' q r'))
+      ( refl)
+      ( z)
+      ( r)
 
 #def rev-associative-concat
   ( p : w = x)
@@ -119,39 +119,39 @@ choice of definition.
   : ( concat A w x z p (concat A x y z q r)) =
     ( concat A w y z (concat A w x y p q) r)
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' r' →
-        concat A w x z' p (concat A x y z' q r') =
-        concat A w y z' (concat A w x y p q) r' ,
-      refl ,
-      z ,
-      r)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' r' →
+          concat A w x z' p (concat A x y z' q r') =
+          concat A w y z' (concat A w x y p q) r')
+      ( refl)
+      ( z)
+      ( r)
 
 #def right-inverse-concat
   ( p : x = y)
   : (concat A x y x p (rev A x y p)) = refl
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' → concat A x y' x p' (rev A x y' p') = refl ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' → concat A x y' x p' (rev A x y' p') = refl)
+      ( refl)
+      ( y)
+      ( p)
 
 #def left-inverse-concat
   ( p : x = y)
   : (concat A y x y (rev A x y p) p) = refl
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' → concat A y' x y' (rev A x y' p') p' = refl ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' → concat A y' x y' (rev A x y' p') p' = refl)
+      ( refl)
+      ( y)
+      ( p)
 ```
 
 ### Concatenation of two paths with common codomain
@@ -183,13 +183,13 @@ Concatenation of two paths with common domain; defined using `concat` and `rev`.
   ( r : y = z)
   : ((concat A x y z p r) = (concat A x y z q r)) → (p = q)
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' r' → ((concat A x y z' p r') = (concat A x y z' q r')) → (p = q) ,
-      \ H → H ,
-      z ,
-      r)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' r' → ((concat A x y z' p r') = (concat A x y z' q r')) → (p = q))
+      ( \ H → H)
+      ( z)
+      ( r)
 
 #end basic-path-coherence
 ```
@@ -210,19 +210,19 @@ of the path algebra coherences defined above.
   : ( rev A x z (concat A x y z p q)) =
     ( concat A z y x (rev A y z q) (rev A x y p))
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' q' →
-        (rev A x z' (concat A x y z' p q')) =
-        (concat A z' y x (rev A y z' q') (rev A x y p)) ,
-      rev
-        ( y = x)
-        ( concat A y y x refl (rev A x y p))
-        ( rev A x y p)
-        ( left-unit-concat A y x (rev A x y p)) ,
-      z ,
-      q)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' q' →
+          (rev A x z' (concat A x y z' p q')) =
+          (concat A z' y x (rev A y z' q') (rev A x y p)))
+      ( rev
+          ( y = x)
+          ( concat A y y x refl (rev A x y p))
+          ( rev A x y p)
+          ( left-unit-concat A y x (rev A x y p)))
+      ( z)
+      ( q)
 ```
 
 ### Postwhiskering paths of paths
@@ -234,13 +234,13 @@ of the path algebra coherences defined above.
   ( r : y = z)
   : (concat A x y z p r) = (concat A x y z q r)
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' r' → (concat A x y z' p r') = (concat A x y z' q r') ,
-      H ,
-      z ,
-      r)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' r' → (concat A x y z' p r') = (concat A x y z' q r'))
+      ( H)
+      ( z)
+      ( r)
 ```
 
 ### Prewhiskering paths of paths
@@ -255,24 +255,24 @@ Prewhiskering paths of paths is much harder.
     ( H : q = r) →
     ( concat A x y z p q) = (concat A x y z p r)
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-      (q : y' = z) →
-      (r : y' = z) →
-      (H : q = r) →
-      (concat A x y' z p' q) = (concat A x y' z p' r) ,
-      \ q r H →
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+        ( q : y' = z) →
+        ( r : y' = z) →
+        ( H : q = r) →
+        ( concat A x y' z p' q) = (concat A x y' z p' r))
+      ( \ q r H →
         concat
           ( x = z)
           ( concat A x x z refl q)
-          r
+          ( r)
           ( concat A x x z refl r)
           ( concat (x = z) (concat A x x z refl q) q r (left-unit-concat A x z q) H)
-          ( rev (x = z) (concat A x x z refl r) r (left-unit-concat A x z r)) ,
-      y ,
-      p)
+          ( rev (x = z) (concat A x x z refl r) r (left-unit-concat A x z r)))
+      ( y)
+      ( p)
 ```
 
 ### Identifying the two definitions of path concatenation
@@ -283,15 +283,15 @@ Prewhiskering paths of paths is much harder.
   : ( q : y = z) →
     ( concat A x y z p q) = (concat' A x y z p q)
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-        (q' : y' =_{A} z) →
-        (concat A x y' z p' q') =_{x =_{A} z} concat' A x y' z p' q' ,
-      \ q' → left-unit-concat A x z q' ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+          (q' : y' =_{A} z) →
+          (concat A x y' z p' q') =_{x =_{A} z} concat' A x y' z p' q')
+      ( \ q' → left-unit-concat A x z q')
+      ( y)
+      ( p)
 
 #def concat'-concat
   ( p : x = y)
@@ -315,16 +315,16 @@ This is easier to prove for `concat'` than for `concat`.
     ( H : p = concat' A x y z q r) →
     ( concat' A y x z (rev A x y q) p) = r
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' q' →
-        (r' : y' =_{A} z) →
-        (H' : p = concat' A x y' z q' r') →
-        (concat' A y' x z (rev A x y' q') p) = r' ,
-      \ r' H' → H' ,
-      y ,
-      q)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' q' →
+        ( r' : y' =_{A} z) →
+        ( H' : p = concat' A x y' z q' r') →
+        ( concat' A y' x z (rev A x y' q') p) = r')
+      ( \ r' H' → H')
+      ( y)
+      ( q)
 ```
 
 The following needs to be outside the previous section because of the usage of
@@ -368,7 +368,7 @@ The following needs to be outside the previous section because of the usage of
   ( f : A → B)
   ( p : x = y)
   : (f x = f y)
-  := idJ (A , x , \ y' → \ p' → (f x = f y') , refl , y , p)
+  := ind-path (A) (x) (\ y' → \ p' → (f x = f y')) (refl) (y) (p)
 
 #def ap-rev
   ( A B : U)
@@ -377,14 +377,14 @@ The following needs to be outside the previous section because of the usage of
   ( p : x = y)
   : (ap A B y x f (rev A x y p)) = (rev B (f x) (f y) (ap A B x y f p))
   :=
-    idJ
-    ( ( A) ,
-      ( x) ,
+    ind-path
+      ( A)
+      ( x)
       ( \ y' p' →
-        ap A B y' x f (rev A x y' p') = rev B (f x) (f y') (ap A B x y' f p')) ,
-      ( refl) ,
-      ( y) ,
-      ( p))
+        ap A B y' x f (rev A x y' p') = rev B (f x) (f y') (ap A B x y' f p'))
+      ( refl)
+      ( y)
+      ( p)
 
 #def ap-concat
   ( A B : U)
@@ -395,15 +395,15 @@ The following needs to be outside the previous section because of the usage of
   : ( ap A B x z f (concat A x y z p q)) =
     ( concat B (f x) (f y) (f z) (ap A B x y f p) (ap A B y z f q))
   :=
-    idJ
-    ( ( A) ,
-      ( y) ,
+    ind-path
+      ( A)
+      ( y)
       ( \ z' q' →
         ( ap A B x z' f (concat A x y z' p q')) =
-        ( concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q'))) ,
-      ( refl) ,
-      ( z) ,
-      ( q))
+        ( concat B (f x) (f y) (f z') (ap A B x y f p) (ap A B y z' f q')))
+      ( refl)
+      ( z)
+      ( q)
 
 #def rev-ap-rev
   ( A B : U)
@@ -412,15 +412,15 @@ The following needs to be outside the previous section because of the usage of
   ( p : x = y)
   : (rev B (f y) (f x) (ap A B y x f (rev A x y p))) = (ap A B x y f p)
   :=
-    idJ
-    ( ( A) ,
-      ( x) ,
+    ind-path
+      ( A)
+      ( x)
       ( \ y' p' →
         (rev B (f y') (f x) (ap A B y' x f (rev A x y' p'))) =
-        (ap A B x y' f p')) ,
-      ( refl) ,
-      ( y) ,
-      ( p))
+        (ap A B x y' f p'))
+      ( refl)
+      ( y)
+      ( p)
 ```
 
 The following is for a specific use.
@@ -437,24 +437,24 @@ The following is for a specific use.
       ( ap A B x y f p)) =
     ( refl)
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-      ( concat
-        ( B) (f y') (f x) (f y')
-        ( ap A B y' x f (rev A x y' p')) (ap A B x y' f p')) =
-        refl ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+        ( concat
+          ( B) (f y') (f x) (f y')
+          ( ap A B y' x f (rev A x y' p')) (ap A B x y' f p')) =
+        ( refl))
+      ( refl)
+      ( y)
+      ( p)
 
 #def ap-id
   ( A : U)
   ( x y : A)
   ( p : x = y)
   : (ap A A x y (identity A) p) = p
-    := idJ (A , x , \ y' p' → (ap A A x y' (\ z → z) p') = p' , refl , y , p)
+  := ind-path (A) (x) (\ y' p' → (ap A A x y' (\ z → z) p') = p') (refl) (y) (p)
 ```
 
 Application of a function to homotopic paths yields homotopic paths.
@@ -468,13 +468,13 @@ Application of a function to homotopic paths yields homotopic paths.
   ( H : p = q)
   : (ap A B x y f p) = (ap A B x y f q)
   :=
-    idJ
-    ( x = y ,
-      p ,
-      \ q' H' → (ap A B x y f p) = (ap A B x y f q') ,
-      refl ,
-      q ,
-      H)
+    ind-path
+      ( x = y)
+      ( p)
+      ( \ q' H' → (ap A B x y f p) = (ap A B x y f q'))
+      ( refl)
+      ( q)
+      ( H)
 
 #def ap-comp
   ( A B C : U)
@@ -485,15 +485,15 @@ Application of a function to homotopic paths yields homotopic paths.
   : ( ap A C x y (composition A B C g f) p) =
     ( ap B C (f x) (f y) g (ap A B x y f p))
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-      ( ap A C x y' (\ z → g (f z)) p') =
-      ( ap B C (f x) (f y') g (ap A B x y' f p')) ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+        ( ap A C x y' (\ z → g (f z)) p') =
+        ( ap B C (f x) (f y') g (ap A B x y' f p')))
+      ( refl)
+      ( y)
+      ( p)
 
 #def rev-ap-comp
   ( A B C : U)
@@ -528,7 +528,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( p : x = y)
   ( u : B x)
   : B y
-  := idJ (A , x , \ y' p' → B y' , u , y , p)
+  := ind-path (A) (x) (\ y' p' → B y') (u) (y) (p)
 ```
 
 ### The lift of a base path to a path from a term in the total space to its transport
@@ -540,13 +540,13 @@ Application of a function to homotopic paths yields homotopic paths.
   ( u : B x)
   : (x , u) =_{Σ (z : A) , B z} (y , transport x y p u)
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' → (x , u) =_{Σ (z : A) , B z} (y' , transport x y' p' u) ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' → (x , u) =_{Σ (z : A) , B z} (y' , transport x y' p' u))
+      ( refl)
+      ( y)
+      ( p)
 ```
 
 ### Transport along concatenated paths
@@ -560,15 +560,15 @@ Application of a function to homotopic paths yields homotopic paths.
   : ( transport x z (concat A x y z p q) u) =
     ( transport y z q (transport x y p u))
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' q' →
-      ( transport x z' (concat A x y z' p q') u) =
-      ( transport y z' q' (transport x y p u)) ,
-      refl ,
-      z ,
-      q)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' q' →
+        ( transport x z' (concat A x y z' p q') u) =
+        ( transport y z' q' (transport x y p u)))
+      ( refl)
+      ( z)
+      ( q)
 
 #def transport-concat-rev
   ( x y z : A)
@@ -578,15 +578,15 @@ Application of a function to homotopic paths yields homotopic paths.
   : ( transport y z q (transport x y p u)) =
     ( transport x z (concat A x y z p q) u)
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' q' →
-      ( transport y z' q' (transport x y p u)) =
-      ( transport x z' (concat A x y z' p q') u) ,
-      refl ,
-      z ,
-      q)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' q' →
+        ( transport y z' q' (transport x y p u)) =
+        ( transport x z' (concat A x y z' p q') u))
+      ( refl)
+      ( z)
+      ( q)
 ```
 
 ### Transport along homotopic paths
@@ -599,13 +599,13 @@ Application of a function to homotopic paths yields homotopic paths.
   ( u : B x)
   : (transport x y p u) = (transport x y q u)
   :=
-    idJ
-    ( x = y ,
-      p ,
-      \ q' H' → (transport x y p u) = (transport x y q' u) ,
-      refl ,
-      q ,
-      H)
+    ind-path
+      ( x = y)
+      ( p)
+      ( \ q' H' → (transport x y p u) = (transport x y q' u))
+      ( refl)
+      ( q)
+      ( H)
 ```
 
 ### Transport along a loop
@@ -633,13 +633,13 @@ Application of a function to homotopic paths yields homotopic paths.
   ( p : x = y)
   : (transport A B x y p (f x)) = f y
   :=
-    idJ
-    ( A ,
-      x ,
-      (\ y' p' → (transport A B x y' p' (f x)) = f y') ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( (\ y' p' → (transport A B x y' p' (f x)) = f y'))
+      ( refl)
+      ( y)
+      ( p)
 ```
 
 ## Higher-order concatenation
@@ -749,13 +749,13 @@ The following is the same as above but with alternating arguments.
   ( p : x = y)
   : triple-concat A y x x y (rev A x y p) refl p = refl
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' → triple-concat A y' x x y' (rev A x y' p') refl p' = refl ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' → triple-concat A y' x x y' (rev A x y' p') refl p' = refl)
+      ( refl)
+      ( y)
+      ( p)
 
 #def ap-rev-refl-id-triple-concat
   ( A B : U)
@@ -764,15 +764,15 @@ The following is the same as above but with alternating arguments.
   ( p : x = y)
   : (ap A B y y f (triple-concat A y x x y (rev A x y p) refl p)) = refl
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-        ap A B y' y' f (triple-concat A y' x x y' (rev A x y' p') refl p') =
-        refl ,
-      refl ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+        ( ap A B y' y' f (triple-concat A y' x x y' (rev A x y' p') refl p')) =
+        ( refl))
+      ( refl)
+      ( y)
+      ( p)
 
 #def ap-triple-concat
   ( A B : U)
@@ -792,23 +792,20 @@ The following is the same as above but with alternating arguments.
       ( ap A B x y f q)
       ( ap A B y z f r))
   :=
-    idJ
-    ( A ,
-      y ,
-      \ z' r' →
-      ap A B w z' f (triple-concat A w x y z' p q r') =
-      triple-concat
-        B
-        ( f w)
-        ( f x)
-        ( f y)
-        ( f z')
-        ( ap A B w x f p)
-        ( ap A B x y f q)
-        ( ap A B y z' f r') ,
-      ap-concat A B w x y f p q ,
-      z ,
-      r)
+    ind-path
+      ( A)
+      ( y)
+      ( \ z' r' →
+        ( ap A B w z' f (triple-concat A w x y z' p q r')) =
+        ( triple-concat
+          ( B)
+          ( f w) (f x) (f y) (f z')
+          ( ap A B w x f p)
+          ( ap A B x y f q)
+          ( ap A B y z' f r')))
+      ( ap-concat A B w x y f p q)
+      ( z)
+      ( r)
 
 #def homotopy-triple-concat
   ( A : U)
@@ -829,12 +826,12 @@ The following is the same as above but with alternating arguments.
   ( H : q = r)
   : (triple-concat A w x y z p q s) = (triple-concat A w x y z p r s)
   :=
-    idJ
-    ( x = y ,
-      q ,
-      \ r' H' →
-      triple-concat A w x y z p q s = triple-concat A w x y z p r' s ,
-      refl ,
-      r ,
-      H)
+    ind-path
+      ( x = y)
+      ( q)
+      ( \ r' H' →
+        triple-concat A w x y z p q s = triple-concat A w x y z p r' s)
+      ( refl)
+      ( r)
+      ( H)
 ```

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -6,6 +6,23 @@ This is a literate `rzk` file:
 #lang rzk-1
 ```
 
+## Path induction
+
+We define path induction in terms of the built-in J rule, so that we can apply
+it like any other function.
+
+```rzk
+#define ind-path
+  ( A : U)
+  ( a : A)
+  ( C : (x : A) -> (a = x) -> U)
+  ( d : C a refl)
+  ( x : A)
+  ( p : a = x)
+  : C x p
+  := idJ (A , a , C , d , x , p)
+```
+
 ## Some basic path algebra
 
 ```rzk

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -102,15 +102,15 @@ composition.
   : (concat B (f x) (f y) (g y) (ap A B x y f p) (H y)) =
     (concat B (f x) (g x) (g y) (H x) (ap A B x y g p))
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-        (concat B (f x) (f y') (g y') (ap A B x y' f p') (H y')) =
-        (concat B (f x) (g x) (g y') (H x) (ap A B x y' g p')) ,
-      left-unit-concat B (f x) (g x) (H x) ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+        ( concat B (f x) (f y') (g y') (ap A B x y' f p') (H y')) =
+        ( concat B (f x) (g x) (g y') (H x) (ap A B x y' g p')))
+      ( left-unit-concat B (f x) (g x) (H x))
+      ( y)
+      ( p)
 ```
 
 ```rzk title="Naturality in another form"
@@ -125,23 +125,23 @@ composition.
       ( rev B (f x) (g x) (H x)) (ap A B x y f p) (H y) =
     ap A B x y g p
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' p' →
-        triple-concat
-          ( B)
-          ( g x)
-          ( f x)
-          ( f y')
-          ( g y')
-          ( rev B (f x) (g x) (H x))
-          ( ap A B x y' f p')
-          ( H y') =
-        ap A B x y' g p' ,
-      rev-refl-id-triple-concat B (f x) (g x) (H x) ,
-      y ,
-      p)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' →
+          triple-concat
+            ( B)
+            ( g x)
+            ( f x)
+            ( f y')
+            ( g y')
+            ( rev B (f x) (g x) (H x))
+            ( ap A B x y' f p')
+            ( H y') =
+          ap A B x y' g p')
+      ( rev-refl-id-triple-concat B (f x) (g x) (H x))
+      ( y)
+      ( p)
 ```
 
 ## An application
@@ -231,32 +231,29 @@ Cancelling the path `H a` on the right and reversing yields a path we need:
   : triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (H x)) p (H y) =
     triple-concat B (g x) (f x) (f y) (g y) (rev B (f x) (g x) (K x)) p (K y)
   :=
-    idJ
-    ( ( f y = g y) ,
-      ( H y) ,
+    ind-path
+      ( f y = g y)
+      ( H y)
       ( \ Ky α' →
-        triple-concat
+        ( triple-concat
           ( B) (g x) (f x) (f y) (g y)
-          ( rev B (f x) (g x) (H x)) (p) (H y) =
-        triple-concat
+          ( rev B (f x) (g x) (H x)) (p) (H y)) =
+        ( triple-concat
           ( B) (g x) (f x) (f y) (g y)
-          ( rev B (f x) (g x) (K x)) (p) (Ky)) ,
-      homotopy-triple-concat
-        B
-        ( g x)
-        ( f x)
-        ( f y)
-        ( g y)
+          ( rev B (f x) (g x) (K x)) (p) (Ky)))
+      ( homotopy-triple-concat
+        ( B) (g x) (f x) (f y) (g y)
         ( rev B (f x) (g x) (H x))
         ( rev B (f x) (g x) (K x))
-        p
+        ( p)
         ( H y)
         ( ap
           ( f x = g x)
           ( g x = f x)
           ( H x)
           ( K x)
-          ( \ G → rev B (f x) (g x) G) (α x)) ,
-      K y ,
-      α y)
+          ( rev B (f x) (g x))
+          ( α x)))
+      ( K y)
+      (α y)
 ```

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -386,13 +386,13 @@ By path induction, an identification between functions defines a homotopy.
   ( p : f = g)
   : (x : X) → (f x = g x)
   :=
-    idJ
-    ( ( (x : X) → A x) ,
-      ( f) ,
-      ( \ g' p' → (x : X) → (f x = g' x)) ,
-      ( \ x → refl) ,
-      ( g) ,
-      ( p))
+    ind-path
+      ( (x : X) → A x)
+      ( f)
+      ( \ g' p' → (x : X) → (f x = g' x))
+      ( \ x → refl)
+      ( g)
+      ( p)
 ```
 
 The function extensionality axiom asserts that this map defines a family of
@@ -513,17 +513,17 @@ dependent function types.
     \ x →
     ( ( rev A y x) ,
       ( \ p →
-        idJ
-        ( A ,
-          x ,
+        ind-path
+          ( A)
+          ( x)
           ( \ y' p' →
             ( composition
               ( x = y') (y' = x) (x = y') (rev A y' x) (rev A x y') (p'))
             =_{x = y'}
-            ( p')) ,
-          ( refl) ,
-          ( y) ,
-          ( p))))
+            ( p'))
+            ( refl)
+            ( y)
+            ( p)))
 
 #def has-section-rev
   ( A : U)
@@ -532,18 +532,16 @@ dependent function types.
   :=
     \ x →
     ( ( rev A y x) ,
-      ( \ p →
-        idJ
-        ( A ,
-          y ,
-          ( \ x' p' →
-            ( composition
-              ( y = x') (x' = y) (y = x') (rev A x' y) (rev A y x') (p'))
-            =_{y = x'}
-            ( p')) ,
-          ( refl) ,
-          ( x) ,
-          ( p))))
+      ( ind-path
+        ( A)
+        ( y)
+        ( \ x' p' →
+          ( composition
+            ( y = x') (x' = y) (y = x') (rev A x' y) (rev A y x') (p'))
+          =_{y = x'}
+          ( p'))
+        ( refl)
+        ( x)))
 
 #def is-equiv-rev
   ( A : U)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -407,19 +407,18 @@ have equivalent identity types.
   (x y : A)
   : has-retraction (x = y) (f x = f y) (ap A B x y f)
   :=
-    ( second (iff-ap-is-half-adjoint-equiv x y) ,
-      \ p →
-          idJ
-          ( A ,
-            x ,
-            \ y' p' →
-              ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
-              p' ,
-            ( rev-refl-id-triple-concat A
-              ( (has-inverse-inverse A B f (first fisHAE)) (f x)) x
-              ( (first (second (first fisHAE))) x)) ,
-            y ,
-            p))
+    ( ( second (iff-ap-is-half-adjoint-equiv x y)) ,
+      ( ind-path
+          ( A)
+          ( x)
+          ( \ y' p' →
+            ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
+            ( p'))
+          ( rev-refl-id-triple-concat A
+            ( has-inverse-inverse A B f (first fisHAE) (f x))
+            ( x)
+            ( first (second (first fisHAE)) x))
+          ( y)))
 
 #def ap-triple-concat-is-half-adjoint-equiv
   ( x y : A)

--- a/src/hott/05-sigma.rzk.md
+++ b/src/hott/05-sigma.rzk.md
@@ -57,16 +57,16 @@ This is a literate `rzk` file:
   : ( transport A B (first s) (first t) (first-path-Σ s t e) (second s)) =
     ( second t)
   :=
-    idJ
-    ( ( Σ (a : A) , B a) ,
-      ( s) ,
+    ind-path
+      ( Σ (a : A) , B a)
+      ( s)
       ( \ t' e' →
         ( transport A B
           ( first s) (first t') (first-path-Σ s t' e') (second s)) =
-        ( second t')) ,
-      ( refl) ,
-      ( t) ,
-      ( e))
+        ( second t'))
+      ( refl)
+      ( t)
+      ( e)
 ```
 
 ```rzk title="Rijke 22, Definition 9.3.1"
@@ -94,7 +94,7 @@ A path in a fiber defines a path in the total space.
   ( u v : B x)
   ( p : u = v)
   : (x , u) =_{Σ (a : A) , B a} (x , v)
-  := idJ (B x , u , \ v' p' → (x , u) = (x , v') , refl , v , p)
+  := ind-path (B x) (u) (\ v' p' → (x , u) = (x , v')) (refl) (v) (p)
 ```
 
 The following is essentially `eq-pair` but with explicit arguments.
@@ -108,15 +108,15 @@ The following is essentially `eq-pair` but with explicit arguments.
     ( (transport A B x y p u) = v) →
     ( x , u) =_{Σ (z : A) , B z} (y , v)
   :=
-    idJ
-    ( ( A) ,
-      ( x) ,
+    ind-path
+      ( A)
+      ( x)
       ( \ y' p' → (u' : B x) → (v' : B y') →
         ((transport A B x y' p' u') = v') →
-        (x , u') =_{Σ (z : A) , B z} (y' , v')) ,
-      ( \ u' v' q' → (eq-eq-fiber-Σ x u' v' q')) ,
-      ( y) ,
-      ( p))
+        (x , u') =_{Σ (z : A) , B z} (y' , v'))
+      ( \ u' v' q' → (eq-eq-fiber-Σ x u' v' q'))
+      ( y)
+      ( p)
 ```
 
 ```rzk title="The inverse to pair-eq"
@@ -133,14 +133,13 @@ The following is essentially `eq-pair` but with explicit arguments.
   ( e : s = t)
   : (eq-pair s t (pair-eq s t e)) = e
   :=
-    idJ
-    ( Σ (a : A) ,
-      B a ,
-      s ,
-      \ t' e' → (eq-pair s t' (pair-eq s t' e')) = e' ,
-      refl ,
-      t ,
-      e)
+    ind-path
+      ( Σ (a : A) , (B a))
+      ( s)
+      ( \ t' e' → (eq-pair s t' (pair-eq s t' e')) = e')
+      ( refl)
+      ( t)
+      ( e)
 ```
 
 Here we've decomposed `e : Eq-Σ s t` as `(e0, e1)` and decomposed `s` and `t`
@@ -158,27 +157,28 @@ similarly for induction purposes.
       =_{Eq-Σ (s0 , s1) (t0 , t1)}
       ( e0 , e1))
   :=
-    idJ
-    ( A ,
-      s0 ,
+    ind-path
+      ( A)
+      ( s0)
       ( \ t0' e0' →
-        (t1 : B t0') → (e1 : (transport A B s0 t0' e0' s1) = t1) →
-        ( ( pair-eq (s0 , s1) (t0' , t1) (eq-pair (s0 , s1) (t0' , t1) (e0' , e1)))
-          =_{Eq-Σ (s0 , s1) (t0' , t1)}
-          ( e0' , e1))) ,
-      ( \ t1 e1 →
-        idJ
-        ( B s0 ,
-          s1 ,
-          \ t1' e1' →
-            ( pair-eq (s0 , s1) (s0 , t1')
-              ( eq-pair (s0 , s1) (s0 , t1') (refl , e1')))
-              =_{Eq-Σ (s0 , s1) (s0 , t1')} (refl , e1') ,
-          refl ,
-          t1 ,
-          e1)) ,
-      t0 ,
-      e0)
+        ( t1 : B t0') →
+        ( e1 : (transport A B s0 t0' e0' s1) = t1) →
+        ( pair-eq (s0 , s1) (t0' , t1) (eq-pair (s0 , s1) (t0' , t1) (e0' , e1)))
+        =_{Eq-Σ (s0 , s1) (t0' , t1)}
+        ( e0' , e1))
+      ( ind-path
+        ( B s0)
+        ( s1)
+        ( \ t1' e1' →
+          ( pair-eq
+            ( s0 , s1)
+            ( s0 , t1')
+            ( eq-pair (s0 , s1) (s0 , t1') (refl , e1')))
+          =_{Eq-Σ (s0 , s1) (s0 , t1')}
+          ( refl , e1'))
+        ( refl))
+      ( t0)
+      ( e0)
 
 #def pair-eq-eq-pair
   ( s t : Σ (a : A) , B a)
@@ -186,7 +186,7 @@ similarly for induction purposes.
   : ( pair-eq s t (eq-pair s t e)) =_{Eq-Σ s t} e
   :=
     pair-eq-eq-pair-split
-    ( first s) (second s) (first t) (first e) (second t) (second e)
+      ( first s) (second s) (first t) (first e) (second t) (second e)
 
 #def Eq-Σ-equiv
   ( s t : Σ (a : A) , B a)
@@ -215,13 +215,13 @@ similarly for induction purposes.
   ( c : C a b)
   : C a' b'
   :=
-    idJ
-    ( B ,
-      b ,
-      \ b'' q' → C a' b'' ,
-      idJ (A , a , \ a'' p' → C a'' b , c , a' , p) ,
-      b' ,
-      q)
+    ind-path
+      ( B)
+      ( b)
+      ( \ b'' q' → C a' b'')
+      ( ind-path (A) (a) (\ a'' p' → C a'' b) (c) (a') (p))
+      ( b')
+      ( q)
 
 #def Eq-Σ-over-product
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
@@ -244,13 +244,13 @@ properties.
   ( e : s = t)
   : Eq-Σ-over-product s t
   :=
-    idJ
-    ( Σ (a : A) , (Σ (b : B) , C a b) ,
-      s ,
-      \ t' e' → (Eq-Σ-over-product s t') ,
-      ( refl , (refl , refl)) ,
-      t ,
-      e)
+    ind-path
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( s)
+      ( \ t' e' → (Eq-Σ-over-product s t'))
+      ( ( refl , (refl , refl)))
+      ( t)
+      ( e)
 ```
 
 It's surprising that the following typechecks since we defined product-transport
@@ -268,20 +268,21 @@ by a dual path induction over both `p` and `q`, rather than by saying that when
     ( r : product-transport a a' u u' p q c = c') →
     ( (a, (u, c)) =_{(Σ (x : A), (Σ (y : B) , C x y))} (a', (u', c')))
   :=
-    idJ
-    ( ( A) ,
-      ( a) ,
+    ind-path
+      ( A)
+      ( a)
       ( \ a'' p' →
-        (q : u = u') →
-        (c' : C a'' u') →
-        (r : product-transport a a'' u u' p' q c = c') →
-        ( (a, (u, c)) =_{(Σ (x : A) , (Σ (y : B), C x y))} (a'', (u', c')))) ,
+        ( q : u = u') →
+        ( c' : C a'' u') →
+        ( r : product-transport a a'' u u' p' q c = c') →
+        ( (a, (u, c)) =_{(Σ (x : A) , (Σ (y : B), C x y))} (a'', (u', c'))))
       ( \ q c' r →
-        ( eq-eq-fiber-Σ A (\x → (Σ (v : B) , C x v)) a
+        eq-eq-fiber-Σ
+          ( A) (\x → (Σ (v : B) , C x v)) (a)
           ( u, c) ( u', c')
-          ( path-of-pairs-pair-of-paths B (\y → C a y) u u' q c c' r))) ,
-      ( a') ,
-      ( p))
+          ( path-of-pairs-pair-of-paths B (\y → C a y) u u' q c c' r))
+      ( a')
+      ( p)
 
 #def eq-triple
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))
@@ -300,13 +301,13 @@ by a dual path induction over both `p` and `q`, rather than by saying that when
   ( e : s = t)
   : (eq-triple s t (triple-eq s t e)) = e
   :=
-    idJ
-    ( ( Σ (a : A) , (Σ (b : B) , C a b)) ,
-      ( s) ,
-      ( \ t' e' → (eq-triple s t' (triple-eq s t' e')) = e') ,
-      ( refl) ,
-      ( t) ,
-      ( e))
+    ind-path
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( s)
+      ( \ t' e' → (eq-triple s t' (triple-eq s t' e')) = e')
+      ( refl)
+      ( t)
+      ( e)
 ```
 
 Here we've decomposed `s`, `t` and `e` for induction purposes:
@@ -316,8 +317,9 @@ Here we've decomposed `s`, `t` and `e` for induction purposes:
   ( a a' : A)
   ( b b' : B)
   ( c : C a b)
-  ( p : a = a')
-  : ( q : b = b') →
+
+  : ( p : a = a') →
+    ( q : b = b') →
     ( c' : C a' b') →
     ( r : product-transport a a' b b' p q c = c') →
     ( triple-eq
@@ -325,9 +327,9 @@ Here we've decomposed `s`, `t` and `e` for induction purposes:
       ( eq-triple (a , (b , c)) (a' , (b' , c')) (p , (q , r)))) =
     ( p , (q , r))
   :=
-    idJ
-    ( ( A) ,
-      ( a) ,
+    ind-path
+      ( A)
+      ( a)
       ( \ a'' p' →
         ( q : b = b') →
         ( c' : C a'' b') →
@@ -335,36 +337,30 @@ Here we've decomposed `s`, `t` and `e` for induction purposes:
         ( triple-eq
           ( a , (b , c)) (a'' , (b' , c'))
           ( eq-triple (a , (b , c)) (a'' , (b' , c')) (p' , (q , r)))) =
-        ( p' , (q , r))) ,
-      \ q →
-        idJ
-        ( ( B) ,
-          ( b) ,
-          ( \ b'' q' →
-            ( c' : C a b'') →
-            ( r : product-transport a a b b'' refl q' c = c') →
-            ( triple-eq
-              ( a , (b , c)) (a , (b'' , c'))
-              ( eq-triple (a , (b , c)) (a , (b'' , c')) (refl , (q' , r)))) =
-              ( refl , (q' , r))) ,
-          ( \ c' r →
-            idJ
-            ( ( C a b) ,
-              ( c) ,
-              ( \ c'' r' →
-                triple-eq
+        ( p' , (q , r)))
+      ( ind-path
+        ( B)
+        ( b)
+        ( \ b'' q' →
+          ( c' : C a b'') →
+          ( r : product-transport a a b b'' refl q' c = c') →
+          ( triple-eq
+            ( a , (b , c)) (a , (b'' , c'))
+            ( eq-triple (a , (b , c)) (a , (b'' , c')) (refl , (q' , r)))) =
+          ( refl , (q' , r)))
+        ( ind-path
+            ( C a b)
+            ( c)
+            ( \ c'' r' →
+              triple-eq
+                ( a , (b , c)) (a , (b , c''))
+                ( eq-triple
                   ( a , (b , c)) (a , (b , c''))
-                  ( eq-triple
-                    ( a , (b , c)) (a , (b , c''))
-                    ( refl , (refl , r'))) =
-                  ( refl , (refl , r'))) ,
-              ( refl) ,
-              ( c') ,
-              ( r))) ,
-          ( b') ,
-          ( q)) ,
-      ( a') ,
-      ( p))
+                  ( refl , (refl , r'))) =
+                ( refl , (refl , r')))
+            ( refl))
+        ( b'))
+      ( a')
 
 #def triple-eq-eq-triple
   ( s t : Σ (a : A) , (Σ (b : B) , C a b))

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -91,7 +91,7 @@ The prototypical contractible type is the unit type, which is built-in to rzk.
   : has-retraction (x = y) Unit (terminal-map (x = y))
   :=
     ( \ a → refl ,
-      \ p → idJ (Unit , x , \ y' p' → refl =_{x = y'} p' , refl , y , p))
+      \ p → ind-path (Unit) (x) (\ y' p' → refl =_{x = y'} p') (refl) (y) (p))
 
 #def terminal-map-of-path-types-of-Unit-has-sec
   ( x y : Unit)
@@ -305,14 +305,14 @@ For example, we prove that based path spaces are contractible.
   ( q : x = y)
   : ( transport A (\ z → (a = z)) x y q p) = (concat A a x y p q)
   :=
-    idJ
-    ( A ,
-      x ,
-      \ y' q' →
-        ( transport A (\ z → (a = z)) x y' q' p) = (concat A a x y' p q') ,
-      refl ,
-      y ,
-      q)
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' q' →
+        ( transport A (\ z → (a = z)) x y' q' p) = (concat A a x y' p q'))
+      ( refl)
+      ( y)
+      ( q)
 ```
 
 The center of contraction in the based path space is `(a , refl)`.

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -23,25 +23,26 @@ We calculate the transport of (a , q) : fib b along p : a = a':
 
 ```rzk
 #def transport-in-fiber
-  (A B : U)
-  (f : A → B)
-  (b : B)
-  (a a' : A)
-  (u : (f a) = b)
-  (p : a = a')
-  : (transport A ( \ x → (f x) = b) a a' p u) =
-    (concat B (f a') (f a) b (ap A B a' a f (rev A a a' p)) u)
+  ( A B : U)
+  ( f : A → B)
+  ( b : B)
+  ( a a' : A)
+  ( u : (f a) = b)
+  ( p : a = a')
+  : ( transport A ( \ x → (f x) = b) a a' p u) =
+    ( concat B (f a') (f a) b (ap A B a' a f (rev A a a' p)) u)
   :=
-    idJ
-    ( A ,
-      a ,
-      \ a'' p' →
-        (transport A (\ x → (f x) = b) a a'' p' u) =
-        (concat B (f a'') (f a) b (ap A B a'' a f (rev A a a'' p')) u) ,
-      ( rev ((f a) = b) (concat B (f a) (f a) b refl u) u
-        ( left-unit-concat B (f a) b u)) ,
-      a' ,
-      p)
+    ind-path
+      ( A)
+      ( a)
+      ( \ a'' p' →
+        ( transport (A) (\ x → (f x) = b) (a) (a'') (p') (u)) =
+        ( concat (B) (f a'') (f a) (b) (ap A B a'' a f (rev A a a'' p')) (u)))
+      ( rev
+        ( (f a) = b) (concat B (f a) (f a) b refl u) (u)
+        ( left-unit-concat B (f a) b u))
+      ( a')
+      ( p)
 ```
 
 ## Contractible maps

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -40,12 +40,13 @@ maps.
     → fib (B (first w)) (C (first w)) (f (first w)) (second w)
   :=
     \ (z , p) →
-      idJ
-      ( (Σ (x : A) , C x) ,
-        ((total-map-family-of-maps A B C f) z) ,
-        \ w' p' → fib (B (first w')) (C (first w')) (f (first w')) (second w') , ((second z) , refl) ,
-        w ,
-        p)
+    ind-path
+      ( Σ (x : A) , C x)
+      ( total-map-family-of-maps A B C f z)
+      ( \ w' p' → fib (B (first w')) (C (first w')) (f (first w')) (second w'))
+      ( second z , refl)
+      ( w)
+      ( p)
 
 #def total-map-to-fiber-retraction
   (A : U)
@@ -57,19 +58,19 @@ maps.
     ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
     ( total-map-to-fiber A B C f w)
   :=
-    ( total-map-from-fiber A B C f w ,
-      \ (b , p) →
-        idJ
-        ( (C (first w)) ,
-          (f (first w) b) ,
-          \ w1 p' →
-            ((total-map-from-fiber A B C f ((first w , w1)))
-              ((total-map-to-fiber A B C f (first w , w1)) (b , p')))
+    ( ( total-map-from-fiber A B C f w) ,
+      ( \ (b , p) →
+        ind-path
+          ( C (first w))
+          ( f (first w) b)
+          ( \ w1 p' →
+            ( ( total-map-from-fiber A B C f ((first w , w1)))
+              ( (total-map-to-fiber A B C f (first w , w1)) (b , p')))
             =_{(fib (B (first w)) (C (first w)) (f (first w)) (w1))}
-            (b , p') ,
-          refl ,
-          (second w) ,
-          p))
+            ( b , p'))
+          ( refl)
+          ( second w)
+          ( p)))
 
 #def total-map-to-fiber-section
   (A : U)
@@ -81,18 +82,18 @@ maps.
     ( fib (Σ (x : A) , B x) (Σ (x : A) , C x) (total-map-family-of-maps A B C f) w)
     ( total-map-to-fiber A B C f w)
   :=
-    ( total-map-from-fiber A B C f w ,
-      \ (z , p) →
-        idJ
-        ( (Σ (x : A) , C x) ,
-          ((first z , f (first z) (second z))) ,
-          \ w' p' →
-            ( (total-map-to-fiber A B C f w')
-              ( (total-map-from-fiber A B C f w') (z , p'))) =
-            ( z , p') ,
-          refl ,
-          w ,
-          p))
+    ( ( total-map-from-fiber A B C f w) ,
+      ( \ (z , p) →
+        ind-path
+          ( Σ (x : A) , C x)
+          ( first z , f (first z) (second z))
+          ( \ w' p' →
+            ( ( total-map-to-fiber A B C f w')
+              ( ( total-map-from-fiber A B C f w') (z , p'))) =
+            ( z , p'))
+          ( refl)
+          ( w)
+          ( p)))
 
 #def total-map-to-fiber-is-equiv
   (A : U)
@@ -420,14 +421,14 @@ map.
   : (pullback-comparison-fiber A B f C z) → (fib A B f (first z))
   :=
     \ (w , p) →
-      idJ
-      ( (Σ (b : B) , C b) ,
-        (pullback-comparison-map A B f C w) ,
-        \ z' p' →
-          ( fib A B f (first z')) ,
-        (first w , refl) ,
-        z ,
-        p)
+    ind-path
+      ( Σ (b : B) , C b)
+      ( pullback-comparison-map A B f C w)
+      ( \ z' p' →
+        ( fib A B f (first z')))
+      ( first w , refl)
+      ( z)
+      ( p)
 
 #def from-base-fiber-to-pullback-comparison-fiber
   (A B : U)
@@ -437,14 +438,14 @@ map.
   : (fib A B f b) → (c : C b) → (pullback-comparison-fiber A B f C (b , c))
   :=
     \ (a , p) →
-        idJ
-        ( B ,
-          f a ,
-          \ b' p' →
-            (c : C b') → (pullback-comparison-fiber A B f C ((b' , c))) ,
-          \ c → ((a , c) , refl) ,
-          b ,
-          p)
+    ind-path
+      ( B)
+      ( f a)
+      ( \ b' p' →
+          (c : C b') → (pullback-comparison-fiber A B f C ((b' , c))))
+      ( \ c → ((a , c) , refl))
+      ( b)
+      ( p)
 
 #def pullback-comparison-fiber-to-fiber-inv
   (A B : U)
@@ -466,15 +467,16 @@ map.
   : ( (pullback-comparison-fiber-to-fiber-inv A B f C z)
       ( (pullback-comparison-fiber-to-fiber A B f C z) (w , p))) = (w , p)
   :=
-    idJ
-    ( (Σ (b : B) , C b) ,
-      (pullback-comparison-map A B f C w) ,
-      \ z' p' →
-        ((pullback-comparison-fiber-to-fiber-inv A B f C z')
-          ((pullback-comparison-fiber-to-fiber A B f C z') (w , p'))) = (w , p') ,
-      refl ,
-      z ,
-      p)
+    ind-path
+      ( Σ (b : B) , C b)
+      ( pullback-comparison-map A B f C w)
+      ( \ z' p' →
+        ( ( pullback-comparison-fiber-to-fiber-inv A B f C z')
+          ( ( pullback-comparison-fiber-to-fiber A B f C z') (w , p'))) =
+        ( w , p'))
+      ( refl)
+      ( z)
+      ( p)
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy-map
   (A B : U)
@@ -487,16 +489,17 @@ map.
         ((pullback-comparison-fiber-to-fiber-inv A B f C (b , c)) (a , p))) =
       (a , p)
   :=
-    idJ
-    ( B ,
-      f a ,
-      \ b' p' → (c : C b') →
-        ( (pullback-comparison-fiber-to-fiber A B f C (b' , c))
+    ind-path
+      ( B)
+      ( f a)
+      ( \ b' p' →
+        ( c : C b') →
+        ( ( pullback-comparison-fiber-to-fiber A B f C (b' , c))
           ( (pullback-comparison-fiber-to-fiber-inv A B f C (b' , c)) (a , p'))) =
-        ( a , p') ,
-      \ c → refl ,
-      b ,
-      p)
+        ( a , p'))
+      ( \ c → refl)
+      ( b)
+      ( p)
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy
   (A B : U)

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -212,13 +212,14 @@ axiom. Here we state the one that will be most useful and derive an application.
   ( f g : (t : ψ) → A t [ ϕ t ↦ a t ])
   ( p : f = g)
   : (t : ψ) → (f t = g t) [ ϕ t ↦ refl ]
-  := idJ
-    ( ( (t : ψ) → A t [ ϕ t ↦ a t ]) ,
-      ( f) ,
-      ( \ g' p' → (t : ψ) → (f t = g' t) [ ϕ t ↦ refl ]) ,
-      ( \ t → refl) ,
-      ( g) ,
-      ( p))
+  :=
+    ind-path
+      ( (t : ψ) → A t [ ϕ t ↦ a t ])
+      ( f)
+      ( \ g' p' → (t : ψ) → (f t = g' t) [ ϕ t ↦ refl ])
+      ( \ t → refl)
+      ( g)
+      ( p)
 ```
 
 The type that encodes the extension extensionality axiom. As suggested by

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -976,9 +976,14 @@ arrow.
   (f g : hom A x y)
   (p : f = g)
   : (hom2 A x x y (id-arr A x) f g)
-  := idJ (hom A x y , f ,
-          \ g' p' → (hom2 A x x y (id-arr A x) f g') ,
-          (id-comp-witness A x y f) , g , p)
+  :=
+    ind-path
+      ( hom A x y)
+      ( f)
+      ( \ g' p' → (hom2 A x x y (id-arr A x) f g'))
+      ( id-comp-witness A x y f)
+      ( g)
+      ( p)
 
 #def homotopy-to-hom2-total-map
   (A : U)
@@ -1033,9 +1038,14 @@ A dual notion of homotopy can be defined similarly.
   (f g : hom A x y)
   (p : f = g)
   : (hom2 A x y y f (id-arr A y) g)
-  := idJ (hom A x y , f ,
-          \ g' p' → (hom2 A x y y f (id-arr A y) g') ,
-          (comp-id-witness A x y f) , g , p)
+  :=
+    ind-path
+      ( hom A x y)
+      ( f)
+      ( \ g' p' → (hom2 A x y y f (id-arr A y) g'))
+      ( comp-id-witness A x y f)
+      ( g)
+      ( p)
 
 #def homotopy-to-hom2'-total-map
   (A : U)
@@ -1094,9 +1104,14 @@ the data provided by a commutative triangle with that boundary.
   (h : hom A x z)
   (p : (Segal-comp A is-segal-A x y z f g) = h)
   : (hom2 A x y z f g h)
-  := idJ (hom A x z , (Segal-comp A is-segal-A x y z f g) ,
-          \ h' p' → (hom2 A x y z f g h') ,
-          Segal-comp-witness A is-segal-A x y z f g , h , p)
+  :=
+    ind-path
+      ( hom A x z)
+      ( Segal-comp A is-segal-A x y z f g)
+      ( \ h' p' → hom2 A x y z f g h')
+      ( Segal-comp-witness A is-segal-A x y z f g)
+      ( h)
+      ( p)
 
 #def Segal-eq-to-hom2-total-map
   (A : U)
@@ -1161,23 +1176,23 @@ composition:
   (q : h = k)
   : (Segal-comp A is-segal-A x y z f h) = (Segal-comp A is-segal-A x y z g k)
   :=
-    idJ
-      ( ( hom A y z),
-        ( h),
-        ( \ k' q' →
-          (Segal-comp A is-segal-A x y z f h) =
-          (Segal-comp A is-segal-A x y z g k')),
-        ( idJ
-          ( ( hom A x y ),
-            ( f),
-            ( \ g' p' →
-              (Segal-comp A is-segal-A x y z f h) =
-              (Segal-comp A is-segal-A x y z g' h)),
-            ( refl),
-            ( g),
-            (p))),
-        ( k),
-        ( q))
+    ind-path
+      ( hom A y z)
+      ( h)
+      ( \ k' q' →
+        ( Segal-comp A is-segal-A x y z f h) =
+        ( Segal-comp A is-segal-A x y z g k'))
+      ( ind-path
+        ( hom A x y )
+        ( f)
+        ( \ g' p' →
+          ( Segal-comp A is-segal-A x y z f h) =
+          ( Segal-comp A is-segal-A x y z g' h))
+        ( refl)
+        ( g)
+        ( p))
+      ( k)
+      ( q)
 ```
 
 As a special case of the above:
@@ -1219,17 +1234,17 @@ As a special case of the above:
   : (Segal-homotopy-postwhisker A is-segal-A x y z f g h p) =
     ap (hom A x y) (hom A x z) f g (\ k → Segal-comp A is-segal-A x y z k h) p
   :=
-    idJ
-    ( hom A x y,
-      f,
-      \ g' p' →
-      (Segal-homotopy-postwhisker A is-segal-A x y z f g' h p') =
-      ap
-        (hom A x y) (hom A x z)
-        f g' (\ k → Segal-comp A is-segal-A x y z k h) p' ,
-      refl ,
-      g ,
-      p)
+    ind-path
+      ( hom A x y)
+      ( f)
+      ( \ g' p' →
+        (Segal-homotopy-postwhisker A is-segal-A x y z f g' h p') =
+        ap
+          (hom A x y) (hom A x z)
+          f g' (\ k → Segal-comp A is-segal-A x y z k h) p')
+      ( refl)
+      ( g)
+      ( p)
 ```
 
 ```rzk title="RS17, Proposition 5.14(b)"
@@ -1243,15 +1258,15 @@ As a special case of the above:
   : (Segal-homotopy-prewhisker A is-segal-A w x y k f g p) =
     ap (hom A x y) (hom A w y) f g (Segal-comp A is-segal-A w x y k) p
   :=
-    idJ
-    ( hom A x y ,
-      f ,
-      \ g' p' →
-      (Segal-homotopy-prewhisker A is-segal-A w x y k f g' p') =
-      ap (hom A x y) (hom A w y) f g' (Segal-comp A is-segal-A w x y k) p' ,
-      refl ,
-      g ,
-      p)
+    ind-path
+      ( hom A x y)
+      ( f)
+      ( \ g' p' →
+        (Segal-homotopy-prewhisker A is-segal-A w x y k f g' p') =
+        ap (hom A x y) (hom A w y) f g' (Segal-comp A is-segal-A w x y k) p')
+      ( refl)
+      ( g)
+      ( p)
 
 #section is-segal-Unit
 

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -36,7 +36,7 @@ identity types.
   (x y : A)
   (p : x = y)
   : hom A x y
-  := idJ (A , x , \ y' → \ p' → hom A x y' , (id-arr A x) , y , p)
+  := ind-path (A) (x) (\ y' → \ p' → hom A x y') ((id-arr A x)) (y) (p)
 
 #def is-discrete
   (A : U)
@@ -83,15 +83,15 @@ of discrete types is discrete.
   : ( arr-eq ((x : X) → A x) f g h) =
     ( first (equiv-discrete-family X A is-discrete-A f g)) h
   :=
-    idJ
-    ( ( (x : X) → A x) ,
-      ( f) ,
+    ind-path
+      ( (x : X) → A x)
+      ( f)
       ( \ g' h' →
         arr-eq ((x : X) → A x) f g' h' =
-        (first (equiv-discrete-family X A is-discrete-A f g')) h') ,
-      ( refl) ,
-      ( g) ,
-      ( h))
+        (first (equiv-discrete-family X A is-discrete-A f g')) h')
+      ( refl)
+      ( g)
+      ( h)
 ```
 
 ```rzk title="RS17, Proposition 7.2"
@@ -157,15 +157,15 @@ only, extending from BOT, that's all we prove here for now.
   : arr-eq ((t : ψ) → A t) f g h =
     ( first (Eq-discrete-extension I ψ A is-discrete-A f g)) h
   :=
-    idJ
-    ( ( (t : ψ) → A t) ,
-      ( f) ,
+    ind-path
+      ( (t : ψ) → A t)
+      ( f)
       ( \ g' h' →
         ( arr-eq ((t : ψ) → A t) f g' h') =
-        ( first (Eq-discrete-extension I ψ A is-discrete-A f g') h')) ,
-      ( refl) ,
-      ( g) ,
-      ( h))
+        ( first (Eq-discrete-extension I ψ A is-discrete-A f g') h'))
+      ( refl)
+      ( g)
+      ( h)
 ```
 
 ```rzk title="RS17, Proposition 7.2, for extension types"
@@ -355,9 +355,9 @@ We close the section so we can use path induction.
         (Δ¹ t) ∧ (s ≡ 0₂) ↦ (arr-eq A x z p) t ,
         (Δ¹ t) ∧ (s ≡ 1₂) ↦ (arr-eq A y w q) t ])
   :=
-    idJ
-    ( ( A) ,
-      ( x) ,
+    ind-path
+      ( A)
+      ( x)
       ( \ z' p' →
         ( g : hom A z' w) →
         ( product-transport A A (hom A) x z' y w p' q f = g) →
@@ -365,35 +365,32 @@ We close the section so we can use path induction.
           [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
             (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
             (Δ¹ t) ∧ (s ≡ 0₂) ↦ (arr-eq A x z' p') t ,
-            (Δ¹ t) ∧ (s ≡ 1₂) ↦ (arr-eq A y w q) t ])) ,
-      ( idJ
-        ( ( A) ,
-          ( y) ,
-          ( \ w' q' →
-            ( g : hom A x w') →
-            ( product-transport A A (hom A) x x y w' refl q' f = g) →
-            ( ((t , s) : Δ¹×Δ¹) → A
-              [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                (Δ¹ t) ∧ (s ≡ 1₂) ↦ (arr-eq A y w' q') t ])) ,
-          ( \ g τ →
-            idJ
-            ( ( hom A x y) ,
-              ( f) ,
-              ( \ g' τ' →
-                ( ((t , s) : Δ¹×Δ¹) → A
-                  [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                    (t ≡ 1₂) ∧ (Δ¹ s) ↦ g' s ,
-                    (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
-                    (Δ¹ t) ∧ (s ≡ 1₂) ↦ y ])),
-              ( \ (t , s) → f s) ,
-              ( g) ,
-              ( τ))),
-          ( w) ,
-          ( q))) ,
-      ( z) ,
-      ( p))
+            (Δ¹ t) ∧ (s ≡ 1₂) ↦ (arr-eq A y w q) t ]))
+      ( ind-path
+        ( A)
+        ( y)
+        ( \ w' q' →
+          ( g : hom A x w') →
+          ( product-transport A A (hom A) x x y w' refl q' f = g) →
+          ( ((t , s) : Δ¹×Δ¹) → A
+            [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
+              (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
+              (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
+              (Δ¹ t) ∧ (s ≡ 1₂) ↦ (arr-eq A y w' q') t ]))
+        ( ind-path
+            ( hom A x y)
+            ( f)
+            ( \ g' τ' →
+              ( ((t , s) : Δ¹×Δ¹) → A
+                [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
+                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g' s ,
+                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
+                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ y ]))
+            ( \ (t , s) → f s))
+        ( w)
+        ( q))
+      ( z)
+      ( p)
 
 #def square-sigma-over-product
   ( A : U)
@@ -439,9 +436,9 @@ We close the section so we can use path induction.
       ( f) (g)
       ( refl , (refl , τ)))
   :=
-    idJ
-    ( ( hom A x y) ,
-      ( f) ,
+    ind-path
+      ( hom A x y)
+      ( f)
       ( \ g' τ' →
         ( first
           ( equiv-square-sigma-over-product A is-discrete-A x y x y f g')
@@ -450,10 +447,10 @@ We close the section so we can use path induction.
           ( A) (is-discrete-A)
           ( x) (y) (x) (y)
           ( f) (g')
-          ( refl , (refl , τ')))) ,
-      ( refl) ,
-      ( g) ,
-      ( τ))
+          ( refl , (refl , τ'))))
+      ( refl)
+      ( g)
+      ( τ)
 
 #def map-equiv-square-sigma-over-product uses (extext)
   ( A : U)
@@ -470,20 +467,20 @@ We close the section so we can use path induction.
     ( square-sigma-over-product
         A is-discrete-A x y z w f g (p , (q , τ)))
   :=
-    idJ
-    ( A ,
-      y ,
-      \ w' q' →
-      ( g : hom A z w') →
-      ( τ : product-transport A A (hom A) x z y w' p q' f = g) →
-      ( first (equiv-square-sigma-over-product
-                A is-discrete-A x y z w' f g))
-        ( p , (q' , τ)) =
-      ( square-sigma-over-product A is-discrete-A x y z w' f g)
-        ( p , (q' , τ)) ,
-      idJ
-      ( ( A) ,
-        ( x) ,
+    ind-path
+      ( A)
+      ( y)
+      ( \ w' q' →
+        ( g : hom A z w') →
+        ( τ : product-transport A A (hom A) x z y w' p q' f = g) →
+        ( first (equiv-square-sigma-over-product
+                  A is-discrete-A x y z w' f g))
+          ( p , (q' , τ)) =
+        ( square-sigma-over-product A is-discrete-A x y z w' f g)
+          ( p , (q' , τ)))
+      ( ind-path
+        ( A)
+        ( x)
         ( \ z' p' →
           ( g : hom A z' y) →
           ( τ :
@@ -492,17 +489,13 @@ We close the section so we can use path induction.
             ( equiv-square-sigma-over-product A is-discrete-A x y z' y f g)
             ( p' , (refl , τ))) =
           ( square-sigma-over-product A is-discrete-A x y z' y f g
-            ( p' , (refl , τ)))) ,
-        ( \ g τ →
-          refl-refl-map-equiv-square-sigma-over-product
-            ( A) (is-discrete-A)
-            ( x) (y)
-            ( f) (g)
-            ( τ)) ,
-        ( z) ,
-        ( p)) ,
-      ( w) ,
-      ( q))
+            ( p' , (refl , τ))))
+        ( refl-refl-map-equiv-square-sigma-over-product
+            ( A) (is-discrete-A) (x) (y) (f))
+        ( z)
+        ( p))
+      ( w)
+      ( q)
 
 #def is-equiv-square-sigma-over-product uses (extext)
   ( A : U)
@@ -525,7 +518,7 @@ We close the section so we can use path induction.
   :=
     is-equiv-rev-homotopic-is-equiv
     ( Σ ( p : x = z) ,
-         ( Σ ( q : y = w) ,
+        ( Σ ( q : y = w) ,
             ( product-transport A A (hom A) x z y w p q f = g)))
     ( Σ ( h : hom A x z) ,
         ( Σ ( k : hom A y w) ,

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -346,7 +346,7 @@ Some of the definitions in this file rely on extension extensionality:
   (is-segal-A : is-segal A)
   (x y : A)
   : (x = y) → Iso A is-segal-A x y
-  := \ p → idJ (A , x , \ y' p' → Iso A is-segal-A x y' , (id-iso A is-segal-A x) , y , p)
+  := \ p → ind-path (A) (x) (\ y' p' → Iso A is-segal-A x y') ((id-iso A is-segal-A x)) (y) (p)
 
 #def is-rezk
   (A : U)


### PR DESCRIPTION
Replaces the built-in `idJ` construction with its special syntax for a normal function called `ind-path`, as [suggested by Nikolai](https://github.com/emilyriehl/yoneda/issues/14#issuecomment-1617784940). I hope the current syntax for `idJ` will be deprecated in the future, but in the meanwhile this is an easy fix.

Builds on #39, related to #14.