### PR TITLE
WIP Fix some namings according to style guidelines

### DIFF
--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -41,7 +41,7 @@ The following demonstrates the syntax for constructing terms in Sigma types:
 
 #variables A B C D : U
 
-#def composition
+#def comp
   ( g : B → C)
   ( f : A → B)
   : A → C

--- a/src/hott/00-common.rzk.md
+++ b/src/hott/00-common.rzk.md
@@ -47,7 +47,7 @@ The following demonstrates the syntax for constructing terms in Sigma types:
   : A → C
   := \ z → g (f z)
 
-#def triple-composition
+#def triple-comp
   ( h : C → D)
   ( g : B → C)
   ( f : A → B)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -465,7 +465,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( f : A → B)
   ( g : B → C)
   ( p : x = y)
-  : ( ap A C x y (composition A B C g f) p) =
+  : ( ap A C x y (comp A B C g f) p) =
     ( ap B C (f x) (f y) g (ap A B x y f p))
   :=
     idJ
@@ -485,7 +485,7 @@ Application of a function to homotopic paths yields homotopic paths.
   ( g : B → C)
   ( p : x = y)
   : ( ap B C (f x) (f y) g (ap A B x y f p)) =
-    ( ap A C x y (composition A B C g f) p)
+    ( ap A C x y (comp A B C g f) p)
   :=
     rev
       ( g (f x) = g (f y))

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -443,7 +443,7 @@ The following is for a specific use.
 Application of a function to homotopic paths yields homotopic paths.
 
 ```rzk
-#def ap-htpy
+#def ap-eq
   ( A B : U)
   ( x y : A)
   ( f : A → B)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -211,7 +211,7 @@ of the path algebra coherences defined above.
 ### Postwhiskering paths of paths
 
 ```rzk
-#def homotopy-concat
+#def concat-eq-left
   ( p q : x = y)
   ( H : p = q)
   ( r : y = z)
@@ -231,7 +231,7 @@ of the path algebra coherences defined above.
 Prewhiskering paths of paths is much harder.
 
 ```rzk
-#def concat-homotopy
+#def concat-eq-right
   ( p : x = y)
   : ( q : y = z) →
     ( r : y = z) →
@@ -793,7 +793,7 @@ The following is the same as above but with alternating arguments.
       z ,
       r)
 
-#def eq-triple-concat-eq-first
+#def triple-concat-eq-first
   ( A : U)
   ( w x y z : A)
   ( p q : w = x)
@@ -801,9 +801,9 @@ The following is the same as above but with alternating arguments.
   ( s : y = z)
   ( H : p = q)
   : (triple-concat A w x y z p r s) = (triple-concat A w x y z q r s)
-  := homotopy-concat A w x z p q H (concat A x y z r s)
+  := concat-eq-left A w x z p q H (concat A x y z r s)
 
-#def eq-triple-concat-eq-second
+#def triple-concat-eq-second
   ( A : U)
   ( w x y z : A)
   ( p : w = x)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -793,7 +793,7 @@ The following is the same as above but with alternating arguments.
       z ,
       r)
 
-#def homotopy-triple-concat
+#def eq-triple-concat-eq-first
   ( A : U)
   ( w x y z : A)
   ( p q : w = x)

--- a/src/hott/01-paths.rzk.md
+++ b/src/hott/01-paths.rzk.md
@@ -803,7 +803,7 @@ The following is the same as above but with alternating arguments.
   : (triple-concat A w x y z p r s) = (triple-concat A w x y z q r s)
   := homotopy-concat A w x z p q H (concat A x y z r s)
 
-#def triple-homotopy-concat
+#def eq-triple-concat-eq-second
   ( A : U)
   ( w x y z : A)
   ( p : w = x)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -185,7 +185,7 @@ following:
         ( ap A A (f a) a (identity A) (H a)))
       ( concat A (f (f a)) (f a) (a) (H (f a)) (H a))
       ( cocone-naturality)
-      ( concat-homotopy
+      ( concat-eq-right
         ( A)
         ( f (f a))
         ( f a)
@@ -241,7 +241,7 @@ Cancelling the path `H a` on the right and reversing yields a path we need:
         triple-concat
           ( B) (g x) (f x) (f y) (g y)
           ( rev B (f x) (g x) (K x)) (p) (Ky)) ,
-      eq-triple-concat-eq-first
+      triple-concat-eq-first
         B
         ( g x)
         ( f x)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -77,8 +77,8 @@ composition.
   : homotopy
       A
       D
-      (triple-composition A B C D g h f)
-      (triple-composition A B C D g k f)
+      (triple-comp A B C D g h f)
+      (triple-comp A B C D g k f)
   :=
     homotopy-postwhisker
       A

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -30,7 +30,7 @@ This is a literate `rzk` file:
 ```
 
 ```rzk
-#def homotopy-composition
+#def comp-homotopy
   (f g h : A → B)
   (H : homotopy f g)
   (K : homotopy g h)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -22,7 +22,7 @@ This is a literate `rzk` file:
 ```
 
 ```rzk title="The reversal of a homotopy"
-#def homotopy-rev
+#def rev-homotopy
   (f g : A → B)
   (H : homotopy f g)
   : homotopy g f

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -30,7 +30,7 @@ This is a literate `rzk` file:
 ```
 
 ```rzk
-#def concat-homotopy
+#def comp-homotopy
   (f g h : A → B)
   (H : homotopy f g)
   (K : homotopy g h)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -241,7 +241,7 @@ Cancelling the path `H a` on the right and reversing yields a path we need:
         triple-concat
           ( B) (g x) (f x) (f y) (g y)
           ( rev B (f x) (g x) (K x)) (p) (Ky)) ,
-      homotopy-triple-concat
+      eq-triple-concat-eq-first
         B
         ( g x)
         ( f x)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -56,14 +56,14 @@ composition.
   (f g : A → B)
   (H : homotopy A B f g)
   (h : B → C)
-  : homotopy A C (composition A B C h f) (composition A B C h g)
+  : homotopy A C (comp A B C h f) (comp A B C h g)
   := \ a → ap B C (f a) (g a) h (H a)
 
 #def homotopy-prewhisker
   (f g : B → C)
   (H : homotopy B C f g)
   (h : A → B)
-  : homotopy A C (composition A B C f h) (composition A B C g h)
+  : homotopy A C (comp A B C f h) (comp A B C g h)
   := \ a → H (h a)
 
 #end homotopy-whiskering
@@ -84,8 +84,8 @@ composition.
       A
       C
       D
-      ( composition A B C h f)
-      ( composition A B C k f)
+      ( comp A B C h f)
+      ( comp A B C k f)
       ( homotopy-prewhisker A B C h k H f)
       g
 ```

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -30,7 +30,7 @@ This is a literate `rzk` file:
 ```
 
 ```rzk
-#def comp-homotopy
+#def concat-homotopy
   (f g h : A → B)
   (H : homotopy f g)
   (K : homotopy g h)

--- a/src/hott/02-homotopies.rzk.md
+++ b/src/hott/02-homotopies.rzk.md
@@ -52,14 +52,14 @@ composition.
 
 #variables A B C : U
 
-#def homotopy-postwhisker
+#def postwhisker-homotopy
   (f g : A → B)
   (H : homotopy A B f g)
   (h : B → C)
   : homotopy A C (comp A B C h f) (comp A B C h g)
   := \ a → ap B C (f a) (g a) h (H a)
 
-#def homotopy-prewhisker
+#def prewhisker-homotopy
   (f g : B → C)
   (H : homotopy B C f g)
   (h : A → B)
@@ -68,7 +68,7 @@ composition.
 
 #end homotopy-whiskering
 
-#def homotopy-whisker
+#def whisker-homotopy
   (A B C D : U)
   (h k : B → C)
   (H : homotopy B C h k)
@@ -80,13 +80,13 @@ composition.
       (triple-comp A B C D g h f)
       (triple-comp A B C D g k f)
   :=
-    homotopy-postwhisker
+    postwhisker-homotopy
       A
       C
       D
       ( comp A B C h f)
       ( comp A B C k f)
-      ( homotopy-prewhisker A B C h k H f)
+      ( prewhisker-homotopy A B C h k H f)
       g
 ```
 
@@ -160,8 +160,8 @@ applies to the path `H a` to produce the following naturality square.
 
 ```rzk
 #def cocone-naturality
-  : (concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
-    (concat A (f (f a)) (f a) (a) (H (f a)) (ap A A (f a) a (identity A) (H a)))
+  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
+    ( concat A (f (f a)) (f a) (a) (H (f a)) (ap A A (f a) a (identity A) (H a)))
   := nat-htpy A A f (identity A) H (f a) a (H a)
 ```
 
@@ -170,8 +170,8 @@ following:
 
 ```rzk
 #def reduced-cocone-naturality
-  : (concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
-    (concat A (f (f a)) (f a) (a) (H (f a)) (H a))
+  : ( concat A (f (f a)) (f a) a (ap A A (f a) a f (H a)) (H a)) =
+    ( concat A (f (f a)) (f a) (a) (H (f a)) (H a))
   :=
     concat
       ( (f (f a)) = a)
@@ -184,8 +184,8 @@ following:
         ( H (f a))
         ( ap A A (f a) a (identity A) (H a)))
       ( concat A (f (f a)) (f a) (a) (H (f a)) (H a))
-      (cocone-naturality)
-      (concat-homotopy
+      ( cocone-naturality)
+      ( concat-homotopy
         ( A)
         ( f (f a))
         ( f a)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -57,7 +57,7 @@ We define equivalences to be bi-invertible maps.
 #def homotopy-inverses-is-equiv uses (f)
   : homotopy B A section-is-equiv retraction-is-equiv
   :=
-    comp-homotopy B A
+    concat-homotopy B A
       ( section-is-equiv)
       ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
       ( retraction-is-equiv)
@@ -115,7 +115,7 @@ The following type of more coherent equivalences is not a proposition.
   : has-inverse A B f
   :=
     ( section-is-equiv A B f is-equiv-f ,
-      ( comp-homotopy A A
+      ( concat-homotopy A A
         ( comp A B A (section-is-equiv A B f is-equiv-f) f)
         ( comp A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -54,7 +54,7 @@ We define equivalences to be bi-invertible maps.
 ```
 
 ```rzk title="The homotopy between the section and retraction of an equivalence"
-#def homotopic-inverses-is-equiv uses (f)
+#def homotopy-inverses-is-equiv uses (f)
   : homotopy B A is-equiv-section is-equiv-retraction
   :=
     homotopy-composition B A
@@ -122,7 +122,7 @@ The following type of more coherent equivalences is not a proposition.
         ( homotopy-prewhisker A B A
           ( is-equiv-section A B f is-equiv-f)
           ( is-equiv-retraction A B f is-equiv-f)
-          ( homotopic-inverses-is-equiv A B f is-equiv-f)
+          ( homotopy-inverses-is-equiv A B f is-equiv-f)
           ( f))
         ( second (first is-equiv-f)) ,
       ( second (second is-equiv-f))))

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -57,7 +57,7 @@ We define equivalences to be bi-invertible maps.
 #def homotopy-inverses-is-equiv uses (f)
   : homotopy B A section-is-equiv retraction-is-equiv
   :=
-    homotopy-composition B A
+    comp-homotopy B A
       ( section-is-equiv)
       ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
       ( retraction-is-equiv)
@@ -115,7 +115,7 @@ The following type of more coherent equivalences is not a proposition.
   : has-inverse A B f
   :=
     ( section-is-equiv A B f is-equiv-f ,
-      ( homotopy-composition A A
+      ( comp-homotopy A A
         ( composition A B A (section-is-equiv A B f is-equiv-f) f)
         ( composition A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -139,7 +139,7 @@ The following type of more coherent equivalences is not a proposition.
 ```
 
 ```rzk title="The inverse of a map with an inverse"
-#def has-inverse-inverse uses (f)
+#def map-inverse-has-inverse uses (f)
   : B → A
   := first (has-inverse-f)
 ```
@@ -150,11 +150,11 @@ maps.
 ```rzk
 #def has-inverse-retraction-composite uses (B has-inverse-f)
   : A → A
-  := composition A B A has-inverse-inverse f
+  := composition A B A map-inverse-has-inverse f
 
 #def has-inverse-section-composite uses (A has-inverse-f)
   : B → B
-  := composition B A B f has-inverse-inverse
+  := composition B A B f map-inverse-has-inverse
 ```
 
 This composite is parallel to `f`; we won't need the dual notion.
@@ -162,7 +162,7 @@ This composite is parallel to `f`; we won't need the dual notion.
 ```rzk
 #def has-inverse-triple-composite uses (has-inverse-f)
   : A → B
-  := triple-composition A B A B f has-inverse-inverse f
+  := triple-composition A B A B f map-inverse-has-inverse f
 ```
 
 This composite is also parallel to `f`; again we won't need the dual notion.
@@ -170,7 +170,7 @@ This composite is also parallel to `f`; again we won't need the dual notion.
 ```rzk
 #def has-inverse-quintuple-composite uses (has-inverse-f)
   : A → B
-  := \ a → f (has-inverse-inverse (f (has-inverse-inverse (f a))))
+  := \ a → f (map-inverse-has-inverse (f (map-inverse-has-inverse (f a))))
 #end has-inverse-data
 ```
 

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -343,7 +343,7 @@ Now we compose the functions that are equivalences.
 If a map is homotopic to an equivalence it is an equivalence.
 
 ```rzk
-#def is-equiv-homotopic-is-equiv
+#def is-equiv-homotopy
   ( A B : U)
   ( f g : A → B)
   ( H : homotopy A B f g)
@@ -373,7 +373,7 @@ If a map is homotopic to an equivalence it is an equivalence.
   ( H : homotopy A B f g)
   ( is-equiv-f : is-equiv A B f)
   : is-equiv A B g
-  := is-equiv-homotopic-is-equiv A B g f (rev-homotopy A B f g H) is-equiv-f
+  := is-equiv-homotopy A B g f (rev-homotopy A B f g H) is-equiv-f
 ```
 
 ## Function extensionality

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -254,7 +254,7 @@ invertible map to prove symmetry:
 Now we compose the functions that are equivalences.
 
 ```rzk
-#def compose-is-equiv
+#def comp-is-equiv
   ( A B C : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -320,7 +320,7 @@ Now we compose the functions that are equivalences.
   : Equiv A D
   := comp-equiv A B D (A≃B) (comp-equiv B C D B≃C C≃D)
 
-#def triple-compose-is-equiv
+#def triple-comp-is-equiv
   ( A B C D : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -330,11 +330,11 @@ Now we compose the functions that are equivalences.
   ( is-equiv-h : is-equiv C D h)
   : is-equiv A D (triple-composition A B C D h g f)
   :=
-    compose-is-equiv A B D
+    comp-is-equiv A B D
       ( f)
       ( is-equiv-f)
       ( composition B C D h g)
-      ( compose-is-equiv B C D g is-equiv-g h is-equiv-h)
+      ( comp-is-equiv B C D g is-equiv-g h is-equiv-h)
 ```
 
 ## Equivalences and homotopy

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -54,7 +54,7 @@ We define equivalences to be bi-invertible maps.
 ```
 
 ```rzk title="The homotopy between the section and retraction of an equivalence"
-#def homotopy-inverses-is-equiv uses (f)
+#def homotopy-section-retraction-is-equiv uses (f)
   : homotopy B A section-is-equiv retraction-is-equiv
   :=
     concat-homotopy B A
@@ -122,7 +122,7 @@ The following type of more coherent equivalences is not a proposition.
         ( prewhisker-homotopy A B A
           ( section-is-equiv A B f is-equiv-f)
           ( retraction-is-equiv A B f is-equiv-f)
-          ( homotopy-inverses-is-equiv A B f is-equiv-f)
+          ( homotopy-section-retraction-is-equiv A B f is-equiv-f)
           ( f))
         ( second (first is-equiv-f)) ,
       ( second (second is-equiv-f))))
@@ -203,7 +203,7 @@ invertible map to prove symmetry:
 ```
 
 ```rzk title="Composition of equivalences in diagrammatic order"
-#def comp-equiv
+#def equiv-comp
   ( A B C : U)
   ( A≃B : Equiv A B)
   ( B≃C : Equiv B C)
@@ -255,7 +255,7 @@ invertible map to prove symmetry:
 Now we compose the functions that are equivalences.
 
 ```rzk
-#def comp-is-equiv
+#def is-equiv-comp
   ( A B C : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -300,7 +300,7 @@ Now we compose the functions that are equivalences.
   ( A≃C : Equiv A C)
   ( B≃C : Equiv B C)
   : Equiv A B
-  := comp-equiv A C B (A≃C) (inv-equiv B C B≃C)
+  := equiv-comp A C B (A≃C) (inv-equiv B C B≃C)
 ```
 
 ```rzk title="Left cancellation of equivalences in diagrammatic order"
@@ -309,7 +309,7 @@ Now we compose the functions that are equivalences.
   ( A≃B : Equiv A B)
   ( A≃C : Equiv A C)
   : Equiv B C
-  := comp-equiv B A C (inv-equiv A B A≃B) (A≃C)
+  := equiv-comp B A C (inv-equiv A B A≃B) (A≃C)
 ```
 
 ```rzk title="A composition of three equivalences"
@@ -319,7 +319,7 @@ Now we compose the functions that are equivalences.
   ( B≃C : Equiv B C)
   ( C≃D : Equiv C D)
   : Equiv A D
-  := comp-equiv A B D (A≃B) (comp-equiv B C D B≃C C≃D)
+  := equiv-comp A B D (A≃B) (equiv-comp B C D B≃C C≃D)
 
 #def triple-comp-is-equiv
   ( A B C D : U)
@@ -331,11 +331,11 @@ Now we compose the functions that are equivalences.
   ( is-equiv-h : is-equiv C D h)
   : is-equiv A D (triple-comp A B C D h g f)
   :=
-    comp-is-equiv A B D
+    is-equiv-comp A B D
       ( f)
       ( is-equiv-f)
       ( comp B C D h g)
-      ( comp-is-equiv B C D g is-equiv-g h is-equiv-h)
+      ( is-equiv-comp B C D g is-equiv-g h is-equiv-h)
 ```
 
 ## Equivalences and homotopy
@@ -367,7 +367,7 @@ If a map is homotopic to an equivalence it is an equivalence.
             ( H (first (second is-equiv-g) b))
             ( second (second is-equiv-g) b))))
 
-#def is-equiv-rev-homotopic-is-equiv
+#def is-equiv-rev-homotopy
   ( A B : U)
   ( f g : A → B)
   ( H : homotopy A B f g)
@@ -422,7 +422,7 @@ Whenever a definition (implicitly) uses function extensionality, we write
 extensionality:
 
 ```rzk title="The equivalence provided by function extensionality"
-#def FunExt-equiv uses (funext)
+#def equiv-FunExt uses (funext)
   ( X : U)
   ( A : X → U)
   ( f g : (x : X) → A x)
@@ -510,7 +510,7 @@ dependent function types.
 #def has-retraction-rev
   ( A : U)
   ( y : A)
-  : (x : A) → has-retraction (x = y) (y = x) ((\ p → ((rev A x y) p)))
+  : (x : A) → has-retraction (x = y) (y = x) (rev A x y)
   :=
     \ x →
     ( ( rev A y x) ,
@@ -530,7 +530,7 @@ dependent function types.
 #def has-section-rev
   ( A : U)
   ( y : A)
-  : (x : A) → has-section (x = y) (y = x) ((\ p → ((rev A x y) p)))
+  : (x : A) → has-section (x = y) (y = x) (rev A x y)
   :=
     \ x →
     ( ( rev A y x) ,

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -16,12 +16,12 @@ This is a literate `rzk` file:
 #def has-section
   ( f : A → B)
   : U
-  := Σ (s : B → A) , (homotopy B B (composition B A B f s) (identity B))
+  := Σ (s : B → A) , (homotopy B B (comp B A B f s) (identity B))
 
 #def has-retraction
   ( f : A → B)
   : U
-  := Σ (r : B → A) , (homotopy A A (composition A B A r f) (identity A))
+  := Σ (r : B → A) , (homotopy A A (comp A B A r f) (identity A))
 ```
 
 We define equivalences to be bi-invertible maps.
@@ -65,12 +65,12 @@ We define equivalences to be bi-invertible maps.
         ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
         ( section-is-equiv)
         ( homotopy-prewhisker B A A
-          ( composition A B A retraction-is-equiv f)
+          ( comp A B A retraction-is-equiv f)
           ( identity A)
           ( second (first is-equiv-f))
           ( section-is-equiv)))
       ( homotopy-postwhisker B B A
-        ( composition B A B f section-is-equiv)
+        ( comp B A B f section-is-equiv)
         ( identity B)
         ( second (second is-equiv-f))
         ( retraction-is-equiv))
@@ -90,8 +90,8 @@ The following type of more coherent equivalences is not a proposition.
   :=
     Σ ( g : B → A) ,
       ( product
-        ( homotopy A A (composition A B A g f) (identity A))
-        ( homotopy B B (composition B A B f g) (identity B)))
+        ( homotopy A A (comp A B A g f) (identity A))
+        ( homotopy B B (comp B A B f g) (identity B)))
 ```
 
 ## Equivalences are invertible maps
@@ -116,8 +116,8 @@ The following type of more coherent equivalences is not a proposition.
   :=
     ( section-is-equiv A B f is-equiv-f ,
       ( comp-homotopy A A
-        ( composition A B A (section-is-equiv A B f is-equiv-f) f)
-        ( composition A B A (retraction-is-equiv A B f is-equiv-f) f)
+        ( comp A B A (section-is-equiv A B f is-equiv-f) f)
+        ( comp A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)
         ( homotopy-prewhisker A B A
           ( section-is-equiv A B f is-equiv-f)
@@ -150,11 +150,11 @@ maps.
 ```rzk
 #def retraction-composite-has-inverse uses (B has-inverse-f)
   : A → A
-  := composition A B A map-inverse-has-inverse f
+  := comp A B A map-inverse-has-inverse f
 
 #def section-composite-has-inverse uses (A has-inverse-f)
   : B → B
-  := composition B A B f map-inverse-has-inverse
+  := comp B A B f map-inverse-has-inverse
 ```
 
 This composite is parallel to `f`; we won't need the dual notion.
@@ -261,9 +261,9 @@ Now we compose the functions that are equivalences.
   ( is-equiv-f : is-equiv A B f)
   ( g : B → C)
   ( is-equiv-g : is-equiv B C g)
-  : is-equiv A C (composition A B C g f)
+  : is-equiv A C (comp A B C g f)
   :=
-    ( ( composition C B A
+    ( ( comp C B A
         ( retraction-is-equiv A B f is-equiv-f)
         ( retraction-is-equiv B C g is-equiv-g) ,
         ( \ a →
@@ -278,7 +278,7 @@ Now we compose the functions that are equivalences.
               ( retraction-is-equiv A B f is-equiv-f)
               ( second (first is-equiv-g) (f a)))
             ( second (first is-equiv-f) a))) ,
-      ( composition C B A
+      ( comp C B A
         ( section-is-equiv A B f is-equiv-f)
         ( section-is-equiv B C g is-equiv-g) ,
         ( \ c →
@@ -334,7 +334,7 @@ Now we compose the functions that are equivalences.
     comp-is-equiv A B D
       ( f)
       ( is-equiv-f)
-      ( composition B C D h g)
+      ( comp B C D h g)
       ( comp-is-equiv B C D g is-equiv-g h is-equiv-h)
 ```
 
@@ -519,7 +519,7 @@ dependent function types.
         ( A ,
           x ,
           ( \ y' p' →
-            ( composition
+            ( comp
               ( x = y') (y' = x) (x = y') (rev A y' x) (rev A x y') (p'))
             =_{x = y'}
             ( p')) ,
@@ -539,7 +539,7 @@ dependent function types.
         ( A ,
           y ,
           ( \ x' p' →
-            ( composition
+            ( comp
               ( y = x') (x' = y) (y = x') (rev A x' y) (rev A y x') (p'))
             =_{y = x'}
             ( p')) ,

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -57,7 +57,7 @@ We define equivalences to be bi-invertible maps.
 #def homotopy-inverses-is-equiv uses (f)
   : homotopy B A section-is-equiv retraction-is-equiv
   :=
-    concat-homotopy B A
+    comp-homotopy B A
       ( section-is-equiv)
       ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
       ( retraction-is-equiv)
@@ -115,7 +115,7 @@ The following type of more coherent equivalences is not a proposition.
   : has-inverse A B f
   :=
     ( section-is-equiv A B f is-equiv-f ,
-      ( concat-homotopy A A
+      ( comp-homotopy A A
         ( comp A B A (section-is-equiv A B f is-equiv-f) f)
         ( comp A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -209,14 +209,15 @@ invertible map to prove symmetry:
   ( B≃C : Equiv B C)
   : Equiv A C
   :=
-    ( \ a → first B≃C (first A≃B a) , -- the composite equivalence
-      ( ( ( \ c →
-            first (first (second A≃B))) ((first (first (second (B≃C)))) c) ,
+    ( ( \ a → first B≃C (first A≃B a)) ,
+      ( ( ( \ c → first (first (second A≃B)) (first (first (second (B≃C))) c)) ,
           ( \ a →
             concat A
               ( first
                 ( first (second A≃B))
-                ( first (first (second B≃C)) (first B≃C (first A≃B a))))
+                ( first
+                  ( first (second B≃C))
+                  ( first B≃C (first A≃B a))))
               ( first (first (second A≃B)) (first A≃B a))
               ( a)
               ( ap B A
@@ -224,11 +225,11 @@ invertible map to prove symmetry:
                 ( first A≃B a)
                 ( first (first (second A≃B)))
                 ( second (first (second B≃C)) (first A≃B a)))
-              ( ( second (first (second A≃B))) a))) ,
-                ( \ c →
-                  first
-                    ( second (second A≃B))
-                    ( (first (second (second (B≃C)))) c) ,
+              ( second (first (second A≃B)) a))) ,
+        ( ( \ c →
+          first
+            ( second (second A≃B))
+            ( first (second (second (B≃C))) c)) ,
           ( \ c →
             concat C
               ( first B≃C

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -64,12 +64,12 @@ We define equivalences to be bi-invertible maps.
       ( homotopy-rev B A
         ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
         ( section-is-equiv)
-        ( homotopy-prewhisker B A A
+        ( prewhisker-homotopy B A A
           ( comp A B A retraction-is-equiv f)
           ( identity A)
           ( second (first is-equiv-f))
           ( section-is-equiv)))
-      ( homotopy-postwhisker B B A
+      ( postwhisker-homotopy B B A
         ( comp B A B f section-is-equiv)
         ( identity B)
         ( second (second is-equiv-f))
@@ -119,7 +119,7 @@ The following type of more coherent equivalences is not a proposition.
         ( comp A B A (section-is-equiv A B f is-equiv-f) f)
         ( comp A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)
-        ( homotopy-prewhisker A B A
+        ( prewhisker-homotopy A B A
           ( section-is-equiv A B f is-equiv-f)
           ( retraction-is-equiv A B f is-equiv-f)
           ( homotopy-inverses-is-equiv A B f is-equiv-f)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -44,36 +44,36 @@ We define equivalences to be bi-invertible maps.
 #variable f : A → B
 #variable is-equiv-f : is-equiv A B f
 
-#def is-equiv-section uses (f)
+#def section-is-equiv uses (f)
   : B → A
   := first (second is-equiv-f)
 
-#def is-equiv-retraction uses (f)
+#def retraction-is-equiv uses (f)
   : B → A
   := first (first is-equiv-f)
 ```
 
 ```rzk title="The homotopy between the section and retraction of an equivalence"
 #def homotopy-inverses-is-equiv uses (f)
-  : homotopy B A is-equiv-section is-equiv-retraction
+  : homotopy B A section-is-equiv retraction-is-equiv
   :=
     homotopy-composition B A
-      ( is-equiv-section)
-      ( triple-composition B A B A is-equiv-retraction f is-equiv-section)
-      ( is-equiv-retraction)
+      ( section-is-equiv)
+      ( triple-composition B A B A retraction-is-equiv f section-is-equiv)
+      ( retraction-is-equiv)
       ( homotopy-rev B A
-        ( triple-composition B A B A is-equiv-retraction f is-equiv-section)
-        ( is-equiv-section)
+        ( triple-composition B A B A retraction-is-equiv f section-is-equiv)
+        ( section-is-equiv)
         ( homotopy-prewhisker B A A
-          ( composition A B A is-equiv-retraction f)
+          ( composition A B A retraction-is-equiv f)
           ( identity A)
           ( second (first is-equiv-f))
-          ( is-equiv-section)))
+          ( section-is-equiv)))
       ( homotopy-postwhisker B B A
-        ( composition B A B f is-equiv-section)
+        ( composition B A B f section-is-equiv)
         ( identity B)
         ( second (second is-equiv-f))
-        ( is-equiv-retraction))
+        ( retraction-is-equiv))
 
 #end equivalence-data
 ```
@@ -114,14 +114,14 @@ The following type of more coherent equivalences is not a proposition.
   ( is-equiv-f : is-equiv A B f)
   : has-inverse A B f
   :=
-    ( is-equiv-section A B f is-equiv-f ,
+    ( section-is-equiv A B f is-equiv-f ,
       ( homotopy-composition A A
-        ( composition A B A (is-equiv-section A B f is-equiv-f) f)
-        ( composition A B A (is-equiv-retraction A B f is-equiv-f) f)
+        ( composition A B A (section-is-equiv A B f is-equiv-f) f)
+        ( composition A B A (retraction-is-equiv A B f is-equiv-f) f)
         ( identity A)
         ( homotopy-prewhisker A B A
-          ( is-equiv-section A B f is-equiv-f)
-          ( is-equiv-retraction A B f is-equiv-f)
+          ( section-is-equiv A B f is-equiv-f)
+          ( retraction-is-equiv A B f is-equiv-f)
           ( homotopy-inverses-is-equiv A B f is-equiv-f)
           ( f))
         ( second (first is-equiv-f)) ,
@@ -148,11 +148,11 @@ The following are some iterated composites associated to a pair of invertible
 maps.
 
 ```rzk
-#def has-inverse-retraction-composite uses (B has-inverse-f)
+#def retraction-composite-has-inverse uses (B has-inverse-f)
   : A → A
   := composition A B A map-inverse-has-inverse f
 
-#def has-inverse-section-composite uses (A has-inverse-f)
+#def section-composite-has-inverse uses (A has-inverse-f)
   : B → B
   := composition B A B f map-inverse-has-inverse
 ```
@@ -160,7 +160,7 @@ maps.
 This composite is parallel to `f`; we won't need the dual notion.
 
 ```rzk
-#def has-inverse-triple-composite uses (has-inverse-f)
+#def triple-composite-has-inverse uses (has-inverse-f)
   : A → B
   := triple-composition A B A B f map-inverse-has-inverse f
 ```
@@ -168,7 +168,7 @@ This composite is parallel to `f`; we won't need the dual notion.
 This composite is also parallel to `f`; again we won't need the dual notion.
 
 ```rzk
-#def has-inverse-quintuple-composite uses (has-inverse-f)
+#def quintuple-composite-has-inverse uses (has-inverse-f)
   : A → B
   := \ a → f (map-inverse-has-inverse (f (map-inverse-has-inverse (f a))))
 #end has-inverse-data
@@ -209,25 +209,26 @@ invertible map to prove symmetry:
   ( B≃C : Equiv B C)
   : Equiv A C
   :=
-    ( \ a → (first B≃C) ((first A≃B) a) , -- the composite equivalence
-      ( ( \ c →
-          ( first (first (second A≃B))) ((first (first (second (B≃C)))) c) ,
+    ( \ a → first B≃C (first A≃B a) , -- the composite equivalence
+      ( ( ( \ c →
+            first (first (second A≃B))) ((first (first (second (B≃C)))) c) ,
           ( \ a →
             concat A
-              ( (first (first (second A≃B)))
-                ((first (first (second B≃C)))
-                ((first B≃C) ((first A≃B) a))))
-              ( (first (first (second A≃B))) ((first A≃B) a))
+              ( first
+                ( first (second A≃B))
+                ( first (first (second B≃C)) (first B≃C (first A≃B a))))
+              ( first (first (second A≃B)) (first A≃B a))
               ( a)
               ( ap B A
-                ( (first (first (second B≃C))) ((first B≃C) ((first A≃B) a)))
-                ( (first A≃B) a)
+                ( first (first (second B≃C)) (first B≃C (first A≃B a)))
+                ( first A≃B a)
                 ( first (first (second A≃B)))
-                ( (second (first (second B≃C))) ((first A≃B) a)))
-              ( (second (first (second A≃B))) a))) ,
+                ( second (first (second B≃C)) (first A≃B a)))
+              ( ( second (first (second A≃B))) a))) ,
                 ( \ c →
-                  ( first (second (second A≃B)))
-                  ( (first (second (second (B≃C)))) c) ,
+                  first
+                    ( second (second A≃B))
+                    ( (first (second (second (B≃C)))) c) ,
           ( \ c →
             concat C
               ( first B≃C
@@ -262,34 +263,34 @@ Now we compose the functions that are equivalences.
   : is-equiv A C (composition A B C g f)
   :=
     ( ( composition C B A
-        ( is-equiv-retraction A B f is-equiv-f)
-        ( is-equiv-retraction B C g is-equiv-g) ,
+        ( retraction-is-equiv A B f is-equiv-f)
+        ( retraction-is-equiv B C g is-equiv-g) ,
         ( \ a →
           concat A
-            ( (is-equiv-retraction A B f is-equiv-f)
-              ((is-equiv-retraction B C g is-equiv-g) (g (f a))))
-            ( (is-equiv-retraction A B f is-equiv-f) (f a))
+            ( retraction-is-equiv A B f is-equiv-f
+              ( retraction-is-equiv B C g is-equiv-g (g (f a))))
+            ( retraction-is-equiv A B f is-equiv-f (f a))
             ( a)
             ( ap B A
-              ( (is-equiv-retraction B C g is-equiv-g) (g (f a)))
+              ( retraction-is-equiv B C g is-equiv-g (g (f a)))
               ( f a)
-              ( is-equiv-retraction A B f is-equiv-f)
-              ( (second (first is-equiv-g)) (f a)))
-            ( (second (first is-equiv-f)) a))) ,
+              ( retraction-is-equiv A B f is-equiv-f)
+              ( second (first is-equiv-g) (f a)))
+            ( second (first is-equiv-f) a))) ,
       ( composition C B A
-        ( is-equiv-section A B f is-equiv-f)
-        ( is-equiv-section B C g is-equiv-g) ,
+        ( section-is-equiv A B f is-equiv-f)
+        ( section-is-equiv B C g is-equiv-g) ,
         ( \ c →
           concat C
-            ( g (f ((first (second is-equiv-f)) ((first (second is-equiv-g)) c))))
-            ( g ((first (second is-equiv-g)) c))
+            ( g (f (first (second is-equiv-f) (first (second is-equiv-g) c))))
+            ( g (first (second is-equiv-g) c))
             ( c)
             ( ap B C
-              ( f ((first (second is-equiv-f)) ((first (second is-equiv-g)) c)))
-              ( (first (second is-equiv-g)) c)
+              ( f (first (second is-equiv-f) (first (second is-equiv-g) c)))
+              ( first (second is-equiv-g) c)
               ( g)
-              ( (second (second is-equiv-f)) ((first (second is-equiv-g)) c)))
-                ((second (second is-equiv-g)) c))))
+              ( second (second is-equiv-f) (first (second is-equiv-g) c)))
+            ( second (second is-equiv-g) c))))
 ```
 
 ```rzk title="Right cancellation of equivalences in diagrammatic order"
@@ -351,19 +352,19 @@ If a map is homotopic to an equivalence it is an equivalence.
     ( ( ( first (first is-equiv-g)) ,
         ( \ a →
           concat A
-            ( (first (first is-equiv-g)) (f a))
-            ( (first (first is-equiv-g)) (g a))
+            ( first (first is-equiv-g) (f a))
+            ( first (first is-equiv-g) (g a))
             ( a)
             ( ap B A (f a) (g a) (first (first is-equiv-g)) (H a))
-            ( (second (first is-equiv-g)) a))) ,
+            ( second (first is-equiv-g) a))) ,
       ( ( first (second is-equiv-g)) ,
         ( \ b →
           concat B
-            ( f ((first (second is-equiv-g)) b))
-            ( g ((first (second is-equiv-g)) b))
+            ( f (first (second is-equiv-g) b))
+            ( g (first (second is-equiv-g) b))
             ( b)
-            ( H ((first (second is-equiv-g)) b))
-            ( (second (second is-equiv-g)) b))))
+            ( H (first (second is-equiv-g) b))
+            ( second (second is-equiv-g) b))))
 
 #def is-equiv-rev-homotopic-is-equiv
   ( A B : U)
@@ -450,25 +451,25 @@ dependent function types.
   ( fibequiv : (x : X) → Equiv (A x) (B x))
   : Equiv ((x : X) → A x) ((x : X) → B x)
   :=
-    ( ( \ a x → (first (fibequiv x)) (a x)) ,
-      ( ( ( \ b x → (first (first (second (fibequiv x)))) (b x)) ,
+    ( ( \ a x → first (fibequiv x) (a x)) ,
+      ( ( ( \ b x → first (first (second (fibequiv x))) (b x)) ,
           ( \ a →
             eq-htpy
               X A
               ( \ x →
-                (first (first (second (fibequiv x))))
-                  ((first (fibequiv x)) (a x)))
+                first
+                  ( first (second (fibequiv x)))
+                  ( first (fibequiv x) (a x)))
               ( a)
-              ( \ x → (second (first (second (fibequiv x)))) (a x)))) ,
-        ( ( \ b x → (first (second (second (fibequiv x)))) (b x)) ,
+              ( \ x → second (first (second (fibequiv x))) (a x)))) ,
+        ( ( \ b x → first (second (second (fibequiv x))) (b x)) ,
           ( \ b →
             eq-htpy
               X B
               ( \ x →
-                (first (fibequiv x))
-                  ((first (second (second (fibequiv x)))) (b x)))
+                first (fibequiv x) (first (second (second (fibequiv x))) (b x)))
               ( b)
-              ( \ x → (second (second (second (fibequiv x)))) (b x))))))
+              ( \ x → second (second (second (fibequiv x))) (b x))))))
 ```
 
 ## Embeddings

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -61,7 +61,7 @@ We define equivalences to be bi-invertible maps.
       ( section-is-equiv)
       ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
       ( retraction-is-equiv)
-      ( homotopy-rev B A
+      ( rev-homotopy B A
         ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
         ( section-is-equiv)
         ( prewhisker-homotopy B A A
@@ -373,7 +373,7 @@ If a map is homotopic to an equivalence it is an equivalence.
   ( H : homotopy A B f g)
   ( is-equiv-f : is-equiv A B f)
   : is-equiv A B g
-  := is-equiv-homotopic-is-equiv A B g f (homotopy-rev A B f g H) is-equiv-f
+  := is-equiv-homotopic-is-equiv A B g f (rev-homotopy A B f g H) is-equiv-f
 ```
 
 ## Function extensionality

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -59,10 +59,10 @@ We define equivalences to be bi-invertible maps.
   :=
     homotopy-composition B A
       ( section-is-equiv)
-      ( triple-composition B A B A retraction-is-equiv f section-is-equiv)
+      ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
       ( retraction-is-equiv)
       ( homotopy-rev B A
-        ( triple-composition B A B A retraction-is-equiv f section-is-equiv)
+        ( triple-comp B A B A retraction-is-equiv f section-is-equiv)
         ( section-is-equiv)
         ( homotopy-prewhisker B A A
           ( composition A B A retraction-is-equiv f)
@@ -162,7 +162,7 @@ This composite is parallel to `f`; we won't need the dual notion.
 ```rzk
 #def triple-composite-has-inverse uses (has-inverse-f)
   : A → B
-  := triple-composition A B A B f map-inverse-has-inverse f
+  := triple-comp A B A B f map-inverse-has-inverse f
 ```
 
 This composite is also parallel to `f`; again we won't need the dual notion.
@@ -328,7 +328,7 @@ Now we compose the functions that are equivalences.
   ( is-equiv-g : is-equiv B C g)
   ( h : C → D)
   ( is-equiv-h : is-equiv C D h)
-  : is-equiv A D (triple-composition A B C D h g f)
+  : is-equiv A D (triple-comp A B C D h g f)
   :=
     comp-is-equiv A B D
       ( f)

--- a/src/hott/03-equivalences.rzk.md
+++ b/src/hott/03-equivalences.rzk.md
@@ -295,7 +295,7 @@ Now we compose the functions that are equivalences.
 ```
 
 ```rzk title="Right cancellation of equivalences in diagrammatic order"
-#def right-cancel-equiv
+#def equiv-right-cancel
   ( A B C : U)
   ( A≃C : Equiv A C)
   ( B≃C : Equiv B C)
@@ -304,7 +304,7 @@ Now we compose the functions that are equivalences.
 ```
 
 ```rzk title="Left cancellation of equivalences in diagrammatic order"
-#def left-cancel-equiv
+#def equiv-left-cancel
   ( A B C : U)
   ( A≃B : Equiv A B)
   ( A≃C : Equiv A C)
@@ -313,7 +313,7 @@ Now we compose the functions that are equivalences.
 ```
 
 ```rzk title="A composition of three equivalences"
-#def triple-comp-equiv
+#def equiv-triple-comp
   ( A B C D : U)
   ( A≃B : Equiv A B)
   ( B≃C : Equiv B C)
@@ -321,7 +321,7 @@ Now we compose the functions that are equivalences.
   : Equiv A D
   := equiv-comp A B D (A≃B) (equiv-comp B C D B≃C C≃D)
 
-#def triple-comp-is-equiv
+#def is-equiv-triple-comp
   ( A B C D : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -529,10 +529,9 @@ dependent function types.
 
 #def has-section-rev
   ( A : U)
-  ( y : A)
-  : (x : A) → has-section (x = y) (y = x) (rev A x y)
+  ( y x : A)
+  : has-section (x = y) (y = x) (rev A x y)
   :=
-    \ x →
     ( ( rev A y x) ,
       ( \ p →
         idJ

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -39,7 +39,7 @@ one:
     Σ ( has-inverse-f : (has-inverse A B f)) ,
       ( ( a : A) →
         ( second (second has-inverse-f) (f a)) =
-          ( ap A B
+        ( ap A B
           ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( a)
           ( f)
@@ -758,7 +758,7 @@ have equivalent identity types.
     is-equiv-ap-is-half-adjoint-equiv A B f
     ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) x y
 
-#def Eq-ap-is-equiv
+#def equiv-ap-is-equiv
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -385,7 +385,7 @@ have equivalent identity types.
 
 #variables A B : U
 #variable f : A → B
-#variable fisHAE : is-half-adjoint-equiv A B f
+#variable is-HAE-f : is-half-adjoint-equiv A B f
 
 #def iff-ap-is-half-adjoint-equiv
   ( x y : A)
@@ -395,13 +395,13 @@ have equivalent identity types.
       \ q →
       triple-concat A
         ( x)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
         ( y)
-        ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-          ( (first (second (first fisHAE))) x))
-        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
-        ( (first (second (first fisHAE))) y))
+        ( rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+          ( (first (second (first is-HAE-f))) x))
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q)
+        ( (first (second (first is-HAE-f))) y))
 
 #def has-retraction-ap-is-half-adjoint-equiv
   (x y : A)
@@ -416,8 +416,8 @@ have equivalent identity types.
               ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
               p' ,
             ( rev-refl-id-triple-concat A
-              ( (map-inverse-has-inverse A B f (first fisHAE)) (f x)) x
-              ( (first (second (first fisHAE))) x)) ,
+              ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x
+              ( (first (second (first is-HAE-f))) x)) ,
             y ,
             p))
 
@@ -427,143 +427,143 @@ have equivalent identity types.
   : ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q) =
     (triple-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
-      ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-        ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-          ( (first (second (first fisHAE))) x)))
+      ( ap A B x ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) f
+        ( rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+          ( (first (second (first is-HAE-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-        ( (first (second (first fisHAE))) y)))
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+        ( (first (second (first is-HAE-f))) y)))
   :=
     ap-triple-concat A B
       ( x)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
       ( y)
       ( f)
-      ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-        ( (first (second (first fisHAE))) x))
-      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
-      ( (first (second (first fisHAE))) y)
+      ( rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+        ( (first (second (first is-HAE-f))) x))
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q)
+      ( (first (second (first is-HAE-f))) y)
 
 #def ap-rev-homotopy-triple-concat-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
     ( f y)
-    ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-      (rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-        ( (first (second (first fisHAE))) x)))
+    ( ap A B x ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) f
+      (rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+        ( (first (second (first is-HAE-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-      ( (first (second (first fisHAE))) y)) =
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+    ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+      ( (first (second (first is-HAE-f))) y)) =
     triple-concat B
     ( f x)
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
     ( f y)
-    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-        ( (first (second (first fisHAE))) x)))
+    ( rev B (f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+        ( (first (second (first is-HAE-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
       ( y)
       ( f)
-      ( (first (second (first fisHAE))) y))
+      ( (first (second (first is-HAE-f))) y))
   :=
     homotopy-triple-concat B
     ( f x)
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
     ( f y)
     ( ap A B
-      ( x) ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-      ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-        ( (first (second (first fisHAE))) x)))
-    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-        ( (first (second (first fisHAE))) x)))
+      ( x) ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) f
+      ( rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+        ( (first (second (first is-HAE-f))) x)))
+    ( rev B (f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+        ( (first (second (first is-HAE-f))) x)))
     ( ap A B
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-      ( (first (second (first fisHAE))) y))
-    ( ap-rev A B (retraction-composite-has-inverse A B f (first fisHAE) x) x f
-      ( (first (second (first fisHAE))) x))
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+    ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+      ( (first (second (first is-HAE-f))) y))
+    ( ap-rev A B (retraction-composite-has-inverse A B f (first is-HAE-f) x) x f
+      ( (first (second (first is-HAE-f))) x))
 
 #def ap-ap-homotopy-triple-concat-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : (triple-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
       ( rev B
-        ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
+        ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x))
         ( f x)
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-          ( (first (second (first fisHAE))) x)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+          ( (first (second (first is-HAE-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-        ( (first (second (first fisHAE))) y))) =
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+        ( (first (second (first is-HAE-f))) y))) =
     ( triple-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
       ( rev B
-        ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-          ( (first (second (first fisHAE))) x)))
+        ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+          ( (first (second (first is-HAE-f))) x)))
       ( ap B B (f x) (f y)
-        ( section-composite-has-inverse A B f (first fisHAE)) q)
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
-        ( f) ((first (second (first fisHAE))) y)))
+        ( section-composite-has-inverse A B f (first is-HAE-f)) q)
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
+        ( f) ((first (second (first is-HAE-f))) y)))
   :=
     triple-homotopy-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
-      ( rev B ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-          ( (first (second (first fisHAE))) x)))
+      ( rev B ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+          ( (first (second (first is-HAE-f))) x)))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-      ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-        ( (first (second (first fisHAE))) y))
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+      ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-HAE-f)) q)
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+        ( (first (second (first is-HAE-f))) y))
       ( rev-ap-comp B A B (f x) (f y)
-        ( map-inverse-has-inverse A B f (first fisHAE)) f q)
+        ( map-inverse-has-inverse A B f (first is-HAE-f)) f q)
 
 -- This needs to be reversed later.
 #def triple-concat-higher-homotopy-is-half-adjoint-equiv
@@ -571,54 +571,54 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
-      ( rev B ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-        ( (second (second (first fisHAE))) (f x)))
+      ( rev B ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+        ( (second (second (first is-HAE-f))) (f x)))
       ( ap B B (f x) (f y)
-        ( section-composite-has-inverse A B f (first fisHAE)) q)
-      ( (second (second (first fisHAE))) (f y)) =
+        ( section-composite-has-inverse A B f (first is-HAE-f)) q)
+      ( (second (second (first is-HAE-f))) (f y)) =
     triple-concat B
       ( f x)
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
       ( f y)
-      (rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-        (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f ((first (second (first fisHAE))) x)))
-        (ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
-        (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f ((first (second (first fisHAE))) y))
+      (rev B (f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+        (ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f ((first (second (first is-HAE-f))) x)))
+        (ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-HAE-f)) q)
+        (ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f ((first (second (first is-HAE-f))) y))
   :=
     triple-concat-higher-homotopy A B
-      ( triple-composite-has-inverse A B f (first fisHAE)) f
-      ( \ a → (((second (second (first fisHAE)))) (f a)))
+      ( triple-composite-has-inverse A B f (first is-HAE-f)) f
+      ( \ a → (((second (second (first is-HAE-f)))) (f a)))
       ( \ a →
-        ( ap A B (retraction-composite-has-inverse A B f (first fisHAE) a) a f
-          ( ((first (second (first fisHAE)))) a)))
-      ( second fisHAE)
+        ( ap A B (retraction-composite-has-inverse A B f (first is-HAE-f) a) a f
+          ( ((first (second (first is-HAE-f)))) a)))
+      ( second is-HAE-f)
       ( x)
       ( y)
       ( ap B B (f x) (f y)
-        ( section-composite-has-inverse A B f (first fisHAE)) q)
+        ( section-composite-has-inverse A B f (first is-HAE-f)) q)
 
 #def triple-concat-nat-htpy-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
     ( f y)
-    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-      ( ((second (second (first fisHAE)))) (f x)))
-    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
-    ( ((second (second (first fisHAE)))) (f y))
+    ( rev B (f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+      ( ((second (second (first is-HAE-f)))) (f x)))
+    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-HAE-f)) q)
+    ( ((second (second (first is-HAE-f)))) (f y))
     = ap B B (f x) (f y) (identity B) q
   :=
     triple-concat-nat-htpy B B
-      ( section-composite-has-inverse A B f (first fisHAE))
+      ( section-composite-has-inverse A B f (first is-HAE-f))
       ( identity B)
-      ( (second (second (first fisHAE))))
+      ( (second (second (first is-HAE-f))))
       ( f x)
       ( f y)
       q
@@ -628,43 +628,43 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
     ( f y)
-    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-        ( (first (second (first fisHAE))) x)))
-    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
-    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-      ( (first (second (first fisHAE))) y)) =
+    ( rev B (f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+      ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+        ( (first (second (first is-HAE-f))) x)))
+    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first is-HAE-f)) q)
+    ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+      ( (first (second (first is-HAE-f))) y)) =
     ap B B (f x) (f y) (identity B) q
   :=
     zag-zig-concat (f x = f y)
       ( triple-concat B
         ( f x)
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
         ( f y)
         ( rev B
-          ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-            ( (first (second (first fisHAE))) x)))
+          ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+          ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+            ( (first (second (first is-HAE-f))) x)))
         ( ap B B (f x) (f y)
-          ( section-composite-has-inverse A B f (first fisHAE)) q)
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
-          f ((first (second (first fisHAE))) y)))
+          ( section-composite-has-inverse A B f (first is-HAE-f)) q)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
+          f ((first (second (first is-HAE-f))) y)))
       ( triple-concat B
         ( f x)
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
         ( f y)
         ( rev B
-          ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
+          ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x))
           ( f x)
-          ( ((second (second (first fisHAE)))) (f x)))
+          ( ((second (second (first is-HAE-f)))) (f x)))
         ( ap B B (f x) (f y)
-          ( section-composite-has-inverse A B f (first fisHAE)) q)
-        ( ((second (second (first fisHAE)))) (f y)))
+          ( section-composite-has-inverse A B f (first is-HAE-f)) q)
+        ( ((second (second (first is-HAE-f)))) (f y)))
       ( ap B B (f x) (f y) (identity B) q)
       ( triple-concat-higher-homotopy-is-half-adjoint-equiv x y q)
       ( triple-concat-nat-htpy-is-half-adjoint-equiv x y q)
@@ -684,63 +684,63 @@ have equivalent identity types.
       ( ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q))
       ( triple-concat B
         ( f x)
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
         ( f y)
-        ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-          ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
-            ( (first (second (first fisHAE))) x)))
+        ( ap A B x ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) f
+          ( rev A (retraction-composite-has-inverse A B f (first is-HAE-f) x) x
+            ( (first (second (first is-HAE-f))) x)))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f y)) f
-          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-          ( (first (second (first fisHAE))) y)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) f
+          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+          ( (first (second (first is-HAE-f))) y)))
       ( ap-triple-concat-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
         ( f y)
         ( rev B
-          ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
-          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-            ( (first (second (first fisHAE))) x)))
+          ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x)) (f x)
+          ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+            ( (first (second (first is-HAE-f))) x)))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f y)) f
-          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
-          ( (first (second (first fisHAE))) y)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f x))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) f
+          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
+          ( (first (second (first is-HAE-f))) y)))
       ( ap-rev-homotopy-triple-concat-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
         ( f y)
         ( rev B
-          ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
+          ( f (retraction-composite-has-inverse A B f (first is-HAE-f) x))
           ( f x)
-          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
-            ( (first (second (first fisHAE))) x)))
+          ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)) x f
+            ( (first (second (first is-HAE-f))) x)))
         ( ap B B (f x) (f y)
-          ( section-composite-has-inverse A B f (first fisHAE)) q)
-        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
-          f ((first (second (first fisHAE))) y)))
+          ( section-composite-has-inverse A B f (first is-HAE-f)) q)
+        ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
+          f ((first (second (first is-HAE-f))) y)))
       ( ap-ap-homotopy-triple-concat-is-half-adjoint-equiv x y q)
       ( ap B B (f x) (f y) (identity B) q)
       ( zag-zig-concat-triple-concat-is-half-adjoint-equiv x y q)
       ( q)
       ( triple-concat-reduction-is-half-adjoint-equiv x y q)
 
-#def has-section-ap-is-half-adjoint-equiv uses (fisHAE)
+#def has-section-ap-is-half-adjoint-equiv uses (is-HAE-f)
   ( x y : A)
   : has-section (x = y) (f x = f y) (ap A B x y f)
   :=
     ( second (iff-ap-is-half-adjoint-equiv x y) ,
       section-htpy-ap-is-half-adjoint-equiv x y)
 
-#def is-equiv-ap-is-half-adjoint-equiv uses (fisHAE)
+#def is-equiv-ap-is-half-adjoint-equiv uses (is-HAE-f)
   ( x y : A)
   : is-equiv (x = y) (f x = f y) (ap A B x y f)
   :=

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -248,7 +248,7 @@ rotation.
           ( triple-composite-has-inverse A B f has-inverse-f a))
         ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
           ( has-inverse-kept-htpy A B f has-inverse-f a)))
-      ( homotopy-concat B
+      ( concat-eq-left B
         ( quintuple-composite-has-inverse A B f has-inverse-f a)
         ( triple-composite-has-inverse A B f has-inverse-f a)
         ( f a)
@@ -452,7 +452,7 @@ have equivalent identity types.
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q)
       ( (first (second (first is-HAE-f))) y)
 
-#def ap-rev-eq-triple-concat-eq-first-is-half-adjoint-equiv
+#def ap-rev-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : triple-concat B
@@ -489,7 +489,7 @@ have equivalent identity types.
       ( f)
       ( (first (second (first is-HAE-f))) y))
   :=
-    eq-triple-concat-eq-first B
+    triple-concat-eq-first B
     ( f x)
     ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
@@ -511,7 +511,7 @@ have equivalent identity types.
     ( ap-rev A B (retraction-composite-has-inverse A B f (first is-HAE-f) x) x f
       ( (first (second (first is-HAE-f))) x))
 
-#def ap-ap-eq-triple-concat-eq-first-is-half-adjoint-equiv
+#def ap-ap-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : (triple-concat B
@@ -546,7 +546,7 @@ have equivalent identity types.
       ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
         ( f) ((first (second (first is-HAE-f))) y)))
   :=
-    eq-triple-concat-eq-second B
+    triple-concat-eq-second B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
@@ -712,7 +712,7 @@ have equivalent identity types.
           ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
         ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
           ( (first (second (first is-HAE-f))) y)))
-      ( ap-rev-eq-triple-concat-eq-first-is-half-adjoint-equiv x y q)
+      ( ap-rev-triple-concat-eq-first-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
@@ -727,7 +727,7 @@ have equivalent identity types.
           ( section-composite-has-inverse A B f (first is-HAE-f)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
           f ((first (second (first is-HAE-f))) y)))
-      ( ap-ap-eq-triple-concat-eq-first-is-half-adjoint-equiv x y q)
+      ( ap-ap-triple-concat-eq-first-is-half-adjoint-equiv x y q)
       ( ap B B (f x) (f y) (identity B) q)
       ( zag-zig-concat-triple-concat-is-half-adjoint-equiv x y q)
       ( q)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -21,7 +21,7 @@ We'll require a more coherent notion of equivalence. Namely, the notion of
       ( ( a : A) →
         ( second (second has-inverse-f) (f a)) =
         ( ap A B
-          ( has-inverse-retraction-composite A B f has-inverse-f a)
+          ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( a)
           ( f)
           ( first (second has-inverse-f) a)))
@@ -40,7 +40,7 @@ one:
       ( ( a : A) →
         ( second (second has-inverse-f) (f a)) =
           ( ap A B
-          ( has-inverse-retraction-composite A B f has-inverse-f a)
+          ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( a)
           ( f)
           ( first (second has-inverse-f) a)))
@@ -57,7 +57,7 @@ and discard the other.
   ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : homotopy A A
-    ( has-inverse-retraction-composite A B f has-inverse-f) (identity A)
+    ( retraction-composite-has-inverse A B f has-inverse-f) (identity A)
   := ( first (second has-inverse-f))
 
 #def has-inverse-discarded-htpy
@@ -65,7 +65,7 @@ and discard the other.
   ( f : A → B)
   ( has-inverse-f : has-inverse A B f)
   : homotopy B B
-    ( has-inverse-section-composite A B f has-inverse-f) (identity B)
+    ( section-composite-has-inverse A B f has-inverse-f) (identity B)
   := (second (second has-inverse-f))
 ```
 
@@ -82,27 +82,27 @@ following naturality square.
 
 #def has-inverse-discarded-naturality-square
   : concat B
-    ( has-inverse-quintuple-composite A B f has-inverse-f a)
-    ( has-inverse-triple-composite A B f has-inverse-f a)
+    ( quintuple-composite-has-inverse A B f has-inverse-f a)
+    ( triple-composite-has-inverse A B f has-inverse-f a)
     ( f a)
-    ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
-      ( has-inverse-triple-composite A B f has-inverse-f)
+    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( triple-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
     ( has-inverse-discarded-htpy A B f has-inverse-f (f a)) =
     concat B
-    ( has-inverse-quintuple-composite A B f has-inverse-f a)
-      ( has-inverse-triple-composite A B f has-inverse-f a)
+    ( quintuple-composite-has-inverse A B f has-inverse-f a)
+      ( triple-composite-has-inverse A B f has-inverse-f a)
       ( f a)
       ( has-inverse-discarded-htpy A B f has-inverse-f
-        ( has-inverse-triple-composite A B f has-inverse-f a))
-      ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
+        ( triple-composite-has-inverse A B f has-inverse-f a))
+      ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
         f (has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     nat-htpy A B
-    ( has-inverse-triple-composite A B f has-inverse-f)
+    ( triple-composite-has-inverse A B f has-inverse-f)
     ( f)
     ( \ x → has-inverse-discarded-htpy A B f has-inverse-f (f x))
-    ( has-inverse-retraction-composite A B f has-inverse-f a)
+    ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( a)
     ( has-inverse-kept-htpy A B f has-inverse-f a)
 ```
@@ -112,84 +112,84 @@ We build a path that will be whiskered into the naturality square above:
 ```rzk
 #def has-inverse-cocone-homotopy-coherence
   : has-inverse-kept-htpy A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a) =
-    ap A A (has-inverse-retraction-composite A B f has-inverse-f a) a
-      ( has-inverse-retraction-composite A B f has-inverse-f)
+      ( retraction-composite-has-inverse A B f has-inverse-f a) =
+    ap A A (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( retraction-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a)
   :=
     cocone-naturality-coherence
       ( A)
-      ( has-inverse-retraction-composite A B f has-inverse-f)
+      ( retraction-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f)
       ( a)
 
 #def has-inverse-ap-cocone-homotopy-coherence
   : ap A B
-    ( has-inverse-retraction-composite A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a))
-    ( has-inverse-retraction-composite A B f has-inverse-f a)
+    ( retraction-composite-has-inverse A B f has-inverse-f
+      ( retraction-composite-has-inverse A B f has-inverse-f a))
+    ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( f)
     ( has-inverse-kept-htpy A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a)) =
+      ( retraction-composite-has-inverse A B f has-inverse-f a)) =
     ap A B
-    ( has-inverse-retraction-composite A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a))
-    ( has-inverse-retraction-composite A B f has-inverse-f a)
+    ( retraction-composite-has-inverse A B f has-inverse-f
+      ( retraction-composite-has-inverse A B f has-inverse-f a))
+    ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( f)
-    ( ap A A (has-inverse-retraction-composite A B f has-inverse-f a) a
-      ( has-inverse-retraction-composite A B f has-inverse-f)
+    ( ap A A (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( retraction-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     ap-htpy A B
-      ( has-inverse-retraction-composite A B f has-inverse-f
-        ( has-inverse-retraction-composite A B f has-inverse-f a))
-      ( has-inverse-retraction-composite A B f has-inverse-f a)
+      ( retraction-composite-has-inverse A B f has-inverse-f
+        ( retraction-composite-has-inverse A B f has-inverse-f a))
+      ( retraction-composite-has-inverse A B f has-inverse-f a)
       ( f)
       ( has-inverse-kept-htpy A B f has-inverse-f
-        ( has-inverse-retraction-composite A B f has-inverse-f a))
-      ( ap A A (has-inverse-retraction-composite A B f has-inverse-f a) a
-        ( has-inverse-retraction-composite A B f has-inverse-f)
+        ( retraction-composite-has-inverse A B f has-inverse-f a))
+      ( ap A A (retraction-composite-has-inverse A B f has-inverse-f a) a
+        ( retraction-composite-has-inverse A B f has-inverse-f)
         ( has-inverse-kept-htpy A B f has-inverse-f a))
       ( has-inverse-cocone-homotopy-coherence)
 
 #def has-inverse-cocone-coherence
   : ap A B
-    ( has-inverse-retraction-composite A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a))
-    ( has-inverse-retraction-composite A B f has-inverse-f a)
+    ( retraction-composite-has-inverse A B f has-inverse-f
+      ( retraction-composite-has-inverse A B f has-inverse-f a))
+    ( retraction-composite-has-inverse A B f has-inverse-f a)
     ( f)
     ( has-inverse-kept-htpy A B f has-inverse-f
-      ( has-inverse-retraction-composite A B f has-inverse-f a)) =
-    ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
-      ( has-inverse-triple-composite A B f has-inverse-f)
+      ( retraction-composite-has-inverse A B f has-inverse-f a)) =
+    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+      ( triple-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     concat
-      ( has-inverse-quintuple-composite A B f has-inverse-f a =
-        has-inverse-triple-composite A B f has-inverse-f a)
+      ( quintuple-composite-has-inverse A B f has-inverse-f a =
+        triple-composite-has-inverse A B f has-inverse-f a)
       ( ap A B
-        ( has-inverse-retraction-composite A B f has-inverse-f
-          ( has-inverse-retraction-composite A B f has-inverse-f a))
-        ( has-inverse-retraction-composite A B f has-inverse-f a)
+        ( retraction-composite-has-inverse A B f has-inverse-f
+          ( retraction-composite-has-inverse A B f has-inverse-f a))
+        ( retraction-composite-has-inverse A B f has-inverse-f a)
         ( f)
         ( has-inverse-kept-htpy A B f has-inverse-f
-          ( has-inverse-retraction-composite A B f has-inverse-f a)))
+          ( retraction-composite-has-inverse A B f has-inverse-f a)))
       ( ap A B
-        ( has-inverse-retraction-composite A B f has-inverse-f
-          ( has-inverse-retraction-composite A B f has-inverse-f a))
-        ( has-inverse-retraction-composite A B f has-inverse-f a)
+        ( retraction-composite-has-inverse A B f has-inverse-f
+          ( retraction-composite-has-inverse A B f has-inverse-f a))
+        ( retraction-composite-has-inverse A B f has-inverse-f a)
         ( f)
         ( ap A A
-          ( has-inverse-retraction-composite A B f has-inverse-f a) a
-          ( has-inverse-retraction-composite A B f has-inverse-f)
+          ( retraction-composite-has-inverse A B f has-inverse-f a) a
+          ( retraction-composite-has-inverse A B f has-inverse-f)
           ( has-inverse-kept-htpy A B f has-inverse-f a)))
-      ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
-        ( has-inverse-triple-composite A B f has-inverse-f)
+      ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+        ( triple-composite-has-inverse A B f has-inverse-f)
         ( has-inverse-kept-htpy A B f has-inverse-f a))
       ( has-inverse-ap-cocone-homotopy-coherence)
       ( rev-ap-comp A A B
-        ( has-inverse-retraction-composite A B f has-inverse-f a) a
-        ( has-inverse-retraction-composite A B f has-inverse-f)
+        ( retraction-composite-has-inverse A B f has-inverse-f a) a
+        ( retraction-composite-has-inverse A B f has-inverse-f)
         ( f)
         ( has-inverse-kept-htpy A B f has-inverse-f a))
 ```
@@ -200,67 +200,67 @@ rotation.
 ```rzk
 #def has-inverse-replaced-naturality-square
   : concat B
-    ( has-inverse-quintuple-composite A B f has-inverse-f a)
-    ( has-inverse-triple-composite A B f has-inverse-f a)
+    ( quintuple-composite-has-inverse A B f has-inverse-f a)
+    ( triple-composite-has-inverse A B f has-inverse-f a)
     ( f a)
     ( ap A B
-      ( has-inverse-retraction-composite A B f has-inverse-f
-        ( has-inverse-retraction-composite A B f has-inverse-f a))
-      ( has-inverse-retraction-composite A B f has-inverse-f a)
+      ( retraction-composite-has-inverse A B f has-inverse-f
+        ( retraction-composite-has-inverse A B f has-inverse-f a))
+      ( retraction-composite-has-inverse A B f has-inverse-f a)
       ( f)
       ( has-inverse-kept-htpy A B f has-inverse-f
-        ( has-inverse-retraction-composite A B f has-inverse-f a)))
+        ( retraction-composite-has-inverse A B f has-inverse-f a)))
     ( has-inverse-discarded-htpy A B f has-inverse-f (f a)) =
     concat B
-    ( has-inverse-quintuple-composite A B f has-inverse-f a)
-    ( has-inverse-triple-composite A B f has-inverse-f a)
+    ( quintuple-composite-has-inverse A B f has-inverse-f a)
+    ( triple-composite-has-inverse A B f has-inverse-f a)
     ( f a)
     ( has-inverse-discarded-htpy A B f has-inverse-f
-      ( has-inverse-triple-composite A B f has-inverse-f a))
-    ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
+      ( triple-composite-has-inverse A B f has-inverse-f a))
+    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     concat
-      ( has-inverse-quintuple-composite A B f has-inverse-f a = f a)
+      ( quintuple-composite-has-inverse A B f has-inverse-f a = f a)
       ( concat B
-        ( has-inverse-quintuple-composite A B f has-inverse-f a)
-        ( has-inverse-triple-composite A B f has-inverse-f a)
+        ( quintuple-composite-has-inverse A B f has-inverse-f a)
+        ( triple-composite-has-inverse A B f has-inverse-f a)
         ( f a)
         ( ap A B
-          ( has-inverse-retraction-composite A B f has-inverse-f
-            ( has-inverse-retraction-composite A B f has-inverse-f a))
-          ( has-inverse-retraction-composite A B f has-inverse-f a) f
+          ( retraction-composite-has-inverse A B f has-inverse-f
+            ( retraction-composite-has-inverse A B f has-inverse-f a))
+          ( retraction-composite-has-inverse A B f has-inverse-f a) f
           ( has-inverse-kept-htpy A B f has-inverse-f
-            ( has-inverse-retraction-composite A B f has-inverse-f a)))
+            ( retraction-composite-has-inverse A B f has-inverse-f a)))
         ( has-inverse-discarded-htpy A B f has-inverse-f (f a)))
       ( concat B
-        ( has-inverse-quintuple-composite A B f has-inverse-f a)
-        ( has-inverse-triple-composite A B f has-inverse-f a)
+        ( quintuple-composite-has-inverse A B f has-inverse-f a)
+        ( triple-composite-has-inverse A B f has-inverse-f a)
         ( f a)
-        ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
-          ( has-inverse-triple-composite A B f has-inverse-f)
+        ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+          ( triple-composite-has-inverse A B f has-inverse-f)
           ( has-inverse-kept-htpy A B f has-inverse-f a))
         ( has-inverse-discarded-htpy A B f has-inverse-f (f a)))
       ( concat B
-        ( has-inverse-quintuple-composite A B f has-inverse-f a)
-        ( has-inverse-triple-composite A B f has-inverse-f a) (f a)
+        ( quintuple-composite-has-inverse A B f has-inverse-f a)
+        ( triple-composite-has-inverse A B f has-inverse-f a) (f a)
         ( has-inverse-discarded-htpy A B f has-inverse-f
-          ( has-inverse-triple-composite A B f has-inverse-f a))
-        ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
+          ( triple-composite-has-inverse A B f has-inverse-f a))
+        ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
           ( has-inverse-kept-htpy A B f has-inverse-f a)))
       ( homotopy-concat B
-        ( has-inverse-quintuple-composite A B f has-inverse-f a)
-        ( has-inverse-triple-composite A B f has-inverse-f a)
+        ( quintuple-composite-has-inverse A B f has-inverse-f a)
+        ( triple-composite-has-inverse A B f has-inverse-f a)
         ( f a)
         ( ap A B
-          ( has-inverse-retraction-composite A B f has-inverse-f
-            ( has-inverse-retraction-composite A B f has-inverse-f a))
-          ( has-inverse-retraction-composite A B f has-inverse-f a)
+          ( retraction-composite-has-inverse A B f has-inverse-f
+            ( retraction-composite-has-inverse A B f has-inverse-f a))
+          ( retraction-composite-has-inverse A B f has-inverse-f a)
           ( f)
           ( has-inverse-kept-htpy A B f has-inverse-f
-            ( has-inverse-retraction-composite A B f has-inverse-f a)))
-        ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a
-          ( has-inverse-triple-composite A B f has-inverse-f)
+            ( retraction-composite-has-inverse A B f has-inverse-f a)))
+        ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a
+          ( triple-composite-has-inverse A B f has-inverse-f)
           ( has-inverse-kept-htpy A B f has-inverse-f a))
         ( has-inverse-cocone-coherence)
         ( has-inverse-discarded-htpy A B f has-inverse-f (f a)))
@@ -271,27 +271,27 @@ This will replace the discarded homotopy.
 
 ```rzk
 #def has-inverse-corrected-htpy
-  : homotopy B B (has-inverse-section-composite A B f has-inverse-f) (\ b → b)
+  : homotopy B B (section-composite-has-inverse A B f has-inverse-f) (\ b → b)
   :=
     \ b →
       concat B
-        ( (has-inverse-section-composite A B f has-inverse-f) b)
-        ( (has-inverse-section-composite A B f has-inverse-f)
-          ((has-inverse-section-composite A B f has-inverse-f) b))
+        ( (section-composite-has-inverse A B f has-inverse-f) b)
+        ( (section-composite-has-inverse A B f has-inverse-f)
+          ((section-composite-has-inverse A B f has-inverse-f) b))
         ( b)
         ( rev B
-          ( (has-inverse-section-composite A B f has-inverse-f)
-            ((has-inverse-section-composite A B f has-inverse-f) b))
-          ( (has-inverse-section-composite A B f has-inverse-f) b)
+          ( (section-composite-has-inverse A B f has-inverse-f)
+            ((section-composite-has-inverse A B f has-inverse-f) b))
+          ( (section-composite-has-inverse A B f has-inverse-f) b)
           ( has-inverse-discarded-htpy A B f has-inverse-f
-            ((has-inverse-section-composite A B f has-inverse-f) b)))
+            ((section-composite-has-inverse A B f has-inverse-f) b)))
         ( concat B
-          ( (has-inverse-section-composite A B f has-inverse-f)
-            ((has-inverse-section-composite A B f has-inverse-f) b))
-          ( (has-inverse-section-composite A B f has-inverse-f) b)
+          ( (section-composite-has-inverse A B f has-inverse-f)
+            ((section-composite-has-inverse A B f has-inverse-f) b))
+          ( (section-composite-has-inverse A B f has-inverse-f) b)
           ( b)
           ( ap A B
-            ( (has-inverse-retraction-composite A B f has-inverse-f)
+            ( (retraction-composite-has-inverse A B f has-inverse-f)
               (map-inverse-has-inverse A B f has-inverse-f b))
             ( map-inverse-has-inverse A B f has-inverse-f b) f
             ( (first (second has-inverse-f))
@@ -304,20 +304,20 @@ The following is the half adjoint coherence.
 ```rzk
 #def has-inverse-coherence
   : ( has-inverse-corrected-htpy (f a)) =
-    ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
+    ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
     triangle-rotation B
-      ( has-inverse-quintuple-composite A B f has-inverse-f a)
-      ( has-inverse-triple-composite A B f has-inverse-f a)
+      ( quintuple-composite-has-inverse A B f has-inverse-f a)
+      ( triple-composite-has-inverse A B f has-inverse-f a)
       ( f a)
       ( concat B
-        ( (has-inverse-section-composite A B f has-inverse-f)
-          ((has-inverse-section-composite A B f has-inverse-f) (f a)))
-        ( (has-inverse-section-composite A B f has-inverse-f) (f a))
+        ( (section-composite-has-inverse A B f has-inverse-f)
+          ((section-composite-has-inverse A B f has-inverse-f) (f a)))
+        ( (section-composite-has-inverse A B f has-inverse-f) (f a))
         ( f a)
         ( ap A B
-          ( (has-inverse-retraction-composite A B f has-inverse-f)
+          ( (retraction-composite-has-inverse A B f has-inverse-f)
             (map-inverse-has-inverse A B f has-inverse-f (f a)))
           ( map-inverse-has-inverse A B f has-inverse-f (f a))
             ( f)
@@ -325,8 +325,8 @@ The following is the half adjoint coherence.
               (map-inverse-has-inverse A B f has-inverse-f (f a))))
         ( (has-inverse-discarded-htpy A B f has-inverse-f (f a))))
       ( has-inverse-discarded-htpy A B f has-inverse-f
-        ( has-inverse-triple-composite A B f has-inverse-f a))
-      ( ap A B (has-inverse-retraction-composite A B f has-inverse-f a) a f
+        ( triple-composite-has-inverse A B f has-inverse-f a))
+      ( ap A B (retraction-composite-has-inverse A B f has-inverse-f a) a f
         ( has-inverse-kept-htpy A B f has-inverse-f a))
       ( has-inverse-replaced-naturality-square)
 ```
@@ -398,7 +398,7 @@ have equivalent identity types.
         ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
         ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( y)
-        ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+        ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
           ( (first (second (first fisHAE))) x))
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
         ( (first (second (first fisHAE))) y))
@@ -431,7 +431,7 @@ have equivalent identity types.
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-        ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+        ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
           ( (first (second (first fisHAE))) x)))
       ( ap A B
         ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
@@ -447,7 +447,7 @@ have equivalent identity types.
       ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( y)
       ( f)
-      ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+      ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x))
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
       ( (first (second (first fisHAE))) y)
@@ -461,7 +461,7 @@ have equivalent identity types.
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
     ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-      (rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+      (rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x)))
     ( ap A B
       ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
@@ -475,7 +475,7 @@ have equivalent identity types.
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
-    ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
     ( ap A B
@@ -496,9 +496,9 @@ have equivalent identity types.
     ( f y)
     ( ap A B
       ( x) ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-      ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+      ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x)))
-    ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
     ( ap A B
@@ -508,7 +508,7 @@ have equivalent identity types.
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
     ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
       ( (first (second (first fisHAE))) y))
-    ( ap-rev A B (has-inverse-retraction-composite A B f (first fisHAE) x) x f
+    ( ap-rev A B (retraction-composite-has-inverse A B f (first fisHAE) x) x f
       ( (first (second (first fisHAE))) x))
 
 #def ap-ap-homotopy-triple-concat-is-half-adjoint-equiv
@@ -520,7 +520,7 @@ have equivalent identity types.
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B
-        ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
+        ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
         ( f x)
         ( ap A B
           ( (map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
@@ -538,11 +538,11 @@ have equivalent identity types.
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B
-        ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+        ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
         ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
           ( (first (second (first fisHAE))) x)))
       ( ap B B (f x) (f y)
-        ( has-inverse-section-composite A B f (first fisHAE)) q)
+        ( section-composite-has-inverse A B f (first fisHAE)) q)
       ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
         ( f) ((first (second (first fisHAE))) y)))
   :=
@@ -551,7 +551,7 @@ have equivalent identity types.
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
-      ( rev B ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+      ( rev B ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
         ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
           ( (first (second (first fisHAE))) x)))
       ( ap A B
@@ -559,7 +559,7 @@ have equivalent identity types.
         ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( f)
         ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
-      ( ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
+      ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
       ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
         ( (first (second (first fisHAE))) y))
       ( rev-ap-comp B A B (f x) (f y)
@@ -574,32 +574,32 @@ have equivalent identity types.
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
-      ( rev B ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+      ( rev B ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
         ( (second (second (first fisHAE))) (f x)))
       ( ap B B (f x) (f y)
-        ( has-inverse-section-composite A B f (first fisHAE)) q)
+        ( section-composite-has-inverse A B f (first fisHAE)) q)
       ( (second (second (first fisHAE))) (f y)) =
     triple-concat B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
-      (rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+      (rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
         (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f ((first (second (first fisHAE))) x)))
-        (ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
+        (ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
         (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f ((first (second (first fisHAE))) y))
   :=
     triple-concat-higher-homotopy A B
-      ( has-inverse-triple-composite A B f (first fisHAE)) f
+      ( triple-composite-has-inverse A B f (first fisHAE)) f
       ( \ a → (((second (second (first fisHAE)))) (f a)))
       ( \ a →
-        ( ap A B (has-inverse-retraction-composite A B f (first fisHAE) a) a f
+        ( ap A B (retraction-composite-has-inverse A B f (first fisHAE) a) a f
           ( ((first (second (first fisHAE)))) a)))
       ( second fisHAE)
       ( x)
       ( y)
       ( ap B B (f x) (f y)
-        ( has-inverse-section-composite A B f (first fisHAE)) q)
+        ( section-composite-has-inverse A B f (first fisHAE)) q)
 
 #def triple-concat-nat-htpy-is-half-adjoint-equiv
   ( x y : A)
@@ -609,14 +609,14 @@ have equivalent identity types.
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
-    ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
       ( ((second (second (first fisHAE)))) (f x)))
-    ( ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
+    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
     ( ((second (second (first fisHAE)))) (f y))
     = ap B B (f x) (f y) (identity B) q
   :=
     triple-concat-nat-htpy B B
-      ( has-inverse-section-composite A B f (first fisHAE))
+      ( section-composite-has-inverse A B f (first fisHAE))
       ( identity B)
       ( (second (second (first fisHAE))))
       ( f x)
@@ -631,10 +631,10 @@ have equivalent identity types.
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
-    ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+    ( rev B (f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
       ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
-    ( ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
+    ( ap B B (f x) (f y) (section-composite-has-inverse A B f (first fisHAE)) q)
     ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
       ( (first (second (first fisHAE))) y)) =
     ap B B (f x) (f y) (identity B) q
@@ -646,11 +646,11 @@ have equivalent identity types.
         ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
-          ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+          ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
           ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap B B (f x) (f y)
-          ( has-inverse-section-composite A B f (first fisHAE)) q)
+          ( section-composite-has-inverse A B f (first fisHAE)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
           f ((first (second (first fisHAE))) y)))
       ( triple-concat B
@@ -659,11 +659,11 @@ have equivalent identity types.
         ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
-          ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
+          ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
           ( f x)
           ( ((second (second (first fisHAE)))) (f x)))
         ( ap B B (f x) (f y)
-          ( has-inverse-section-composite A B f (first fisHAE)) q)
+          ( section-composite-has-inverse A B f (first fisHAE)) q)
         ( ((second (second (first fisHAE)))) (f y)))
       ( ap B B (f x) (f y) (identity B) q)
       ( triple-concat-higher-homotopy-is-half-adjoint-equiv x y q)
@@ -688,7 +688,7 @@ have equivalent identity types.
         ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
-          ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
+          ( rev A (retraction-composite-has-inverse A B f (first fisHAE) x) x
             ( (first (second (first fisHAE))) x)))
         ( ap A B
           ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
@@ -703,7 +703,7 @@ have equivalent identity types.
         ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
-          ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
+          ( f (retraction-composite-has-inverse A B f (first fisHAE) x)) (f x)
           ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap A B
@@ -719,12 +719,12 @@ have equivalent identity types.
         ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
-          ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
+          ( f (retraction-composite-has-inverse A B f (first fisHAE) x))
           ( f x)
           ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap B B (f x) (f y)
-          ( has-inverse-section-composite A B f (first fisHAE)) q)
+          ( section-composite-has-inverse A B f (first fisHAE)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
           f ((first (second (first fisHAE))) y)))
       ( ap-ap-homotopy-triple-concat-is-half-adjoint-equiv x y q)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -746,17 +746,17 @@ have equivalent identity types.
   :=
     ( has-retraction-ap-is-half-adjoint-equiv x y ,
       has-section-ap-is-half-adjoint-equiv x y)
+
 #end equiv-identity-types-equiv
 
 #def is-equiv-ap-is-equiv
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
-  ( x y : A)
-  : is-equiv (x = y) (f x = f y) (ap A B x y f)
+  : is-emb A B f
   :=
     is-equiv-ap-is-half-adjoint-equiv A B f
-    ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) x y
+    ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f)
 
 #def equiv-ap-is-equiv
   ( A B : U)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -749,7 +749,7 @@ have equivalent identity types.
 
 #end equiv-identity-types-equiv
 
-#def is-equiv-ap-is-equiv
+#def is-emb-is-equiv
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
@@ -758,11 +758,18 @@ have equivalent identity types.
     is-equiv-ap-is-half-adjoint-equiv A B f
     ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f)
 
+#def emb-is-equiv
+  (A B : U)
+  (f : A → B)
+  (is-equiv-f : is-equiv A B f)
+  : Emb A B
+  := (f , is-emb-is-equiv A B f is-equiv-f)
+
 #def equiv-ap-is-equiv
   ( A B : U)
   ( f : A → B)
   ( is-equiv-f : is-equiv A B f)
   ( x y : A)
   : Equiv (x = y) (f x = f y)
-  := (ap A B x y f , is-equiv-ap-is-equiv A B f is-equiv-f x y)
+  := (ap A B x y f , is-emb-is-equiv A B f is-equiv-f x y)
 ```

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -292,10 +292,10 @@ This will replace the discarded homotopy.
           ( b)
           ( ap A B
             ( (has-inverse-retraction-composite A B f has-inverse-f)
-              (has-inverse-inverse A B f has-inverse-f b))
-            ( has-inverse-inverse A B f has-inverse-f b) f
+              (map-inverse-has-inverse A B f has-inverse-f b))
+            ( map-inverse-has-inverse A B f has-inverse-f b) f
             ( (first (second has-inverse-f))
-              (has-inverse-inverse A B f has-inverse-f b)))
+              (map-inverse-has-inverse A B f has-inverse-f b)))
           ( (has-inverse-discarded-htpy A B f has-inverse-f b)))
 ```
 
@@ -318,11 +318,11 @@ The following is the half adjoint coherence.
         ( f a)
         ( ap A B
           ( (has-inverse-retraction-composite A B f has-inverse-f)
-            (has-inverse-inverse A B f has-inverse-f (f a)))
-          ( has-inverse-inverse A B f has-inverse-f (f a))
+            (map-inverse-has-inverse A B f has-inverse-f (f a)))
+          ( map-inverse-has-inverse A B f has-inverse-f (f a))
             ( f)
             ( (first (second has-inverse-f))
-              (has-inverse-inverse A B f has-inverse-f (f a))))
+              (map-inverse-has-inverse A B f has-inverse-f (f a))))
         ( (has-inverse-discarded-htpy A B f has-inverse-f (f a))))
       ( has-inverse-discarded-htpy A B f has-inverse-f
         ( has-inverse-triple-composite A B f has-inverse-f a))
@@ -348,7 +348,7 @@ one.
   ( has-inverse-f : has-inverse A B f)
   : has-inverse A B f
   :=
-    ( has-inverse-inverse A B f has-inverse-f ,
+    ( map-inverse-has-inverse A B f has-inverse-f ,
       ( has-inverse-kept-htpy A B f has-inverse-f ,
         has-inverse-corrected-htpy A B f has-inverse-f))
 ```
@@ -395,12 +395,12 @@ have equivalent identity types.
       \ q →
       triple-concat A
         ( x)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-        ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( y)
         ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
           ( (first (second (first fisHAE))) x))
-        ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q)
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
         ( (first (second (first fisHAE))) y))
 
 #def has-retraction-ap-is-half-adjoint-equiv
@@ -416,7 +416,7 @@ have equivalent identity types.
               ( second (iff-ap-is-half-adjoint-equiv x y')) (ap A B x y' f p') =
               p' ,
             ( rev-refl-id-triple-concat A
-              ( (has-inverse-inverse A B f (first fisHAE)) (f x)) x
+              ( (map-inverse-has-inverse A B f (first fisHAE)) (f x)) x
               ( (first (second (first fisHAE))) x)) ,
             y ,
             p))
@@ -427,29 +427,29 @@ have equivalent identity types.
   : ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q) =
     (triple-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
-      ( ap A B x ((has-inverse-inverse A B f (first fisHAE)) (f x)) f
+      ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
         ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
           ( (first (second (first fisHAE))) x)))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-        ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
         ( (first (second (first fisHAE))) y)))
   :=
     ap-triple-concat A B
       ( x)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-      ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( y)
       ( f)
       ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x))
-      ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q)
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q)
       ( (first (second (first fisHAE))) y)
 
 #def ap-rev-homotopy-triple-concat-is-half-adjoint-equiv
@@ -457,56 +457,56 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
-    ( ap A B x ((has-inverse-inverse A B f (first fisHAE)) (f x)) f
+    ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
       (rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x)))
     ( ap A B
-      ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-      ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-    ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
       ( (first (second (first fisHAE))) y)) =
     triple-concat B
     ( f x)
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
     ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
     ( ap A B
-      ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-      ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
     ( ap A B
-      ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( y)
       ( f)
       ( (first (second (first fisHAE))) y))
   :=
     homotopy-triple-concat B
     ( f x)
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
     ( ap A B
-      ( x) ((has-inverse-inverse A B f (first fisHAE)) (f x)) f
+      ( x) ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
       ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
         ( (first (second (first fisHAE))) x)))
     ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
     ( ap A B
-      ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-      ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
       ( f)
-      ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-    ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+      ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
       ( (first (second (first fisHAE))) y))
     ( ap-rev A B (has-inverse-retraction-composite A B f (first fisHAE) x) x f
       ( (first (second (first fisHAE))) x))
@@ -516,54 +516,54 @@ have equivalent identity types.
   ( q : f x = f y)
   : (triple-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B
         ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
         ( f x)
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
           ( (first (second (first fisHAE))) x)))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-        ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
         ( (first (second (first fisHAE))) y))) =
     ( triple-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B
         ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
           ( (first (second (first fisHAE))) x)))
       ( ap B B (f x) (f y)
         ( has-inverse-section-composite A B f (first fisHAE)) q)
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
         ( f) ((first (second (first fisHAE))) y)))
   :=
     triple-homotopy-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
           ( (first (second (first fisHAE))) x)))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-        ( (has-inverse-inverse A B f (first fisHAE)) (f y))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f y))
         ( f)
-        ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
+        ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
       ( ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
         ( (first (second (first fisHAE))) y))
       ( rev-ap-comp B A B (f x) (f y)
-        ( has-inverse-inverse A B f (first fisHAE)) f q)
+        ( map-inverse-has-inverse A B f (first fisHAE)) f q)
 
 -- This needs to be reversed later.
 #def triple-concat-higher-homotopy-is-half-adjoint-equiv
@@ -571,8 +571,8 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       ( rev B ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
         ( (second (second (first fisHAE))) (f x)))
@@ -581,13 +581,13 @@ have equivalent identity types.
       ( (second (second (first fisHAE))) (f y)) =
     triple-concat B
       ( f x)
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
       ( f y)
       (rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-        (ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f ((first (second (first fisHAE))) x)))
+        (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f ((first (second (first fisHAE))) x)))
         (ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
-        (ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f ((first (second (first fisHAE))) y))
+        (ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f ((first (second (first fisHAE))) y))
   :=
     triple-concat-higher-homotopy A B
       ( has-inverse-triple-composite A B f (first fisHAE)) f
@@ -606,8 +606,8 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
     ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
       ( ((second (second (first fisHAE)))) (f x)))
@@ -628,35 +628,35 @@ have equivalent identity types.
   ( q : f x = f y)
   : triple-concat B
     ( f x)
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
     ( f y)
     ( rev B (f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-      ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+      ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
         ( (first (second (first fisHAE))) x)))
     ( ap B B (f x) (f y) (has-inverse-section-composite A B f (first fisHAE)) q)
-    ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+    ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
       ( (first (second (first fisHAE))) y)) =
     ap B B (f x) (f y) (identity B) q
   :=
     zag-zig-concat (f x = f y)
       ( triple-concat B
         ( f x)
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
           ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-          ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap B B (f x) (f y)
           ( has-inverse-section-composite A B f (first fisHAE)) q)
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
           f ((first (second (first fisHAE))) y)))
       ( triple-concat B
         ( f x)
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
           ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
@@ -684,48 +684,48 @@ have equivalent identity types.
       ( ap A B x y f ((second (iff-ap-is-half-adjoint-equiv x y)) q))
       ( triple-concat B
         ( f x)
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
-        ( ap A B x ((has-inverse-inverse A B f (first fisHAE)) (f x)) f
+        ( ap A B x ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) f
           ( rev A (has-inverse-retraction-composite A B f (first fisHAE) x) x
             ( (first (second (first fisHAE))) x)))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-          ( (has-inverse-inverse A B f (first fisHAE)) (f y)) f
-          ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f y)) f
+          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
           ( (first (second (first fisHAE))) y)))
       ( ap-triple-concat-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
           ( f (has-inverse-retraction-composite A B f (first fisHAE) x)) (f x)
-          ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f x))
-          ( (has-inverse-inverse A B f (first fisHAE)) (f y)) f
-          ( ap B A (f x) (f y) (has-inverse-inverse A B f (first fisHAE)) q))
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f x))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f y)) f
+          ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first fisHAE)) q))
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y f
           ( (first (second (first fisHAE))) y)))
       ( ap-rev-homotopy-triple-concat-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f x)))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f y)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f x)))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f y)))
         ( f y)
         ( rev B
           ( f (has-inverse-retraction-composite A B f (first fisHAE) x))
           ( f x)
-          ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f x)) x f
+          ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f x)) x f
             ( (first (second (first fisHAE))) x)))
         ( ap B B (f x) (f y)
           ( has-inverse-section-composite A B f (first fisHAE)) q)
-        ( ap A B ((has-inverse-inverse A B f (first fisHAE)) (f y)) y
+        ( ap A B ((map-inverse-has-inverse A B f (first fisHAE)) (f y)) y
           f ((first (second (first fisHAE))) y)))
       ( ap-ap-homotopy-triple-concat-is-half-adjoint-equiv x y q)
       ( ap B B (f x) (f y) (identity B) q)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -546,7 +546,7 @@ have equivalent identity types.
       ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
         ( f) ((first (second (first is-HAE-f))) y)))
   :=
-    triple-homotopy-concat B
+    eq-triple-concat-eq-second B
       ( f x)
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -140,7 +140,7 @@ We build a path that will be whiskered into the naturality square above:
       ( retraction-composite-has-inverse A B f has-inverse-f)
       ( has-inverse-kept-htpy A B f has-inverse-f a))
   :=
-    ap-htpy A B
+    ap-eq A B
       ( retraction-composite-has-inverse A B f has-inverse-f
         ( retraction-composite-has-inverse A B f has-inverse-f a))
       ( retraction-composite-has-inverse A B f has-inverse-f a)

--- a/src/hott/04-half-adjoint-equivalences.rzk.md
+++ b/src/hott/04-half-adjoint-equivalences.rzk.md
@@ -452,7 +452,7 @@ have equivalent identity types.
       ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q)
       ( (first (second (first is-HAE-f))) y)
 
-#def ap-rev-homotopy-triple-concat-is-half-adjoint-equiv
+#def ap-rev-eq-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : triple-concat B
@@ -489,7 +489,7 @@ have equivalent identity types.
       ( f)
       ( (first (second (first is-HAE-f))) y))
   :=
-    homotopy-triple-concat B
+    eq-triple-concat-eq-first B
     ( f x)
     ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
     ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)))
@@ -511,7 +511,7 @@ have equivalent identity types.
     ( ap-rev A B (retraction-composite-has-inverse A B f (first is-HAE-f) x) x f
       ( (first (second (first is-HAE-f))) x))
 
-#def ap-ap-homotopy-triple-concat-is-half-adjoint-equiv
+#def ap-ap-eq-triple-concat-eq-first-is-half-adjoint-equiv
   ( x y : A)
   ( q : f x = f y)
   : (triple-concat B
@@ -712,7 +712,7 @@ have equivalent identity types.
           ( ap B A (f x) (f y) (map-inverse-has-inverse A B f (first is-HAE-f)) q))
         ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y f
           ( (first (second (first is-HAE-f))) y)))
-      ( ap-rev-homotopy-triple-concat-is-half-adjoint-equiv x y q)
+      ( ap-rev-eq-triple-concat-eq-first-is-half-adjoint-equiv x y q)
       ( triple-concat B
         ( f x)
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f x)))
@@ -727,7 +727,7 @@ have equivalent identity types.
           ( section-composite-has-inverse A B f (first is-HAE-f)) q)
         ( ap A B ((map-inverse-has-inverse A B f (first is-HAE-f)) (f y)) y
           f ((first (second (first is-HAE-f))) y)))
-      ( ap-ap-homotopy-triple-concat-is-half-adjoint-equiv x y q)
+      ( ap-ap-eq-triple-concat-eq-first-is-half-adjoint-equiv x y q)
       ( ap B B (f x) (f y) (identity B) q)
       ( zag-zig-concat-triple-concat-is-half-adjoint-equiv x y q)
       ( q)

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -217,7 +217,7 @@ A retract of contractible types is contractible.
   := first (second is-retract-of-A-B)
 
 #def is-retract-of-homotopy
-  : homotopy A A (composition A B A is-retract-of-retraction is-retract-of-section) (identity A)
+  : homotopy A A (comp A B A is-retract-of-retraction is-retract-of-section) (identity A)
   := second (second is-retract-of-A-B)
 ```
 
@@ -236,7 +236,7 @@ A retract of contractible types is contractible.
   := concat
       A
       ( is-retract-of-is-contr-isInhabited is-contr-B)
-      ( (composition A B A is-retract-of-retraction is-retract-of-section) a)
+      ( (comp A B A is-retract-of-retraction is-retract-of-section) a)
       a
       ( ap B A (contraction-center B is-contr-B) (is-retract-of-section a)
         ( is-retract-of-retraction)
@@ -438,7 +438,7 @@ A type is contractible if and only if it has singleton induction.
   : ( homotopy
       ( B a)
       ( B a)
-      ( composition
+      ( comp
         ( B a)
         ( (x : A) → B x)
         ( B a)

--- a/src/hott/06-contractible.rzk.md
+++ b/src/hott/06-contractible.rzk.md
@@ -159,7 +159,7 @@ A type is contractible if and only if its terminal map is an equivalence.
   : is-contr B
   := ( terminal-map-is-equiv-implies-contr B
       ( second
-        ( comp-equiv B A Unit
+        ( equiv-comp B A Unit
           ( inv-equiv A B f)
           ( ( terminal-map A) ,
             ( contr-implies-terminal-map-is-equiv A is-contr-A)))))
@@ -430,7 +430,7 @@ A type is contractible if and only if it has singleton induction.
   : (B a) → ((x : A) → B x)
   := ( first singleton-ind-A)
 
-#def comp-sing
+#def compute-ind-sing
   ( A : U)
   ( a : A)
   ( B : A → U)

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -853,7 +853,7 @@ Specializing the above to `isHAE-fib-base-path`:
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
           ( first z) f
           ( ((first (second (first fisHAE)))) (first z))))
       ( second z)
@@ -883,7 +883,7 @@ Specializing the above to `isHAE-fib-base-path`:
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
         ( first z)
         ( f)
         ( (first (second (first fisHAE))) (first z))))
@@ -900,7 +900,7 @@ Specializing the above to `isHAE-fib-base-path`:
             ( (first (second (first fisHAE))) (first z))))
         ( (second (second (first fisHAE))) (f (first z)))
         ( ap A B
-          ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
           ( first z) f
           ( ((first (second (first fisHAE)))) (first z)))
         ( (second fisHAE) (first z)))
@@ -919,7 +919,7 @@ Specializing the above to `isHAE-fib-base-path`:
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
         ( first z) f
         ( ((first (second (first fisHAE)))) (first z))))
     ( second z) =
@@ -938,12 +938,12 @@ Specializing the above to `isHAE-fib-base-path`:
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
         ( first z) f
         ( ((first (second (first fisHAE)))) (first z))))
     ( refl)
     ( concat-ap-rev-ap-id A B
-      ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+      ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
       ( first z)
       ( f)
       ( ((first (second (first fisHAE)))) (first z)))
@@ -1143,7 +1143,7 @@ Specializing the above to `isHAE-fib-base-path`:
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( has-inverse-retraction-composite A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
           ( first z) f
           ( (first (second (first fisHAE))) (first z))))
       ( second z))

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -116,12 +116,12 @@ We now show that half adjoint equivalences are contractible maps.
 #def is-surj-is-half-adjoint-equiv
   (A B : U)
   (f : A → B)
-  (fisHAE : is-half-adjoint-equiv A B f)
+  (is-HAE-f : is-half-adjoint-equiv A B f)
   (b : B)
   : fib A B f b
   :=
-    ( (map-inverse-has-inverse A B f (first fisHAE)) b ,
-      (second (second (first fisHAE))) b)
+    ( (map-inverse-has-inverse A B f (first is-HAE-f)) b ,
+      (second (second (first is-HAE-f))) b)
 ```
 
 It takes much more work to construct the contracting homotopy. The bath path of
@@ -132,1042 +132,1042 @@ this homotopy is straightforward.
 
 #variables A B : U
 #variable f : A → B
-#variable fisHAE : is-half-adjoint-equiv A B f
+#variable is-HAE-f : is-half-adjoint-equiv A B f
 #variable b : B
 #variable z : fib A B f b
 
-#def isHAE-fib-base-path
-  : ((map-inverse-has-inverse A B f (first fisHAE)) b) = (first z)
+#def is-HAE-fib-base-path
+  : ((map-inverse-has-inverse A B f (first is-HAE-f)) b) = (first z)
   :=
     concat A
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( first z)
-      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
         ( rev B (f (first z)) b (second z)))
-      ( (first (second (first fisHAE))) (first z))
+      ( (first (second (first is-HAE-f))) (first z))
 ```
 
-Specializing the above to `isHAE-fib-base-path`:
+Specializing the above to `is-HAE-fib-base-path`:
 
 ```rzk
-#def isHAE-fib-base-path-transport
+#def is-HAE-fib-base-path-transport
   : transport A (\ x → (f x) = b)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-      ( isHAE-fib-base-path )
-      ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
-          ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-            ( isHAE-fib-base-path )))
-      ( (second (second (first fisHAE))) b)
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+      ( is-HAE-fib-base-path )
+      ( (second (second (first is-HAE-f))) b) =
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+          ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+            ( is-HAE-fib-base-path )))
+      ( (second (second (first is-HAE-f))) b)
   :=
     transport-in-fiber A B f b
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-      ( (second (second (first fisHAE))) b)
-      ( isHAE-fib-base-path )
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+      ( (second (second (first is-HAE-f))) b)
+      ( is-HAE-fib-base-path )
 
-#def isHAE-fib-base-path-rev-coherence
-  : rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-      ( isHAE-fib-base-path) =
+#def is-HAE-fib-base-path-rev-coherence
+  : rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+      ( is-HAE-fib-base-path) =
     concat A
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-        ( (first (second (first fisHAE))) (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+        ( (first (second (first is-HAE-f))) (first z)))
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
           ( rev B (f (first z)) b (second z))))
   :=
     rev-concat A
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( first z)
-      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
         ( rev B (f (first z)) b (second z)))
-      ( (first (second (first fisHAE))) (first z))
+      ( (first (second (first is-HAE-f))) (first z))
 
-#def isHAE-fib-base-path-transport-rev-calculation
-  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
-      ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-        ( isHAE-fib-base-path )))
-    ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+#def is-HAE-fib-base-path-transport-rev-calculation
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+      ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+        ( is-HAE-fib-base-path )))
+    ( (second (second (first is-HAE-f))) b) =
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
       ( concat A
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z)))
+          ( (first (second (first is-HAE-f))) (first z)))
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
             ( rev B (f (first z)) b (second z))))))
-    ( (second (second (first fisHAE))) b)
+    ( (second (second (first is-HAE-f))) b)
   :=
     homotopy-concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
-        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-          ( isHAE-fib-base-path )))
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+          ( is-HAE-fib-base-path )))
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
         ( concat A
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z)))
+            ( (first (second (first is-HAE-f))) (first z)))
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
-      ( ap-htpy A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
-        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-          ( isHAE-fib-base-path ))
+      ( ap-htpy A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+          ( is-HAE-fib-base-path ))
         ( concat A
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z)))
+            ( (first (second (first is-HAE-f))) (first z)))
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z)))))
-        ( isHAE-fib-base-path-rev-coherence ))
-      ( (second (second (first fisHAE))) b)
+        ( is-HAE-fib-base-path-rev-coherence ))
+      ( (second (second (first is-HAE-f))) b)
 
-#def isHAE-fib-base-path-transport-ap-calculation
-  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+#def is-HAE-fib-base-path-transport-ap-calculation
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
       ( concat A
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z)))
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
             ( rev B (f (first z)) b (second z))))))
-    ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( (second (second (first is-HAE-f))) b) =
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
-      ( (second (second (first fisHAE))) b)
+      ( (second (second (first is-HAE-f))) b)
   :=
     homotopy-concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
         ( concat A
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z)))
+            ( (first (second (first is-HAE-f))) (first z)))
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
       ( ap-concat A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z)))
+          ( (first (second (first is-HAE-f))) (first z)))
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
             ( rev B (f (first z)) b (second z)))))
-      ( (second (second (first fisHAE))) b)
+      ( (second (second (first is-HAE-f))) b)
 
-#def isHAE-fib-base-path-transport-rev-ap-rev-calculation
-  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+#def is-HAE-fib-base-path-transport-rev-ap-rev-calculation
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
             ( rev B (f (first z)) b (second z))))))
-    ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( (second (second (first is-HAE-f))) b) =
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
-          ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( ap B A (f (first z)) b
-            ( map-inverse-has-inverse A B f (first fisHAE))
+            ( map-inverse-has-inverse A B f (first is-HAE-f))
             ( second z))))
-      ( (second (second (first fisHAE))) b)
+      ( (second (second (first is-HAE-f))) b)
   :=
     homotopy-concat B
-      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( ap B A
-            ( f (first z)) b (map-inverse-has-inverse A B f (first fisHAE))
+            ( f (first z)) b (map-inverse-has-inverse A B f (first is-HAE-f))
             ( second z))))
       ( concat-homotopy B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z)))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) f
           ( ap B A (f (first z)) b
-            ( map-inverse-has-inverse A B f (first fisHAE)) (second z)))
+            ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z)))
         ( ap-htpy A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( ap B A b
               ( f (first z))
-              ( map-inverse-has-inverse A B f (first fisHAE))
+              ( map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))
           ( ap B A
             ( f (first z))
             ( b)
-            ( map-inverse-has-inverse A B f (first fisHAE))
+            ( map-inverse-has-inverse A B f (first is-HAE-f))
             ( second z))
           ( rev-ap-rev B A (f (first z)) b
-            ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
-      ( (second (second (first fisHAE))) b)
+            ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z))))
+      ( (second (second (first is-HAE-f))) b)
 
-#def isHAE-fib-base-path-transport-ap-ap-calculation
-  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+#def is-HAE-fib-base-path-transport-ap-ap-calculation
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
-        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( f)
         ( ap B A (f (first z)) b
-          ( map-inverse-has-inverse A B f (first fisHAE))
+          ( map-inverse-has-inverse A B f (first is-HAE-f))
           ( second z))))
-    ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( (second (second (first is-HAE-f))) b) =
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
-        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z)))
-    ( (second (second (first fisHAE))) b)
+    ( (second (second (first is-HAE-f))) b)
   :=
     homotopy-concat B
-    ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( f)
         ( ap B A
           ( f (first z)) b
-          ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
+          ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z))))
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z)))
     ( concat-homotopy B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
         ( f)
         ( ap B A (f (first z)) b
-          ( map-inverse-has-inverse A B f (first fisHAE)) (second z)))
+          ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z)))
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z))
       ( rev-ap-comp B A B
         ( f (first z))
         ( b)
-        ( map-inverse-has-inverse A B f (first fisHAE))
+        ( map-inverse-has-inverse A B f (first is-HAE-f))
         ( f)
         ( second z)))
-    ( (second (second (first fisHAE))) b)
+    ( (second (second (first is-HAE-f))) b)
 
-#def isHAE-fib-base-path-transport-assoc-calculation
-  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+#def is-HAE-fib-base-path-transport-assoc-calculation
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z)))
-    ( (second (second (first fisHAE))) b) =
+    ( (second (second (first is-HAE-f))) b) =
     concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z))
-      ( (second (second (first fisHAE))) b))
+      ( (second (second (first is-HAE-f))) b))
   :=
     associative-concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+        ( (first (second (first is-HAE-f))) (first z))))
     ( ap B B (f (first z)) b
-      ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+      ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
       ( second z))
-    ( (second (second (first fisHAE))) b)
+    ( (second (second (first is-HAE-f))) b)
 
-#def isHAE-fib-base-path-transport-nat-calculation
+#def is-HAE-fib-base-path-transport-nat-calculation
   : concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z))
-      ( (second (second (first fisHAE))) b)) =
+      ( (second (second (first is-HAE-f))) b)) =
     concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( b)
-      ( (second (second (first fisHAE))) (f (first z)))
+      ( (second (second (first is-HAE-f))) (f (first z)))
       ( ap B B (f (first z)) b (identity B) (second z)))
   :=
     concat-homotopy B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( b)
         ( ap B B
           ( f (first z))
           ( b)
-          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
           ( second z))
-        ( (second (second (first fisHAE))) b))
+        ( (second (second (first is-HAE-f))) b))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z)))
       ( nat-htpy B B
-        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( identity B)
-        ( second (second (first fisHAE)))
+        ( second (second (first is-HAE-f)))
         ( f (first z))
         ( b)
         ( second z))
 
-#def isHAE-fib-base-path-transport-ap-id-calculation
+#def is-HAE-fib-base-path-transport-ap-id-calculation
   : concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( b)
-      ( (second (second (first fisHAE))) (f (first z)))
+      ( (second (second (first is-HAE-f))) (f (first z)))
       ( ap B B (f (first z)) b (identity B) (second z))) =
   concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( b)
-      ( (second (second (first fisHAE))) (f (first z)))
+      ( (second (second (first is-HAE-f))) (f (first z)))
       ( second z))
   :=
     concat-homotopy B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z)))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         (second z))
       ( concat-homotopy B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z))
         ( second z)
         ( ap-id B (f (first z)) b (second z)))
 
-#def isHAE-fib-base-path-transport-reassoc-calculation
+#def is-HAE-fib-base-path-transport-reassoc-calculation
   : concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
     ( concat B
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( b)
-      ( (second (second (first fisHAE))) (f (first z)))
+      ( (second (second (first is-HAE-f))) (f (first z)))
       ( second z)) =
     concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
-        ( (second (second (first fisHAE))) (f (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
+        ( (second (second (first is-HAE-f))) (f (first z))))
       ( second z)
   :=
     rev-associative-concat B
     ( f (first z))
-    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
     ( f (first z))
     ( b)
     ( ap A B
       ( first z)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
       ( f)
       ( rev A
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( first z)
-        ( (first (second (first fisHAE))) (first z))))
-    ( (second (second (first fisHAE))) (f (first z)))
+        ( (first (second (first is-HAE-f))) (first z))))
+    ( (second (second (first is-HAE-f))) (f (first z)))
     ( second z)
 
-#def isHAE-fib-base-path-transport-HAE-calculation
+#def is-HAE-fib-base-path-transport-HAE-calculation
   : concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
-      ( (second (second (first fisHAE))) (f (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
+      ( (second (second (first is-HAE-f))) (f (first z))))
     ( second z) =
     concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
           ( first z) f
-          ( ((first (second (first fisHAE)))) (first z))))
+          ( ((first (second (first is-HAE-f)))) (first z))))
       ( second z)
   :=
     homotopy-concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
-      ( (second (second (first fisHAE))) (f (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
+      ( (second (second (first is-HAE-f))) (f (first z))))
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
         ( first z)
         ( f)
-        ( (first (second (first fisHAE))) (first z))))
+        ( (first (second (first is-HAE-f))) (first z))))
       ( concat-homotopy B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
-        ( (second (second (first fisHAE))) (f (first z)))
+            ( (first (second (first is-HAE-f))) (first z))))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( ap A B
-          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
           ( first z) f
-          ( ((first (second (first fisHAE)))) (first z)))
-        ( (second fisHAE) (first z)))
+          ( ((first (second (first is-HAE-f)))) (first z)))
+        ( (second is-HAE-f) (first z)))
       ( second z)
 
-#def isHAE-fib-base-path-transport-HAE-reduction
+#def is-HAE-fib-base-path-transport-HAE-reduction
   : concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( ap A B
-        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
         ( first z) f
-        ( ((first (second (first fisHAE)))) (first z))))
+        ( ((first (second (first is-HAE-f)))) (first z))))
     ( second z) =
     concat B (f (first z)) (f (first z)) b (refl) (second z)
   :=
     homotopy-concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( ap A B
-        ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+        ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
         ( first z) f
-        ( ((first (second (first fisHAE)))) (first z))))
+        ( ((first (second (first is-HAE-f)))) (first z))))
     ( refl)
     ( concat-ap-rev-ap-id A B
-      ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+      ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
       ( first z)
       ( f)
-      ( ((first (second (first fisHAE)))) (first z)))
+      ( ((first (second (first is-HAE-f)))) (first z)))
     ( second z)
 
-#def isHAE-fib-base-path-transport-HAE-final-reduction uses (A)
+#def is-HAE-fib-base-path-transport-HAE-final-reduction uses (A)
   : concat B (f (first z)) (f (first z)) b (refl) (second z) = second z
   := left-unit-concat B (f (first z)) b (second z)
 
-#def isHAE-fib-base-path-transport-path
+#def is-HAE-fib-base-path-transport-path
   : transport A ( \ x → (f x) = b)
-    ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-    ( isHAE-fib-base-path )
-    ( (second (second (first fisHAE))) b) = second z
+    ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+    ( is-HAE-fib-base-path )
+    ( (second (second (first is-HAE-f))) b) = second z
   :=
     alternating-12ary-concat ( (f (first z)) = b)
     ( transport A ( \ x → (f x) = b)
-      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-      ( isHAE-fib-base-path )
-      ( (second (second (first fisHAE))) b))
+      ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+      ( is-HAE-fib-base-path )
+      ( (second (second (first is-HAE-f))) b))
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
-        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
-          ( isHAE-fib-base-path )))
-      ( (second (second (first fisHAE))) b))
-    ( isHAE-fib-base-path-transport )
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
+          ( is-HAE-fib-base-path )))
+      ( (second (second (first is-HAE-f))) b))
+    ( is-HAE-fib-base-path-transport )
     ( concat B
-      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
-      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
         ( concat A
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z)))
+            ( (first (second (first is-HAE-f))) (first z)))
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
-      ( (second (second (first fisHAE))) b))
-    ( isHAE-fib-base-path-transport-rev-calculation)
+      ( (second (second (first is-HAE-f))) b))
+    ( is-HAE-fib-base-path-transport-rev-calculation)
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
-      ( (second (second (first fisHAE))) b))
-    ( isHAE-fib-base-path-transport-ap-calculation )
+      ( (second (second (first is-HAE-f))) b))
+    ( is-HAE-fib-base-path-transport-ap-calculation )
     ( concat B
-      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
-          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           f
           ( ap B A (f (first z)) b
-            ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
-      ( (second (second (first fisHAE))) b))
-    ( isHAE-fib-base-path-transport-rev-ap-rev-calculation )
-    ( concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+            ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z))))
+      ( (second (second (first is-HAE-f))) b))
+    ( is-HAE-fib-base-path-transport-rev-ap-rev-calculation )
+    ( concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap B B (f (first z)) b
-          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
           ( second z)))
-      ( (second (second (first fisHAE))) b))
-    ( isHAE-fib-base-path-transport-ap-ap-calculation )
+      ( (second (second (first is-HAE-f))) b))
+    ( is-HAE-fib-base-path-transport-ap-ap-calculation )
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
         ( b)
         ( ap B B
           ( f (first z)) ( b)
-          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
           ( second z))
-        ( (second (second (first fisHAE))) b)))
-    ( isHAE-fib-base-path-transport-assoc-calculation)
+        ( (second (second (first is-HAE-f))) b)))
+    ( is-HAE-fib-base-path-transport-assoc-calculation)
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
         ( f)
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) (first z)
+          ( (first (second (first is-HAE-f))) (first z))))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z))))
-    ( isHAE-fib-base-path-transport-nat-calculation)
+    ( is-HAE-fib-base-path-transport-nat-calculation)
     ( concat B
       ( f (first z))
-      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))) f
         ( rev A
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( first z)
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( concat B
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
-        ( (second (second (first fisHAE))) (f (first z)))
+        ( (second (second (first is-HAE-f))) (f (first z)))
         ( second z)))
-    (isHAE-fib-base-path-transport-ap-id-calculation)
+    (is-HAE-fib-base-path-transport-ap-id-calculation)
     ( concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
-        ( (second (second (first fisHAE))) (f (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
+        ( (second (second (first is-HAE-f))) (f (first z))))
         ( second z))
-    ( isHAE-fib-base-path-transport-reassoc-calculation)
+    ( is-HAE-fib-base-path-transport-reassoc-calculation)
     ( concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( f)
           ( rev A
-            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( first z)
-            ( (first (second (first fisHAE))) (first z))))
+            ( (first (second (first is-HAE-f))) (first z))))
         ( ap A B
-          ( retraction-composite-has-inverse A B f (first fisHAE) (first z))
+          ( retraction-composite-has-inverse A B f (first is-HAE-f) (first z))
           ( first z) f
-          ( (first (second (first fisHAE))) (first z))))
+          ( (first (second (first is-HAE-f))) (first z))))
       ( second z))
-    ( isHAE-fib-base-path-transport-HAE-calculation)
+    ( is-HAE-fib-base-path-transport-HAE-calculation)
     ( concat B (f (first z)) (f (first z)) b (refl) (second z))
-    ( isHAE-fib-base-path-transport-HAE-reduction)
+    ( is-HAE-fib-base-path-transport-HAE-reduction)
     ( second z)
-    ( isHAE-fib-base-path-transport-HAE-final-reduction)
+    ( is-HAE-fib-base-path-transport-HAE-final-reduction)
 ```
 
 Finally, we may define the contracting homotopy:
 
 ```rzk
-#def isHAE-fib-contracting-homotopy
-  : (is-surj-is-half-adjoint-equiv A B f fisHAE b) = z
+#def is-HAE-fib-contracting-homotopy
+  : (is-surj-is-half-adjoint-equiv A B f is-HAE-f b) = z
   :=
     path-of-pairs-pair-of-paths A
     ( \ x → (f x) = b)
-    ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+    ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
     ( first z)
-    ( isHAE-fib-base-path)
-    ( (second (second (first fisHAE))) b)
+    ( is-HAE-fib-base-path)
+    ( (second (second (first is-HAE-f))) b)
     ( second z)
-    ( isHAE-fib-base-path-transport-path)
+    ( is-HAE-fib-base-path-transport-path)
 
 #end half-adjoint-equivalence-fiber-data
 ```
@@ -1178,11 +1178,11 @@ Half adjoint equivalences define contractible maps:
 #def is-contr-map-is-half-adjoint-equiv
   (A B : U)
   (f : A → B)
-  (fisHAE : is-half-adjoint-equiv A B f)
+  (is-HAE-f : is-half-adjoint-equiv A B f)
   : is-contr-map A B f
   := \ b →
-        ( is-surj-is-half-adjoint-equiv A B f fisHAE b ,
-          \ z → isHAE-fib-contracting-homotopy A B f fisHAE b z)
+        ( is-surj-is-half-adjoint-equiv A B f is-HAE-f b ,
+          \ z → is-HAE-fib-contracting-homotopy A B f is-HAE-f b z)
 ```
 
 ## Equivalences are contractible maps
@@ -1196,7 +1196,7 @@ Half adjoint equivalences define contractible maps:
   := \ b →
         ( is-surj-is-half-adjoint-equiv A B f
           ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b ,
-          \ z → isHAE-fib-contracting-homotopy A B f
+          \ z → is-HAE-fib-contracting-homotopy A B f
             ( is-half-adjoint-equiv-is-equiv A B f is-equiv-f) b z)
 
 #def is-contr-map-iff-is-equiv

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -235,7 +235,7 @@ Specializing the above to `is-HAE-fib-base-path`:
             ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
             ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first is-HAE-f))
               ( rev B (f (first z)) b (second z))))))
-      ( ap-htpy A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
+      ( ap-eq A B (first z) ((map-inverse-has-inverse A B f (first is-HAE-f)) b) f
         ( rev A ((map-inverse-has-inverse A B f (first is-HAE-f)) b) (first z)
           ( is-HAE-fib-base-path ))
         ( concat A
@@ -459,7 +459,7 @@ Specializing the above to `is-HAE-fib-base-path`:
           ( (map-inverse-has-inverse A B f (first is-HAE-f)) b) f
           ( ap B A (f (first z)) b
             ( map-inverse-has-inverse A B f (first is-HAE-f)) (second z)))
-        ( ap-htpy A B
+        ( ap-eq A B
           ( (map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z)))
           ( (map-inverse-has-inverse A B f (first is-HAE-f)) b)
           ( f)

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -509,7 +509,7 @@ Specializing the above to `isHAE-fib-base-path`:
           ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( (second (second (first fisHAE))) b)
   :=
@@ -544,7 +544,7 @@ Specializing the above to `isHAE-fib-base-path`:
           ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( concat-homotopy B
       ( f (first z))
@@ -564,7 +564,7 @@ Specializing the above to `isHAE-fib-base-path`:
         ( ap B A (f (first z)) b
           ( map-inverse-has-inverse A B f (first fisHAE)) (second z)))
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( rev-ap-comp B A B
         ( f (first z))
@@ -588,7 +588,7 @@ Specializing the above to `isHAE-fib-base-path`:
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( (second (second (first fisHAE))) b) =
     concat B
@@ -608,7 +608,7 @@ Specializing the above to `isHAE-fib-base-path`:
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( (second (second (first fisHAE))) b))
   :=
@@ -625,7 +625,7 @@ Specializing the above to `isHAE-fib-base-path`:
         ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
         ( (first (second (first fisHAE))) (first z))))
     ( ap B B (f (first z)) b
-      ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+      ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
       ( second z))
     ( (second (second (first fisHAE))) b)
 
@@ -647,7 +647,7 @@ Specializing the above to `isHAE-fib-base-path`:
       ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( (second (second (first fisHAE))) b)) =
     concat B
@@ -688,7 +688,7 @@ Specializing the above to `isHAE-fib-base-path`:
         ( ap B B
           ( f (first z))
           ( b)
-          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z))
         ( (second (second (first fisHAE))) b))
       ( concat B
@@ -698,7 +698,7 @@ Specializing the above to `isHAE-fib-base-path`:
         ( (second (second (first fisHAE))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z)))
       ( nat-htpy B B
-        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+        ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( identity B)
         ( second (second (first fisHAE)))
         ( f (first z))
@@ -1051,7 +1051,7 @@ Specializing the above to `isHAE-fib-base-path`:
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap B B (f (first z)) b
-          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z)))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport-ap-ap-calculation )
@@ -1073,7 +1073,7 @@ Specializing the above to `isHAE-fib-base-path`:
         ( b)
         ( ap B B
           ( f (first z)) ( b)
-          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
+          ( comp B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z))
         ( (second (second (first fisHAE))) b)))
     ( isHAE-fib-base-path-transport-assoc-calculation)

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -214,7 +214,7 @@ Specializing the above to `is-HAE-fib-base-path`:
             ( rev B (f (first z)) b (second z))))))
     ( (second (second (first is-HAE-f))) b)
   :=
-    homotopy-concat B
+    concat-eq-left B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
@@ -293,7 +293,7 @@ Specializing the above to `is-HAE-fib-base-path`:
               ( rev B (f (first z)) b (second z))))))
       ( (second (second (first is-HAE-f))) b)
   :=
-    homotopy-concat B
+    concat-eq-left B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
       ( b)
@@ -392,7 +392,7 @@ Specializing the above to `is-HAE-fib-base-path`:
             ( second z))))
       ( (second (second (first is-HAE-f))) b)
   :=
-    homotopy-concat B
+    concat-eq-left B
       ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
       ( concat B
         ( f (first z))
@@ -434,7 +434,7 @@ Specializing the above to `is-HAE-fib-base-path`:
           ( ap B A
             ( f (first z)) b (map-inverse-has-inverse A B f (first is-HAE-f))
             ( second z))))
-      ( concat-homotopy B
+      ( concat-eq-right B
         ( f (first z))
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
@@ -513,7 +513,7 @@ Specializing the above to `is-HAE-fib-base-path`:
         ( second z)))
     ( (second (second (first is-HAE-f))) b)
   :=
-    homotopy-concat B
+    concat-eq-left B
     ( f (first z)) (f ((map-inverse-has-inverse A B f (first is-HAE-f)) b)) b
     ( concat B
       ( f (first z))
@@ -546,7 +546,7 @@ Specializing the above to `is-HAE-fib-base-path`:
       ( ap B B (f (first z)) b
         ( comp B A B f (map-inverse-has-inverse A B f (first is-HAE-f)))
         ( second z)))
-    ( concat-homotopy B
+    ( concat-eq-right B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) b))
@@ -669,7 +669,7 @@ Specializing the above to `is-HAE-fib-base-path`:
       ( (second (second (first is-HAE-f))) (f (first z)))
       ( ap B B (f (first z)) b (identity B) (second z)))
   :=
-    concat-homotopy B
+    concat-eq-right B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
@@ -743,7 +743,7 @@ Specializing the above to `is-HAE-fib-base-path`:
       ( (second (second (first is-HAE-f))) (f (first z)))
       ( second z))
   :=
-    concat-homotopy B
+    concat-eq-right B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
       ( b)
@@ -766,7 +766,7 @@ Specializing the above to `is-HAE-fib-base-path`:
         ( b)
         ( (second (second (first is-HAE-f))) (f (first z)))
         (second z))
-      ( concat-homotopy B
+      ( concat-eq-right B
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
         ( b)
@@ -858,7 +858,7 @@ Specializing the above to `is-HAE-fib-base-path`:
           ( ((first (second (first is-HAE-f)))) (first z))))
       ( second z)
   :=
-    homotopy-concat B (f (first z)) (f (first z)) b
+    concat-eq-left B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
@@ -887,7 +887,7 @@ Specializing the above to `is-HAE-fib-base-path`:
         ( first z)
         ( f)
         ( (first (second (first is-HAE-f))) (first z))))
-      ( concat-homotopy B
+      ( concat-eq-right B
         ( f (first z))
         ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))
         ( f (first z))
@@ -925,7 +925,7 @@ Specializing the above to `is-HAE-fib-base-path`:
     ( second z) =
     concat B (f (first z)) (f (first z)) b (refl) (second z)
   :=
-    homotopy-concat B (f (first z)) (f (first z)) b
+    concat-eq-left B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
       ( f ((map-inverse-has-inverse A B f (first is-HAE-f)) (f (first z))))

--- a/src/hott/07-fibers.rzk.md
+++ b/src/hott/07-fibers.rzk.md
@@ -120,7 +120,7 @@ We now show that half adjoint equivalences are contractible maps.
   (b : B)
   : fib A B f b
   :=
-    ( (has-inverse-inverse A B f (first fisHAE)) b ,
+    ( (map-inverse-has-inverse A B f (first fisHAE)) b ,
       (second (second (first fisHAE))) b)
 ```
 
@@ -137,13 +137,13 @@ this homotopy is straightforward.
 #variable z : fib A B f b
 
 #def isHAE-fib-base-path
-  : ((has-inverse-inverse A B f (first fisHAE)) b) = (first z)
+  : ((map-inverse-has-inverse A B f (first fisHAE)) b) = (first z)
   :=
     concat A
-      ( (has-inverse-inverse A B f (first fisHAE)) b)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( first z)
-      ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
         ( rev B (f (first z)) b (second z)))
       ( (first (second (first fisHAE))) (first z))
 ```
@@ -153,517 +153,517 @@ Specializing the above to `isHAE-fib-base-path`:
 ```rzk
 #def isHAE-fib-base-path-transport
   : transport A (\ x → (f x) = b)
-      ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
       ( isHAE-fib-base-path )
       ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
-          ( rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+          ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
             ( isHAE-fib-base-path )))
       ( (second (second (first fisHAE))) b)
   :=
     transport-in-fiber A B f b
-      ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
       ( (second (second (first fisHAE))) b)
       ( isHAE-fib-base-path )
 
 #def isHAE-fib-base-path-rev-coherence
-  : rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+  : rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
       ( isHAE-fib-base-path) =
     concat A
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-      ( (has-inverse-inverse A B f (first fisHAE)) b)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
         ( (first (second (first fisHAE))) (first z)))
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
           ( rev B (f (first z)) b (second z))))
   :=
     rev-concat A
-      ( (has-inverse-inverse A B f (first fisHAE)) b)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( first z)
-      ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+      ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
         ( rev B (f (first z)) b (second z)))
       ( (first (second (first fisHAE))) (first z))
 
 #def isHAE-fib-base-path-transport-rev-calculation
-  : concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
-      ( rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+      ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
         ( isHAE-fib-base-path )))
     ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
       ( concat A
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z)))
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
             ( rev B (f (first z)) b (second z))))))
     ( (second (second (first fisHAE))) b)
   :=
     homotopy-concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
-        ( rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
           ( isHAE-fib-base-path )))
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
         ( concat A
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z)))
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
-      ( ap-htpy A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
-        ( rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( ap-htpy A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
           ( isHAE-fib-base-path ))
         ( concat A
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z)))
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z)))))
         ( isHAE-fib-base-path-rev-coherence ))
       ( (second (second (first fisHAE))) b)
 
 #def isHAE-fib-base-path-transport-ap-calculation
-  : concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
-    ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+    ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
       ( concat A
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z)))
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
             ( rev B (f (first z)) b (second z))))))
     ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( (second (second (first fisHAE))) b)
   :=
     homotopy-concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
         ( concat A
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z)))
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( ap-concat A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z)))
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
             ( rev B (f (first z)) b (second z)))))
       ( (second (second (first fisHAE))) b)
 
 #def isHAE-fib-base-path-transport-rev-ap-rev-calculation
-  : concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
             ( rev B (f (first z)) b (second z))))))
     ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
-          ( first z) ((has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( ap B A (f (first z)) b
-            ( has-inverse-inverse A B f (first fisHAE))
+            ( map-inverse-has-inverse A B f (first fisHAE))
             ( second z))))
       ( (second (second (first fisHAE))) b)
   :=
     homotopy-concat B
-      ( f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( ap B A
-            ( f (first z)) b (has-inverse-inverse A B f (first fisHAE))
+            ( f (first z)) b (map-inverse-has-inverse A B f (first fisHAE))
             ( second z))))
       ( concat-homotopy B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z)))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b) f
           ( ap B A (f (first z)) b
-            ( has-inverse-inverse A B f (first fisHAE)) (second z)))
+            ( map-inverse-has-inverse A B f (first fisHAE)) (second z)))
         ( ap-htpy A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( ap B A b
               ( f (first z))
-              ( has-inverse-inverse A B f (first fisHAE))
+              ( map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))
           ( ap B A
             ( f (first z))
             ( b)
-            ( has-inverse-inverse A B f (first fisHAE))
+            ( map-inverse-has-inverse A B f (first fisHAE))
             ( second z))
           ( rev-ap-rev B A (f (first z)) b
-            ( has-inverse-inverse A B f (first fisHAE)) (second z))))
+            ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
       ( (second (second (first fisHAE))) b)
 
 #def isHAE-fib-base-path-transport-ap-ap-calculation
-  : concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
-        ( first z) ((has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( f)
         ( ap B A (f (first z)) b
-          ( has-inverse-inverse A B f (first fisHAE))
+          ( map-inverse-has-inverse A B f (first fisHAE))
           ( second z))))
     ( (second (second (first fisHAE))) b) =
-    concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+    concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
-        ( first z) ((has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( (second (second (first fisHAE))) b)
   :=
     homotopy-concat B
-    ( f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+    ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( f)
         ( ap B A
           ( f (first z)) b
-          ( has-inverse-inverse A B f (first fisHAE)) (second z))))
+          ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( concat-homotopy B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-        ( (has-inverse-inverse A B f (first fisHAE)) b)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) b)
         ( f)
         ( ap B A (f (first z)) b
-          ( has-inverse-inverse A B f (first fisHAE)) (second z)))
+          ( map-inverse-has-inverse A B f (first fisHAE)) (second z)))
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( rev-ap-comp B A B
         ( f (first z))
         ( b)
-        ( has-inverse-inverse A B f (first fisHAE))
+        ( map-inverse-has-inverse A B f (first fisHAE))
         ( f)
         ( second z)))
     ( (second (second (first fisHAE))) b)
 
 #def isHAE-fib-base-path-transport-assoc-calculation
-  : concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+  : concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z)))
     ( (second (second (first fisHAE))) b) =
     concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( (second (second (first fisHAE))) b))
   :=
     associative-concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
         ( (first (second (first fisHAE))) (first z))))
     ( ap B B (f (first z)) b
-      ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+      ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
       ( second z))
     ( (second (second (first fisHAE))) b)
 
 #def isHAE-fib-base-path-transport-nat-calculation
   : concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
       ( ap B B (f (first z)) b
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( second z))
       ( (second (second (first fisHAE))) b)) =
     concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( b)
       ( (second (second (first fisHAE))) (f (first z)))
@@ -671,34 +671,34 @@ Specializing the above to `isHAE-fib-base-path`:
   :=
     concat-homotopy B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( b)
         ( ap B B
           ( f (first z))
           ( b)
-          ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z))
         ( (second (second (first fisHAE))) b))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z)))
       ( nat-htpy B B
-        ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+        ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
         ( identity B)
         ( second (second (first fisHAE)))
         ( f (first z))
@@ -708,36 +708,36 @@ Specializing the above to `isHAE-fib-base-path`:
 #def isHAE-fib-base-path-transport-ap-id-calculation
   : concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( b)
       ( (second (second (first fisHAE))) (f (first z)))
       ( ap B B (f (first z)) b (identity B) (second z))) =
   concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( b)
       ( (second (second (first fisHAE))) (f (first z)))
@@ -745,29 +745,29 @@ Specializing the above to `isHAE-fib-base-path`:
   :=
     concat-homotopy B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
         ( ap B B (f (first z)) b (identity B) (second z)))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
         (second z))
       ( concat-homotopy B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
@@ -778,17 +778,17 @@ Specializing the above to `isHAE-fib-base-path`:
 #def isHAE-fib-base-path-transport-reassoc-calculation
   : concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( concat B
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( b)
       ( (second (second (first fisHAE))) (f (first z)))
@@ -796,13 +796,13 @@ Specializing the above to `isHAE-fib-base-path`:
     concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( (second (second (first fisHAE))) (f (first z))))
@@ -810,15 +810,15 @@ Specializing the above to `isHAE-fib-base-path`:
   :=
     rev-associative-concat B
     ( f (first z))
-    ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+    ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
     ( f (first z))
     ( b)
     ( ap A B
       ( first z)
-      ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+      ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
       ( f)
       ( rev A
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( first z)
         ( (first (second (first fisHAE))) (first z))))
     ( (second (second (first fisHAE))) (f (first z)))
@@ -828,14 +828,14 @@ Specializing the above to `isHAE-fib-base-path`:
   : concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( (second (second (first fisHAE))) (f (first z))))
@@ -843,13 +843,13 @@ Specializing the above to `isHAE-fib-base-path`:
     concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
@@ -861,25 +861,25 @@ Specializing the above to `isHAE-fib-base-path`:
     homotopy-concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( (second (second (first fisHAE))) (f (first z))))
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
@@ -889,13 +889,13 @@ Specializing the above to `isHAE-fib-base-path`:
         ( (first (second (first fisHAE))) (first z))))
       ( concat-homotopy B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( (second (second (first fisHAE))) (f (first z)))
@@ -910,12 +910,12 @@ Specializing the above to `isHAE-fib-base-path`:
   : concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( ap A B
-        ( first z) ((has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( first z) ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ((has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
@@ -928,13 +928,13 @@ Specializing the above to `isHAE-fib-base-path`:
     homotopy-concat B (f (first z)) (f (first z)) b
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( f (first z))
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( ap A B
@@ -955,141 +955,141 @@ Specializing the above to `isHAE-fib-base-path`:
 
 #def isHAE-fib-base-path-transport-path
   : transport A ( \ x → (f x) = b)
-    ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
+    ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
     ( isHAE-fib-base-path )
     ( (second (second (first fisHAE))) b) = second z
   :=
     alternating-12ary-concat ( (f (first z)) = b)
     ( transport A ( \ x → (f x) = b)
-      ( (has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( (map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
       ( isHAE-fib-base-path )
       ( (second (second (first fisHAE))) b))
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
-        ( rev A ((has-inverse-inverse A B f (first fisHAE)) b) (first z)
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
+        ( rev A ((map-inverse-has-inverse A B f (first fisHAE)) b) (first z)
           ( isHAE-fib-base-path )))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport )
     ( concat B
-      ( f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
-      ( ap A B (first z) ((has-inverse-inverse A B f (first fisHAE)) b) f
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
+      ( ap A B (first z) ((map-inverse-has-inverse A B f (first fisHAE)) b) f
         ( concat A
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z)))
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport-rev-calculation)
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
       ( b)
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) b)
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-            ( ap B A b (f (first z)) (has-inverse-inverse A B f (first fisHAE))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) b)
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+            ( ap B A b (f (first z)) (map-inverse-has-inverse A B f (first fisHAE))
               ( rev B (f (first z)) b (second z))))))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport-ap-calculation )
     ( concat B
-      ( f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+      ( f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
-          ( (has-inverse-inverse A B f (first fisHAE)) b)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) b)
           f
           ( ap B A (f (first z)) b
-            ( has-inverse-inverse A B f (first fisHAE)) (second z))))
+            ( map-inverse-has-inverse A B f (first fisHAE)) (second z))))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport-rev-ap-rev-calculation )
-    ( concat B (f (first z)) (f ((has-inverse-inverse A B f (first fisHAE)) b)) b
+    ( concat B (f (first z)) (f ((map-inverse-has-inverse A B f (first fisHAE)) b)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap B B (f (first z)) b
-          ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z)))
       ( (second (second (first fisHAE))) b))
     ( isHAE-fib-base-path-transport-ap-ap-calculation )
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) b))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) b))
         ( b)
         ( ap B B
           ( f (first z)) ( b)
-          ( composition B A B f (has-inverse-inverse A B f (first fisHAE)))
+          ( composition B A B f (map-inverse-has-inverse A B f (first fisHAE)))
           ( second z))
         ( (second (second (first fisHAE))) b)))
     ( isHAE-fib-base-path-transport-assoc-calculation)
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
         ( f)
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) (first z)
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) (first z)
           ( (first (second (first fisHAE))) (first z))))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
@@ -1097,17 +1097,17 @@ Specializing the above to `isHAE-fib-base-path`:
     ( isHAE-fib-base-path-transport-nat-calculation)
     ( concat B
       ( f (first z))
-      ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+      ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
       ( b)
       ( ap A B
         ( first z)
-        ( (has-inverse-inverse A B f (first fisHAE)) (f (first z))) f
+        ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z))) f
         ( rev A
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( first z)
           ( (first (second (first fisHAE))) (first z))))
       ( concat B
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( b)
         ( (second (second (first fisHAE))) (f (first z)))
@@ -1116,14 +1116,14 @@ Specializing the above to `isHAE-fib-base-path`:
     ( concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( (second (second (first fisHAE))) (f (first z))))
@@ -1132,14 +1132,14 @@ Specializing the above to `isHAE-fib-base-path`:
     ( concat B (f (first z)) (f (first z)) b
       ( concat B
         ( f (first z))
-        ( f ((has-inverse-inverse A B f (first fisHAE)) (f (first z))))
+        ( f ((map-inverse-has-inverse A B f (first fisHAE)) (f (first z))))
         ( f (first z))
         ( ap A B
           ( first z)
-          ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+          ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
           ( f)
           ( rev A
-            ( (has-inverse-inverse A B f (first fisHAE)) (f (first z)))
+            ( (map-inverse-has-inverse A B f (first fisHAE)) (f (first z)))
             ( first z)
             ( (first (second (first fisHAE))) (first z))))
         ( ap A B
@@ -1162,7 +1162,7 @@ Finally, we may define the contracting homotopy:
   :=
     path-of-pairs-pair-of-paths A
     ( \ x → (f x) = b)
-    ( (has-inverse-inverse A B f (first fisHAE)) b)
+    ( (map-inverse-has-inverse A B f (first fisHAE)) b)
     ( first z)
     ( isHAE-fib-base-path)
     ( (second (second (first fisHAE))) b)

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -631,9 +631,10 @@ fundamental theorem:
 
 ## 2-of-3 for equivalences
 
+The following functions refine `equiv-right-cancel` and `equiv-left-cancel` by
+providing control over the underlying maps of the equivalence.
+
 ```rzk
--- It might be better to redo this without appealing to results about
--- embeddings so that this could go earlier.
 #def is-equiv-right-factor
   ( A B C : U)
   ( f : A → B)

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -364,21 +364,25 @@ The pullback of a family along homotopic maps is equivalent.
   :=
     ( map-inverse-pullback-homotopy ,
       \ c →
-        concat (pullback A B g C a)
-          ( transport B C (f a) (g a) (α a)
-            ( transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c))
-          ( transport B C (g a) (g a)
-            ( concat B (g a) (f a) (g a) (rev B (f a) (g a) (α a)) (α a)) c)
-          ( c)
-          ( transport-concat-rev B C (g a) (f a) (g a)
-            ( rev B (f a) (g a) (α a)) (α a) c)
-          ( transport2 B C (g a) (g a)
-            ( concat B (g a) (f a) (g a) (rev B (f a) (g a) (α a)) (α a)) refl
-            ( left-inverse-concat B (f a) (g a) (α a)) c))
+      concat
+        ( pullback A B g C a)
+        ( transport B C (f a) (g a) (α a)
+          ( transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c))
+        ( transport B C (g a) (g a)
+          ( concat B (g a) (f a) (g a) (rev B (f a) (g a) (α a)) (α a)) c)
+        ( c)
+        ( transport-concat-rev B C (g a) (f a) (g a)
+          ( rev B (f a) (g a) (α a)) (α a) (c))
+        ( transport2 B C (g a) (g a)
+          ( concat B (g a) (f a) (g a) (rev B (f a) (g a) (α a)) (α a))
+          ( refl)
+          ( left-inverse-concat B (f a) (g a) (α a)) c))
 
 #def is-equiv-pullback-homotopy uses (α)
   : is-equiv
-    (pullback A B f C a) (pullback A B g C a) (pullback-homotopy)
+      ( pullback A B f C a)
+      ( pullback A B g C a)
+      ( pullback-homotopy)
   := ( has-retraction-pullback-homotopy , has-section-pullback-homotopy)
 
 #def equiv-pullback-homotopy uses (α)
@@ -407,20 +411,22 @@ map.
 
 ```rzk
 #def pullback-comparison-fiber
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
   : U
   :=
-    fib (Σ (a : A) , (pullback A B f C) a) (Σ (b : B) , C b)
+    fib
+      ( Σ (a : A) , (pullback A B f C) a)
+      ( Σ (b : B) , C b)
       ( pullback-comparison-map A B f C) z
 
 #def pullback-comparison-fiber-to-fiber
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
   : (pullback-comparison-fiber A B f C z) → (fib A B f (first z))
   :=
     \ (w , p) →
@@ -434,10 +440,10 @@ map.
         p)
 
 #def from-base-fiber-to-pullback-comparison-fiber
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (b : B)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( b : B)
   : (fib A B f b) → (c : C b) → (pullback-comparison-fiber A B f C (b , c))
   :=
     \ (a , p) →
@@ -451,10 +457,10 @@ map.
           p)
 
 #def pullback-comparison-fiber-to-fiber-inv
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
   : (fib A B f (first z)) → (pullback-comparison-fiber A B f C z)
   :=
     \ (a , p) →
@@ -462,11 +468,11 @@ map.
       ( first z) (a , p) (second z)
 
 #def pullback-comparison-fiber-to-fiber-retracting-homotopy
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
-  ((w , p) : pullback-comparison-fiber A B f C z)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
+  ( (w , p) : pullback-comparison-fiber A B f C z)
   : ( (pullback-comparison-fiber-to-fiber-inv A B f C z)
       ( (pullback-comparison-fiber-to-fiber A B f C z) (w , p))) = (w , p)
   :=
@@ -481,11 +487,11 @@ map.
       p)
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy-map
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (b : B)
-  ((a , p) : fib A B f b)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( b : B)
+  ( (a , p) : fib A B f b)
   : (c : C b) →
       ((pullback-comparison-fiber-to-fiber A B f C (b , c))
         ((pullback-comparison-fiber-to-fiber-inv A B f C (b , c)) (a , p))) =
@@ -503,27 +509,27 @@ map.
       p)
 
 #def pullback-comparison-fiber-to-fiber-section-homotopy
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
-  ((a , p) : fib A B f (first z))
-  : ((pullback-comparison-fiber-to-fiber A B f C z)
-      ((pullback-comparison-fiber-to-fiber-inv A B f C z) (a , p))) = (a , p)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
+  ( (a , p) : fib A B f (first z))
+  : ( pullback-comparison-fiber-to-fiber A B f C z
+      ( pullback-comparison-fiber-to-fiber-inv A B f C z (a , p))) = (a , p)
   :=
     pullback-comparison-fiber-to-fiber-section-homotopy-map A B f C
-    ( first z) (a , p) (second z)
+      ( first z) (a , p) (second z)
 
 #def equiv-pullback-comparison-fiber
-  (A B : U)
-  (f : A → B)
-  (C : B → U)
-  (z : Σ (b : B) , C b)
+  ( A B : U)
+  ( f : A → B)
+  ( C : B → U)
+  ( z : Σ (b : B) , C b)
   : Equiv (pullback-comparison-fiber A B f C z) (fib A B f (first z))
   :=
     ( pullback-comparison-fiber-to-fiber A B f C z ,
-      ( (pullback-comparison-fiber-to-fiber-inv A B f C z ,
-        pullback-comparison-fiber-to-fiber-retracting-homotopy A B f C z) ,
+      ( ( pullback-comparison-fiber-to-fiber-inv A B f C z ,
+          pullback-comparison-fiber-to-fiber-retracting-homotopy A B f C z) ,
         ( pullback-comparison-fiber-to-fiber-inv A B f C z ,
           pullback-comparison-fiber-to-fiber-section-homotopy A B f C z)))
 ```
@@ -533,10 +539,10 @@ equivalence of total spaces.
 
 ```rzk
 #def total-equiv-pullback-is-equiv
-  (A B : U)
-  (f : A → B)
-  (is-equiv-f : is-equiv A B f)
-  (C : B → U)
+  ( A B : U)
+  ( f : A → B)
+  ( is-equiv-f : is-equiv A B f)
+  ( C : B → U)
   : Equiv (Σ (a : A) , (pullback A B f C) a) (Σ (b : B) , C b)
   :=
     ( pullback-comparison-map A B f C ,
@@ -582,12 +588,15 @@ equivalence of total spaces.
       ( \ x →
         ( total-equiv-family-of-equiv A
           ( \ x' → (a = x'))
-          B
-          f
-          ( is-equiv-are-contr (Σ (x' : A) , (a = x')) (Σ (x' : A) , (B x'))
-            ( is-contr-based-paths A a) is-contr-B
-            ( total-map-family-of-maps A ( \ x' → (a = x')) B f))
-          x)))
+          ( B)
+          ( f)
+          ( is-equiv-are-contr
+            ( Σ (x' : A) , (a = x'))
+            ( Σ (x' : A) , (B x'))
+            ( is-contr-based-paths A a)
+            ( is-contr-B)
+            ( total-map-family-of-maps A (\ x' → (a = x')) B f))
+          ( x))))
 ```
 
 This allows us to apply "based path induction" to a family satisfying the
@@ -596,11 +605,11 @@ fundamental theorem:
 ```rzk
 -- Please suggest a better name.
 #def ind-based-path
-  (familyequiv : (z : A) → (is-equiv (a = z) (B z) (f z)))
-  (P : (z : A) → B z → U)
-  (p0 : P a (f a refl))
-  (u : A)
-  (p : B u)
+  ( familyequiv : (z : A) → (is-equiv (a = z) (B z) (f z)))
+  ( P : (z : A) → B z → U)
+  ( p0 : P a (f a refl))
+  ( u : A)
+  ( p : B u)
   : P u p
   :=
     ind-sing

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -687,15 +687,15 @@ equivalence.
   : is-equiv A B f
   :=
     ( ( composition B C A
-        (is-equiv-retraction A C (composition A B C g f) gfisequiv) g ,
+        (retraction-is-equiv A C (composition A B C g f) gfisequiv) g ,
         (second (first gfisequiv))) ,
       ( composition B C A
-        (is-equiv-section A C (composition A B C g f) gfisequiv) g ,
+        (section-is-equiv A C (composition A B C g f) gfisequiv) g ,
         \ b →
           inv-ap-is-emb
             B C g
             ( is-emb-is-equiv B C g is-equiv-g)
-            ( f ((is-equiv-section A C (composition A B C g f) gfisequiv) (g b)))
+            ( f ((section-is-equiv A C (composition A B C g f) gfisequiv) (g b)))
             b
             ( (second (second gfisequiv)) (g b))))
 
@@ -708,35 +708,35 @@ equivalence.
   : is-equiv B C g
   :=
     ( ( composition C A B
-          f (is-equiv-retraction A C (composition A B C g f) gfisequiv) ,
+          f (retraction-is-equiv A C (composition A B C g f) gfisequiv) ,
         \ b →
           triple-concat B
-            ( f ((is-equiv-retraction A C (composition A B C g f) gfisequiv)
+            ( f ((retraction-is-equiv A C (composition A B C g f) gfisequiv)
               (g b)))
-            ( f ((is-equiv-retraction A C (composition A B C g f) gfisequiv)
-              (g (f ((is-equiv-section A B f is-equiv-f) b)))))
-            ( f ((is-equiv-section A B f is-equiv-f) b))
+            ( f ((retraction-is-equiv A C (composition A B C g f) gfisequiv)
+              (g (f ((section-is-equiv A B f is-equiv-f) b)))))
+            ( f ((section-is-equiv A B f is-equiv-f) b))
             ( b)
             ( ap B B
               ( b)
-              ( f ((is-equiv-section A B f is-equiv-f) b))
+              ( f ((section-is-equiv A B f is-equiv-f) b))
               ( \ b0 →
-                ( f ((is-equiv-retraction A C
+                ( f ((retraction-is-equiv A C
                       ( composition A B C g f) gfisequiv) (g b0))))
-              ( rev B (f ((is-equiv-section A B f is-equiv-f) b)) b
+              ( rev B (f ((section-is-equiv A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
             ( ( homotopy-whisker B A A B
                 ( \ a →
-                  ( is-equiv-retraction A C
+                  ( retraction-is-equiv A C
                     ( composition A B C g f) gfisequiv) (g (f a)))
                 ( \ a → a)
                 ( second (first gfisequiv))
-                ( is-equiv-section A B f is-equiv-f)
+                ( section-is-equiv A B f is-equiv-f)
                 f) b)
             ( (second (second is-equiv-f)) b)) ,
       ( composition C A B
         ( f)
-        ( is-equiv-section A C (composition A B C g f) gfisequiv) ,
+        ( section-is-equiv A C (composition A B C g f) gfisequiv) ,
         ( second (second gfisequiv))))
 ```
 

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -683,19 +683,19 @@ equivalence.
   (f : A → B)
   (g : B → C)
   (is-equiv-g : is-equiv B C g)
-  (gfisequiv : is-equiv A C (composition A B C g f))
+  (gfisequiv : is-equiv A C (comp A B C g f))
   : is-equiv A B f
   :=
-    ( ( composition B C A
-        (retraction-is-equiv A C (composition A B C g f) gfisequiv) g ,
+    ( ( comp B C A
+        (retraction-is-equiv A C (comp A B C g f) gfisequiv) g ,
         (second (first gfisequiv))) ,
-      ( composition B C A
-        (section-is-equiv A C (composition A B C g f) gfisequiv) g ,
+      ( comp B C A
+        (section-is-equiv A C (comp A B C g f) gfisequiv) g ,
         \ b →
           inv-ap-is-emb
             B C g
             ( is-emb-is-equiv B C g is-equiv-g)
-            ( f ((section-is-equiv A C (composition A B C g f) gfisequiv) (g b)))
+            ( f ((section-is-equiv A C (comp A B C g f) gfisequiv) (g b)))
             b
             ( (second (second gfisequiv)) (g b))))
 
@@ -704,16 +704,16 @@ equivalence.
   (f : A → B)
   (is-equiv-f : is-equiv A B f)
   (g : B → C)
-  (gfisequiv : is-equiv A C (composition A B C g f))
+  (gfisequiv : is-equiv A C (comp A B C g f))
   : is-equiv B C g
   :=
-    ( ( composition C A B
-          f (retraction-is-equiv A C (composition A B C g f) gfisequiv) ,
+    ( ( comp C A B
+          f (retraction-is-equiv A C (comp A B C g f) gfisequiv) ,
         \ b →
           triple-concat B
-            ( f ((retraction-is-equiv A C (composition A B C g f) gfisequiv)
+            ( f ((retraction-is-equiv A C (comp A B C g f) gfisequiv)
               (g b)))
-            ( f ((retraction-is-equiv A C (composition A B C g f) gfisequiv)
+            ( f ((retraction-is-equiv A C (comp A B C g f) gfisequiv)
               (g (f ((section-is-equiv A B f is-equiv-f) b)))))
             ( f ((section-is-equiv A B f is-equiv-f) b))
             ( b)
@@ -722,21 +722,21 @@ equivalence.
               ( f ((section-is-equiv A B f is-equiv-f) b))
               ( \ b0 →
                 ( f ((retraction-is-equiv A C
-                      ( composition A B C g f) gfisequiv) (g b0))))
+                      ( comp A B C g f) gfisequiv) (g b0))))
               ( rev B (f ((section-is-equiv A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
             ( ( homotopy-whisker B A A B
                 ( \ a →
                   ( retraction-is-equiv A C
-                    ( composition A B C g f) gfisequiv) (g (f a)))
+                    ( comp A B C g f) gfisequiv) (g (f a)))
                 ( \ a → a)
                 ( second (first gfisequiv))
                 ( section-is-equiv A B f is-equiv-f)
                 f) b)
             ( (second (second is-equiv-f)) b)) ,
-      ( composition C A B
+      ( comp C A B
         ( f)
-        ( section-is-equiv A C (composition A B C g f) gfisequiv) ,
+        ( section-is-equiv A C (comp A B C g f) gfisequiv) ,
         ( second (second gfisequiv))))
 ```
 

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -330,19 +330,19 @@ The pullback of a family along homotopic maps is equivalent.
 
 #def pullback-homotopy
   : (pullback A B f C a) → (pullback A B g C a)
-  := \ c → transport B C (f a) (g a) (α a) c
+  := transport B C (f a) (g a) (α a)
 
-#def pullback-homotopy-inverse
+#def map-inverse-pullback-homotopy
   : (pullback A B g C a) → (pullback A B f C a)
-  := \ c → transport B C (g a) (f a) (rev B (f a) (g a) (α a)) c
+  := transport B C (g a) (f a) (rev B (f a) (g a) (α a))
 
-#def pullback-homotopy-has-retraction
+#def has-retraction-pullback-homotopy
   : has-retraction
     ( pullback A B f C a)
     ( pullback A B g C a)
     ( pullback-homotopy)
   :=
-    ( pullback-homotopy-inverse ,
+    ( map-inverse-pullback-homotopy ,
       \ c →
         concat
         ( pullback A B f C a)
@@ -355,14 +355,14 @@ The pullback of a family along homotopic maps is equivalent.
         ( transport-concat-rev B C (f a) (g a) (f a) (α a)
           ( rev B (f a) (g a) (α a)) c)
         ( transport2 B C (f a) (f a)
-        ( concat B (f a) (g a) (f a) (α a) (rev B (f a) (g a) (α a))) refl
-        ( right-inverse-concat B (f a) (g a) (α a)) c))
+          ( concat B (f a) (g a) (f a) (α a) (rev B (f a) (g a) (α a))) refl
+          ( right-inverse-concat B (f a) (g a) (α a)) c))
 
-#def pullback-homotopy-has-section
+#def has-section-pullback-homotopy
   : has-section (pullback A B f C a) (pullback A B g C a)
     ( pullback-homotopy)
   :=
-    ( pullback-homotopy-inverse ,
+    ( map-inverse-pullback-homotopy ,
       \ c →
         concat (pullback A B g C a)
           ( transport B C (f a) (g a) (α a)
@@ -379,7 +379,11 @@ The pullback of a family along homotopic maps is equivalent.
 #def is-equiv-pullback-homotopy uses (α)
   : is-equiv
     (pullback A B f C a) (pullback A B g C a) (pullback-homotopy)
-  := ( pullback-homotopy-has-retraction , pullback-homotopy-has-section)
+  := ( has-retraction-pullback-homotopy , has-section-pullback-homotopy)
+
+#def equiv-pullback-homotopy uses (α)
+  : Equiv (pullback A B f C a) (pullback A B g C a)
+  := (pullback-homotopy , is-equiv-pullback-homotopy)
 
 #end is-equiv-pullback-htpy
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -725,7 +725,7 @@ equivalence.
                       ( comp A B C g f) gfisequiv) (g b0))))
               ( rev B (f ((section-is-equiv A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
-            ( ( homotopy-whisker B A A B
+            ( ( whisker-homotopy B A A B
                 ( \ a →
                   ( retraction-is-equiv A C
                     ( comp A B C g f) gfisequiv) (g (f a)))

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -613,66 +613,6 @@ fundamental theorem:
 #end fundamental-thm-id-types
 ```
 
-For all `x` , `y` in `A`, `ap_{e ,x ,y}` is an equivalence.
-
-```rzk
-#def emb-is-equiv
-  (A B : U)
-  (e : A → B)
-  (is-equiv-e : is-equiv A B e)
-  : (Emb A B)
-  :=
-    ( e ,
-      \ x y →
-      ( fund-id-sum-over-codomain-contr-implies-fam-of-eqs
-```
-
-By the fundamental theorem of identity types, it will suffice to show
-contractibility of `Σ_{t : A} e x = e t` for the family of maps `ap_e`, which is
-of type `(t : A) → (x = t) → (e x = e t)`:
-
-```rzk
-        ( A)
-        ( x)
-        ( \ t → (e x = e t))
-        ( \ t → (ap A B x t e))
-        ( ( is-contr-is-equiv-to-contr
-```
-
-Contractibility of `Σ_{t : A} e x = e t` will follow since
-`total (\ t → rev B (e x) = (e t))`, mapping from `Σ_{t : A} e x = e t` to
-`Σ_{t : A} e t = e x` is an equivalence, and
-`Σ_{t : A} e t = e x ~ fib (e , e x)` is contractible since `e` is an
-equivalence.
-
-```rzk
-            ( Σ (y' : A) , (e x = e y')) -- source type
-            ( Σ (y' : A) , (e y' = e x)) -- target type
-            ( ( total-map-family-of-maps A
-                ( \ y' → (e x) = (e y'))
-                ( \ y' → (e y') = (e x))
-                ( \ y' → (rev B (e x) (e y')))) , -- a) total map
-        ( -- b) proof that total map is equivalence
-          ( first
-            ( total-equiv-iff-family-of-equiv A
-              ( \ y' → (e x) = (e y'))
-              ( \ y' → (e y') = (e x))
-              ( \ y' → (rev B (e x) (e y')))))
-          ( \ y' → (is-equiv-rev B (e x) (e y')))))
-        ( -- fiber of e at e(x) is contractible
-          ( is-contr-map-is-equiv A B e is-equiv-e) (e x))))) (y))
-          -- evaluate at y
-```
-
-```rzk
-#def is-emb-is-equiv
-  (A B : U)
-  (e : A → B)
-  (is-equiv-e : is-equiv A B e)
-  : is-emb A B e
-  := (second (emb-is-equiv A B e is-equiv-e))
-```
-
 ## 2-of-3 for equivalences
 
 ```rzk

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -608,7 +608,7 @@ fundamental theorem:
         ( fund-id-fam-of-eqs-implies-sum-over-codomain-contr familyequiv)
         ( \ (x', p') → P x' p'))
       ( p0)
-      (u , p)
+      ( u , p)
 
 #end fundamental-thm-id-types
 ```
@@ -618,42 +618,42 @@ fundamental theorem:
 ```rzk
 -- It might be better to redo this without appealing to results about
 -- embeddings so that this could go earlier.
-#def RightCancel-is-equiv
-  (A B C : U)
-  (f : A → B)
-  (g : B → C)
-  (is-equiv-g : is-equiv B C g)
-  (gfisequiv : is-equiv A C (comp A B C g f))
+#def is-equiv-right-factor
+  ( A B C : U)
+  ( f : A → B)
+  ( g : B → C)
+  ( is-equiv-g : is-equiv B C g)
+  ( is-equiv-gf : is-equiv A C (comp A B C g f))
   : is-equiv A B f
   :=
     ( ( comp B C A
-        (retraction-is-equiv A C (comp A B C g f) gfisequiv) g ,
-        (second (first gfisequiv))) ,
+        (retraction-is-equiv A C (comp A B C g f) is-equiv-gf) g ,
+        (second (first is-equiv-gf))) ,
       ( comp B C A
-        (section-is-equiv A C (comp A B C g f) gfisequiv) g ,
+        (section-is-equiv A C (comp A B C g f) is-equiv-gf) g ,
         \ b →
           inv-ap-is-emb
             B C g
             ( is-emb-is-equiv B C g is-equiv-g)
-            ( f ((section-is-equiv A C (comp A B C g f) gfisequiv) (g b)))
+            ( f ((section-is-equiv A C (comp A B C g f) is-equiv-gf) (g b)))
             b
-            ( (second (second gfisequiv)) (g b))))
+            ( (second (second is-equiv-gf)) (g b))))
 
-#def LeftCancel-is-equiv
-  (A B C : U)
-  (f : A → B)
-  (is-equiv-f : is-equiv A B f)
-  (g : B → C)
-  (gfisequiv : is-equiv A C (comp A B C g f))
+#def is-equiv-left-factor
+  ( A B C : U)
+  ( f : A → B)
+  ( is-equiv-f : is-equiv A B f)
+  ( g : B → C)
+  ( is-equiv-gf : is-equiv A C (comp A B C g f))
   : is-equiv B C g
   :=
     ( ( comp C A B
-          f (retraction-is-equiv A C (comp A B C g f) gfisequiv) ,
+          f (retraction-is-equiv A C (comp A B C g f) is-equiv-gf) ,
         \ b →
           triple-concat B
-            ( f ((retraction-is-equiv A C (comp A B C g f) gfisequiv)
+            ( f ((retraction-is-equiv A C (comp A B C g f) is-equiv-gf)
               (g b)))
-            ( f ((retraction-is-equiv A C (comp A B C g f) gfisequiv)
+            ( f ((retraction-is-equiv A C (comp A B C g f) is-equiv-gf)
               (g (f ((section-is-equiv A B f is-equiv-f) b)))))
             ( f ((section-is-equiv A B f is-equiv-f) b))
             ( b)
@@ -662,22 +662,22 @@ fundamental theorem:
               ( f ((section-is-equiv A B f is-equiv-f) b))
               ( \ b0 →
                 ( f ((retraction-is-equiv A C
-                      ( comp A B C g f) gfisequiv) (g b0))))
+                      ( comp A B C g f) is-equiv-gf) (g b0))))
               ( rev B (f ((section-is-equiv A B f is-equiv-f) b)) b
                 ( (second (second is-equiv-f)) b)))
             ( ( whisker-homotopy B A A B
                 ( \ a →
                   ( retraction-is-equiv A C
-                    ( comp A B C g f) gfisequiv) (g (f a)))
+                    ( comp A B C g f) is-equiv-gf) (g (f a)))
                 ( \ a → a)
-                ( second (first gfisequiv))
+                ( second (first is-equiv-gf))
                 ( section-is-equiv A B f is-equiv-f)
                 f) b)
             ( (second (second is-equiv-f)) b)) ,
       ( comp C A B
         ( f)
-        ( section-is-equiv A C (comp A B C g f) gfisequiv) ,
-        ( second (second gfisequiv))))
+        ( section-is-equiv A C (comp A B C g f) is-equiv-gf) ,
+        ( second (second is-equiv-gf))))
 ```
 
 ## Maps over product types
@@ -700,43 +700,44 @@ types over a product type.
   := \ (a , (b , c)) → (f a , (g b , h a b c))
 
 #def pullback-is-equiv-base-is-equiv-total-is-equiv
-  (totalisequiv : is-equiv
-                    (Σ (a : A) , (Σ (b : B) , C a b))
-                    (Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-                    total-map-fibered-map-over-product)
-  (is-equiv-f : is-equiv A A' f)
+  ( is-equiv-total :
+    is-equiv
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+      ( total-map-fibered-map-over-product))
+  ( is-equiv-f : is-equiv A A' f)
   : is-equiv
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
-    ( \ (a , (b , c)) → (a , (g b , h a b c)))
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
+      ( \ (a , (b , c)) → (a , (g b , h a b c)))
   :=
-    RightCancel-is-equiv
+    is-equiv-right-factor
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
     ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
     ( \ (a , (b , c)) → (a , (g b , h a b c)))
     ( \ (a , (b' , c')) → (f a , (b' , c')))
-    ( second (total-equiv-pullback-is-equiv
-                A
-                A'
-                f
-                is-equiv-f
-                ( \ a' → (Σ (b' : B') , C' a' b'))))
-    ( totalisequiv)
+    ( second
+      ( total-equiv-pullback-is-equiv
+        ( A) (A')
+        ( f) (is-equiv-f)
+        ( \ a' → (Σ (b' : B') , C' a' b'))))
+    ( is-equiv-total)
 
 #def pullback-is-equiv-bases-are-equiv-total-is-equiv
-  (totalisequiv : is-equiv
-                    ( Σ (a : A) , (Σ (b : B) , C a b))
-                    ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-                    total-map-fibered-map-over-product)
-  (is-equiv-f : is-equiv A A' f)
-  (is-equiv-g : is-equiv B B' g)
+  ( is-equiv-total :
+      is-equiv
+        ( Σ (a : A) , (Σ (b : B) , C a b))
+        ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+        ( total-map-fibered-map-over-product))
+  ( is-equiv-f : is-equiv A A' f)
+  ( is-equiv-g : is-equiv B B' g)
   : is-equiv
-    ( Σ (a : A) , (Σ (b : B) , C a b))
-    ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
-    ( \ (a , (b , c)) → (a , (b , h a b c)))
+      ( Σ (a : A) , (Σ (b : B) , C a b))
+      ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
+      ( \ (a , (b , c)) → (a , (b , h a b c)))
   :=
-    RightCancel-is-equiv
+    is-equiv-right-factor
     ( Σ (a : A) , (Σ (b : B) , C a b))
     ( Σ (a : A) , (Σ (b : B) , C' (f a) (g b)))
     ( Σ (a : A) , (Σ (b' : B') , C' (f a) b'))
@@ -749,18 +750,17 @@ types over a product type.
       ( \ a →
         ( second
           ( total-equiv-pullback-is-equiv
-              B
-              B'
-              g
-              is-equiv-g
-              ( \ b' → C' (f a) b')))))
-    ( pullback-is-equiv-base-is-equiv-total-is-equiv totalisequiv is-equiv-f)
+            ( B) (B')
+            ( g) (is-equiv-g)
+            ( \ b' → C' (f a) b')))))
+    ( pullback-is-equiv-base-is-equiv-total-is-equiv is-equiv-total is-equiv-f)
 
 #def fibered-map-is-equiv-bases-are-equiv-total-map-is-equiv
-  (totalisequiv : is-equiv
-                  ( Σ (a : A) , (Σ (b : B) , C a b))
-                  ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
-                  total-map-fibered-map-over-product)
+  ( is-equiv-total :
+      is-equiv
+        ( Σ (a : A) , (Σ (b : B) , C a b))
+        ( Σ (a' : A') , (Σ (b' : B') , C' a' b'))
+        ( total-map-fibered-map-over-product))
   (is-equiv-f : is-equiv A A' f)
   (is-equiv-g : is-equiv B B' g)
   (a0 : A)
@@ -768,18 +768,18 @@ types over a product type.
   : is-equiv (C a0 b0) (C' (f a0) (g b0)) (h a0 b0)
   :=
     total-equiv-family-of-equiv B
-    ( \ b → C a0 b)
-    ( \ b → C' (f a0) (g b))
-    ( \ b c → h a0 b c)
-    ( total-equiv-family-of-equiv
-      A
-      ( \ a → (Σ (b : B) , C a b))
-      ( \ a → (Σ (b : B) , C' (f a) (g b)))
-      ( \ a (b , c) → (b , h a b c))
-      ( pullback-is-equiv-bases-are-equiv-total-is-equiv
-          totalisequiv is-equiv-f is-equiv-g)
-      a0)
-    b0
+      ( \ b → C a0 b)
+      ( \ b → C' (f a0) (g b))
+      ( \ b c → h a0 b c)
+      ( total-equiv-family-of-equiv
+        ( A)
+        ( \ a → (Σ (b : B) , C a b))
+        ( \ a → (Σ (b : B) , C' (f a) (g b)))
+        ( \ a (b , c) → (b , h a b c))
+        ( pullback-is-equiv-bases-are-equiv-total-is-equiv
+            is-equiv-total is-equiv-f is-equiv-g)
+        ( a0))
+      ( b0)
 
 #end fibered-map-over-product
 ```

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -258,6 +258,18 @@ implication could be proven similarly.
       ( is-contr-map-is-equiv
         ( Σ (x : A) , B x) (Σ (x : A) , C x)
         ( total-map-family-of-maps A B C f) totalequiv) a)
+
+#def family-equiv-total-equiv
+  ( A : U)
+  ( B C : A → U)
+  ( f : (a : A) → (B a) → (C a))
+  ( totalequiv : is-equiv
+                ( Σ (x : A) , B x)
+                ( Σ (x : A) , C x)
+                ( total-map-family-of-maps A B C f))
+  ( a : A)
+  : Equiv (B a) (C a)
+  := ( f a , total-equiv-family-of-equiv A B C f totalequiv a)
 ```
 
 In summary, a family of maps is an equivalence iff the map on total spaces is an

--- a/src/hott/08-families-of-maps.rzk.md
+++ b/src/hott/08-families-of-maps.rzk.md
@@ -132,7 +132,7 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
   (f : (a : A) → (B a) → (C a))
   (invfamily : (a : A) → has-inverse (B a) (C a) (f a))
   : (Σ (x : A) , C x) → (Σ (x : A) , B x)
-  := \ (a , c) → (a , (has-inverse-inverse (B a) (C a) (f a) (invfamily a)) c)
+  := \ (a , c) → (a , (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)
 
 #def invertible-family-total-retraction
   (A : U)
@@ -147,7 +147,7 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
     ( invertible-family-total-inverse A B C f invfamily ,
       \ (a , b) →
         (eq-eq-fiber-Σ A B a
-          ( (has-inverse-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
+          ( (map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) (f a b)) b
           ( (first (second (invfamily a))) b)))
 
 #def invertible-family-total-section
@@ -160,7 +160,7 @@ It will be easiest to work with the incoherent notion of two-sided-inverses.
     ( invertible-family-total-inverse A B C f invfamily ,
       \ (a , c) →
         ( eq-eq-fiber-Σ A C a
-          ( f a ((has-inverse-inverse (B a) (C a) (f a) (invfamily a)) c)) c
+          ( f a ((map-inverse-has-inverse (B a) (C a) (f a) (invfamily a)) c)) c
           ( (second (second (invfamily a))) c)))
 
 #def invertible-family-total-invertible

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -235,7 +235,7 @@ Finally, we have:
 ```rzk title="The main theorem"
 #def projection-theorem
   (A : U)
-  (B : (a : A) → U)
+  (B : A → U)
   : iff
     ( is-equiv (Σ (x : A) , B x) A (total-space-projection A B))
     ( contractible-fibers A B)

--- a/src/hott/10-trivial-fibrations.rzk.md
+++ b/src/hott/10-trivial-fibrations.rzk.md
@@ -48,7 +48,7 @@ The following type asserts that the fibers of a type family are contractible.
 
 #def contractible-fibers-section-htpy uses (contractible-fibers-A-B)
   : homotopy A A
-    ( composition A (Σ (x : A) , B x) A
+    ( comp A (Σ (x : A) , B x) A
       ( total-space-projection A B) (contractible-fibers-actual-section))
     ( identity A)
   := \ x → refl

--- a/src/simplicial-hott/04-extension-types.rzk.md
+++ b/src/simplicial-hott/04-extension-types.rzk.md
@@ -10,7 +10,7 @@ This is a literate `rzk` file:
 
 ## Prerequisites
 
-- `hott/4-equivalences.rzk` — contains the definitions of `Eq` and `comp-equiv`
+- `hott/4-equivalences.rzk` — contains the definitions of `Eq` and `equiv-comp`
 - the file `hott/4-equivalences.rzk` relies in turn on the previous files in
   `hott/`
 
@@ -107,7 +107,7 @@ This is a literate `rzk` file:
     ( (s : ζ) → ((t : ψ) → X t s [ ϕ t ↦ f (t , s) ])
         [ χ s ↦ \ t → f (t , s) ])
   :=
-    comp-equiv
+    equiv-comp
       ( (t : ψ) → ((s : ζ) → X t s [ χ s ↦ f (t , s) ])
         [ ϕ t ↦ \ s → f (t , s) ])
       ( ((t , s) : I × J | ψ t ∧ ζ s) → X t s

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -380,7 +380,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
   (fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
   : is-local-horn-inclusion ((x : X) → A x)
   :=
-    triple-compose-is-equiv
+    triple-comp-is-equiv
       ( Δ² → ((x : X) → A x) )
       ( (x : X) → Δ² → A x )
       ( (x : X) → Λ → A x )
@@ -421,7 +421,7 @@ then $(x : X) → A x$ is a Segal type.
   (fiberwise-is-segal-A : (s : ψ) → is-local-horn-inclusion (A s) )
   : is-local-horn-inclusion ((s : ψ) → A s )
   :=
-    triple-compose-is-equiv
+    triple-comp-is-equiv
     ( Δ² → (s : ψ) → A s  )
     ( (s : ψ) → Δ² → A s  )
     ( (s : ψ) → Λ → A s  )

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -265,7 +265,7 @@ witnesses of the equivalence).
   (is-segal-A : is-segal A)
   : Equiv (Δ² → A) (Λ → A)
   :=
-    comp-equiv
+    equiv-comp
       ( Δ² → A)
       ( Σ ( k : Λ → A) ,
           ( Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
@@ -333,7 +333,7 @@ exactly `horn-restriction A`.
             ( \ t → k (1₂ , t))
             ( h)))
       ( second
-        ( comp-equiv
+        ( equiv-comp
           ( Σ ( k : Λ → A ) ,
             Σ ( h : hom A (k (0₂ , 0₂)) (k (1₂ , 1₂))) ,
               ( hom2 A

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -99,7 +99,7 @@ relation. Composition is written in diagrammatic order to match the order of
 arguments in `is-segal`.
 
 ```rzk
-#def Segal-comp
+#def comp-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
@@ -108,13 +108,13 @@ arguments in `is-segal`.
   : hom A x z
   := first (first (is-segal-A x y z f g))
 
-#def Segal-comp-witness
+#def comp-witness-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
-  : hom2 A x y z f g (Segal-comp A is-segal-A x y z f g)
+  : hom2 A x y z f g (comp-Segal A is-segal-A x y z f g)
   := second (first (is-segal-A x y z f g))
 ```
 
@@ -149,7 +149,7 @@ composite equals $h$.
 </svg>
 
 ```rzk
-#def Segal-comp-uniqueness
+#def comp-uniqueness-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
@@ -157,12 +157,12 @@ composite equals $h$.
   (g : hom A y z)
   (h : hom A x z)
   (alpha : hom2 A x y z f g h)
-  : (Segal-comp A is-segal-A x y z f g) = h
+  : (comp-Segal A is-segal-A x y z f g) = h
   := first-path-Σ
       (hom A x z)
       (\ k → hom2 A x y z f g k)
-      (Segal-comp A is-segal-A x y z f g ,
-        Segal-comp-witness A is-segal-A x y z f g)
+      (comp-Segal A is-segal-A x y z f g ,
+        comp-witness-Segal A is-segal-A x y z f g)
       (h , alpha)
       (contracting-htpy
         (Σ (k : hom A x z) , hom2 A x y z f g k)
@@ -260,7 +260,7 @@ witnesses of the equivalence).
 ```
 
 ```rzk title="RS17, Theorem 5.5 (the hard direction)"
-#def Segal-equiv-horn-restriction
+#def equiv-horn-restriction-Segal
   (A : U)
   (is-segal-A : is-segal A)
   : Equiv (Δ² → A) (Λ → A)
@@ -304,7 +304,7 @@ exactly `horn-restriction A`.
 #def test-Segal-equiv-horn-restriction
   ( A : U)
   ( is-segal-A : is-segal A)
-  : (first (Segal-equiv-horn-restriction A is-segal-A)) = (horn-restriction A)
+  : (first (equiv-horn-restriction-Segal A is-segal-A)) = (horn-restriction A)
   := refl
 ```
 
@@ -313,7 +313,7 @@ exactly `horn-restriction A`.
   ( A : U)
   ( is-segal-A : is-segal A)
   : is-local-horn-inclusion A
-  := second (Segal-equiv-horn-restriction A is-segal-A)
+  := second (equiv-horn-restriction-Segal A is-segal-A)
 ```
 
 ```rzk title="Types that are local at the horn inclusion are Segal types"
@@ -374,7 +374,7 @@ instance if $X$ is a type and $A : X → U$ is such that $A x$ is a Segal type f
 all $x$ then $(x : X) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(i)"
-#def Segal-function-types uses (funext)
+#def function-types-Segal uses (funext)
   (X : U)
   (A : (_ : X) → U)
   (fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
@@ -414,7 +414,7 @@ If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $
 then $(x : X) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(ii)"
-#def Segal-extension-types uses (extext)
+#def extension-types-Segal uses (extext)
   (I : CUBE)
   (ψ : (s : I) → TOPE)
   (A : (s : ψ) → U )
@@ -481,7 +481,7 @@ For later use, an equivalent characterization of the arrow type.
   (is-segal-A : is-local-horn-inclusion A)
   : is-local-horn-inclusion (arr A)
   :=
-    Segal-extension-types
+    extension-types-Segal
       ( 2)
       ( Δ¹)
       ( \ t → A)
@@ -489,13 +489,13 @@ For later use, an equivalent characterization of the arrow type.
 ```
 
 ```rzk title="RS17, Corollary 5.6(ii), special case for the Segal condition"
-#def Segal-arrow-types uses (extext)
+#def arrow-types-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   : is-segal (arr A)
   :=
     is-segal-is-local-horn-inclusion (arr A)
-      ( Segal-extension-types
+      ( extension-types-Segal
           ( 2)
           ( Δ¹)
           ( \ t → A)
@@ -576,14 +576,14 @@ an identity arrow recovers the original arrow. Thus, an identity axiom was not
 needed in the definition of Segal types.
 
 ```rzk title="If $A$ is Segal then the right unit law holds"
-#def Segal-comp-id
+#def comp-id-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
-  : (Segal-comp A is-segal-A x y y f (id-arr A y)) = f
+  : (comp-Segal A is-segal-A x y y f (id-arr A y)) = f
   :=
-    Segal-comp-uniqueness
+    comp-uniqueness-Segal
       ( A)
       ( is-segal-A)
       x y y
@@ -594,14 +594,14 @@ needed in the definition of Segal types.
 ```
 
 ```rzk title="If $A$ is Segal then the left unit law holds"
-#def Segal-id-comp
+#def id-comp-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
-  : (Segal-comp A is-segal-A x x y (id-arr A x) f) =_{hom A x y} f
+  : (comp-Segal A is-segal-A x x y (id-arr A x) f) =_{hom A x y} f
   :=
-    Segal-comp-uniqueness
+    comp-uniqueness-Segal
       ( A)
       ( is-segal-A)
       x x y
@@ -663,14 +663,14 @@ For use in the proof of associativity:
 </svg>
 
 ```rzk
-#def Segal-comp-witness-square
+#def comp-witness-square-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
   : Δ¹×Δ¹ → A
-  := unfolding-square A (Segal-comp-witness A is-segal-A x y z f g)
+  := unfolding-square A (comp-witness-Segal A is-segal-A x y z f g)
 ```
 
 The `Segal-comp-witness-square` as an arrow in the arrow type:
@@ -688,14 +688,14 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
 </svg>
 
 ```rzk
-#def Segal-arr-in-arr
+#def arr-in-arr-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
   : hom (arr A) f g
-  := \ t s → (Segal-comp-witness-square A is-segal-A x y z f g) (t , s)
+  := \ t s → (comp-witness-square-Segal A is-segal-A x y z f g) (t , s)
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -724,7 +724,7 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
 </svg>
 
 ```rzk
-#def Segal-associativity-witness uses (extext)
+#def associativity-witness-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -732,19 +732,19 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
   (g : hom A x y)
   (h : hom A y z)
   : hom2 (arr A) f g h
-      (Segal-arr-in-arr A is-segal-A w x y f g)
-      (Segal-arr-in-arr A is-segal-A x y z g h)
-      (Segal-comp (arr A) (Segal-arrow-types A is-segal-A)
+      (arr-in-arr-Segal A is-segal-A w x y f g)
+      (arr-in-arr-Segal A is-segal-A x y z g h)
+      (comp-Segal (arr A) (arrow-types-Segal A is-segal-A)
       f g h
-      (Segal-arr-in-arr A is-segal-A w x y f g)
-      (Segal-arr-in-arr A is-segal-A x y z g h))
+      (arr-in-arr-Segal A is-segal-A w x y f g)
+      (arr-in-arr-Segal A is-segal-A x y z g h))
   :=
-    Segal-comp-witness
+    comp-witness-Segal
       ( arr A)
-      ( Segal-arrow-types A is-segal-A)
+      ( arrow-types-Segal A is-segal-A)
       f g h
-      ( Segal-arr-in-arr A is-segal-A w x y f g)
-      ( Segal-arr-in-arr A is-segal-A x y z g h)
+      ( arr-in-arr-Segal A is-segal-A w x y f g)
+      ( arr-in-arr-Segal A is-segal-A x y z g h)
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -770,7 +770,7 @@ The `Segal-associativity-witness` curries to define a diagram $Δ²×Δ¹ → A$
 $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
 
 ```rzk
-#def Segal-associativity-tetrahedron uses (extext)
+#def associativity-tetrahedron-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -780,7 +780,7 @@ $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
   : Δ³ → A
   :=
     \ ((t , s) , r) →
-    (Segal-associativity-witness A is-segal-A w x y z f g h) (t , r) s
+    (associativity-witness-Segal A is-segal-A w x y z f g h) (t , r) s
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -805,7 +805,7 @@ The diagonal composite of three arrows extracted from the
 `Segal-associativity-tetrahedron`.
 
 ```rzk
-#def Segal-triple-composite uses (extext)
+#def triple-composite-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -815,7 +815,7 @@ The diagonal composite of three arrows extracted from the
   : hom A w z
   :=
     \ t →
-    ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
+    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
       ( (t , t) , t)
 ```
 
@@ -840,7 +840,7 @@ The diagonal composite of three arrows extracted from the
 </svg>
 
 ```rzk
-#def Segal-left-associativity-witness uses (extext)
+#def left-associativity-witness-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -848,12 +848,12 @@ The diagonal composite of three arrows extracted from the
   (g : hom A x y)
   (h : hom A y z)
   : hom2 A w y z
-    (Segal-comp A is-segal-A w x y f g)
+    (comp-Segal A is-segal-A w x y f g)
     h
-    (Segal-triple-composite A is-segal-A w x y z f g h)
+    (triple-composite-Segal A is-segal-A w x y z f g h)
   :=
     \ (t , s) →
-    ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
+    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
       ( (t , t) , s)
 ```
 
@@ -880,7 +880,7 @@ The front face:
 </svg>
 
 ```rzk
-#def Segal-right-associativity-witness uses (extext)
+#def right-associativity-witness-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -889,78 +889,78 @@ The front face:
   (h : hom A y z)
   : hom2 A w x z
     f
-    (Segal-comp A is-segal-A x y z g h)
-    (Segal-triple-composite A is-segal-A w x y z f g h)
+    (comp-Segal A is-segal-A x y z g h)
+    (triple-composite-Segal A is-segal-A w x y z f g h)
   :=
     \ (t , s) →
-    ( Segal-associativity-tetrahedron A is-segal-A w x y z f g h)
+    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
       ((t , s) , s)
 ```
 
 ```rzk
-#def Segal-left-associativity uses (extext)
+#def left-associativity-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
   (f : hom A w x)
   (g : hom A x y)
   (h : hom A y z)
-  : (Segal-comp A is-segal-A w y z (Segal-comp A is-segal-A w x y f g) h) =
-    (Segal-triple-composite A is-segal-A w x y z f g h)
+  : (comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
+    (triple-composite-Segal A is-segal-A w x y z f g h)
   :=
-    Segal-comp-uniqueness
-      A is-segal-A w y z (Segal-comp A is-segal-A w x y f g) h
-      ( Segal-triple-composite A is-segal-A w x y z f g h)
-      ( Segal-left-associativity-witness A is-segal-A w x y z f g h)
+    comp-uniqueness-Segal
+      A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h
+      ( triple-composite-Segal A is-segal-A w x y z f g h)
+      ( left-associativity-witness-Segal A is-segal-A w x y z f g h)
 
-#def Segal-right-associativity uses (extext)
+#def right-associativity-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
   (f : hom A w x)
   (g : hom A x y)
   (h : hom A y z)
-  : (Segal-comp A is-segal-A w x z f (Segal-comp A is-segal-A x y z g h)) =
-      (Segal-triple-composite A is-segal-A w x y z f g h)
-  := Segal-comp-uniqueness
-        A is-segal-A w x z f (Segal-comp A is-segal-A x y z g h)
-      ( Segal-triple-composite A is-segal-A w x y z f g h)
-      ( Segal-right-associativity-witness A is-segal-A w x y z f g h)
+  : (comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)) =
+      (triple-composite-Segal A is-segal-A w x y z f g h)
+  := comp-uniqueness-Segal
+        A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)
+      ( triple-composite-Segal A is-segal-A w x y z f g h)
+      ( right-associativity-witness-Segal A is-segal-A w x y z f g h)
 
-#def Segal-associativity uses (extext)
+#def associativity-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
   (f : hom A w x)
   (g : hom A x y)
   (h : hom A y z)
-  : (Segal-comp A is-segal-A w y z (Segal-comp A is-segal-A w x y f g) h) =
-      (Segal-comp A is-segal-A w x z f (Segal-comp A is-segal-A x y z g h))
+  : (comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
+      (comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h))
   :=
     zig-zag-concat
     ( hom A w z)
-    ( Segal-comp A is-segal-A w y z (Segal-comp A is-segal-A w x y f g) h)
-    ( Segal-triple-composite A is-segal-A w x y z f g h)
-    ( Segal-comp A is-segal-A w x z f (Segal-comp A is-segal-A x y z g h))
-    ( Segal-left-associativity A is-segal-A w x y z f g h)
-    ( Segal-right-associativity A is-segal-A w x y z f g h)
+    ( comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h)
+    ( triple-composite-Segal A is-segal-A w x y z f g h)
+    ( comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h))
+    ( left-associativity-Segal A is-segal-A w x y z f g h)
+    ( right-associativity-Segal A is-segal-A w x y z f g h)
 
 
-#def Segal-postcomp
+#def postcomp-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
   : (z : A) → (hom A z x) → (hom A z y)
-  := \ z → \ g → (Segal-comp A is-segal-A z x y g f)
+  := \ z → \ g → (comp-Segal A is-segal-A z x y g f)
 
-#def Segal-precomp
+#def precomp-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
   : (z : A) → (hom A y z) → (hom A x z)
-  := \ z → \ g → (Segal-comp A is-segal-A x y z f g)
+  := \ z → \ g → (comp-Segal A is-segal-A x y z f g)
 ```
 
 ## Homotopies
@@ -988,7 +988,7 @@ arrow.
       (Σ (g : hom A x y) , (hom2 A x x y (id-arr A x) f g))
   := \ (g , p) → (g , homotopy-to-hom2 A x y f g p)
 
-#def Segal-homotopy-to-hom2-total-map-is-equiv
+#def homotopy-to-hom2-total-map-is-equiv-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
@@ -1020,7 +1020,7 @@ arrow.
         ( \ k → (f = k))
         ( \ k → (hom2 A x x y (id-arr A x) f k))
         ( homotopy-to-hom2 A x y f)
-        ( Segal-homotopy-to-hom2-total-map-is-equiv A is-segal-A x y f)
+        ( homotopy-to-hom2-total-map-is-equiv-Segal A is-segal-A x y f)
         ( h)))
 ```
 
@@ -1045,7 +1045,7 @@ A dual notion of homotopy can be defined similarly.
       (Σ (g : hom A x y) , (hom2 A x y y f (id-arr A y) g))
   := \ (g , p) → (g , homotopy-to-hom2' A x y f g p)
 
-#def Segal-homotopy-to-hom2'-total-map-is-equiv
+#def homotopy-to-hom2'-total-map-is-equiv-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y : A)
@@ -1077,7 +1077,7 @@ A dual notion of homotopy can be defined similarly.
         ( \ k → (f = k))
         ( \ k → (hom2 A x y y f (id-arr A y) k))
         ( homotopy-to-hom2' A x y f)
-        ( Segal-homotopy-to-hom2'-total-map-is-equiv A is-segal-A x y f)
+        ( homotopy-to-hom2'-total-map-is-equiv-Segal A is-segal-A x y f)
         ( h)))
 ```
 
@@ -1085,46 +1085,46 @@ More generally, a homotopy between a composite and another map is equivalent to
 the data provided by a commutative triangle with that boundary.
 
 ```rzk
-#def Segal-eq-to-hom2
+#def eq-to-hom2-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
   (h : hom A x z)
-  (p : (Segal-comp A is-segal-A x y z f g) = h)
+  (p : (comp-Segal A is-segal-A x y z f g) = h)
   : (hom2 A x y z f g h)
-  := idJ (hom A x z , (Segal-comp A is-segal-A x y z f g) ,
+  := idJ (hom A x z , (comp-Segal A is-segal-A x y z f g) ,
           \ h' p' → (hom2 A x y z f g h') ,
-          Segal-comp-witness A is-segal-A x y z f g , h , p)
+          comp-witness-Segal A is-segal-A x y z f g , h , p)
 
-#def Segal-eq-to-hom2-total-map
+#def eq-to-hom2-total-map-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
-  : (Σ (h : hom A x z) , (Segal-comp A is-segal-A x y z f g) = h) →
+  : (Σ (h : hom A x z) , (comp-Segal A is-segal-A x y z f g) = h) →
       (Σ (h : hom A x z) , (hom2 A x y z f g h))
-  := \ (h , p) → (h , Segal-eq-to-hom2 A is-segal-A x y z f g h p)
+  := \ (h , p) → (h , eq-to-hom2-Segal A is-segal-A x y z f g h p)
 
-#def Segal-eq-to-hom2-total-map-is-equiv
+#def eq-to-hom2-total-map-is-equiv-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f : hom A x y)
   (g : hom A y z)
   : is-equiv
-      (Σ (h : hom A x z) , (Segal-comp A is-segal-A x y z f g) = h)
+      (Σ (h : hom A x z) , (comp-Segal A is-segal-A x y z f g) = h)
       (Σ (h : hom A x z) , (hom2 A x y z f g h))
-      (Segal-eq-to-hom2-total-map A is-segal-A x y z f g)
+      (eq-to-hom2-total-map-Segal A is-segal-A x y z f g)
   :=
     is-equiv-are-contr
-    ( Σ (h : hom A x z) , (Segal-comp A is-segal-A x y z f g) = h)
+    ( Σ (h : hom A x z) , (comp-Segal A is-segal-A x y z f g) = h)
     ( Σ (h : hom A x z) , (hom2 A x y z f g h))
-    ( is-contr-based-paths (hom A x z) (Segal-comp A is-segal-A x y z f g) )
+    ( is-contr-based-paths (hom A x z) (comp-Segal A is-segal-A x y z f g) )
     ( is-segal-A x y z f g)
-    ( Segal-eq-to-hom2-total-map A is-segal-A x y z f g)
+    ( eq-to-hom2-total-map-Segal A is-segal-A x y z f g)
 ```
 
 ```rzk title="RS17, Proposition 5.12"
@@ -1135,15 +1135,15 @@ the data provided by a commutative triangle with that boundary.
   (f : hom A x y)
   (g : hom A y z)
   (k : hom A x z)
-  : Equiv ((Segal-comp A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
+  : Equiv ((comp-Segal A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
   :=
-    ( Segal-eq-to-hom2 A is-segal-A x y z f g k ,
+    ( eq-to-hom2-Segal A is-segal-A x y z f g k ,
       total-equiv-family-of-equiv
       ( hom A x z)
-      ( \ m → (Segal-comp A is-segal-A x y z f g) = m)
+      ( \ m → (comp-Segal A is-segal-A x y z f g) = m)
       ( \ m → hom2 A x y z f g m)
-      ( Segal-eq-to-hom2 A is-segal-A x y z f g)
-      ( Segal-eq-to-hom2-total-map-is-equiv A is-segal-A x y z f g)
+      ( eq-to-hom2-Segal A is-segal-A x y z f g)
+      ( eq-to-hom2-total-map-is-equiv-Segal A is-segal-A x y z f g)
       ( k))
 ```
 
@@ -1151,7 +1151,7 @@ Homotopies form a congruence, meaning that homotopies are respected by
 composition:
 
 ```rzk title="RS17, Proposition 5.13"
-#def Segal-homotopy-congruence
+#def homotopy-congruence-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
@@ -1159,20 +1159,20 @@ composition:
   (h k : hom A y z)
   (p : f = g)
   (q : h = k)
-  : (Segal-comp A is-segal-A x y z f h) = (Segal-comp A is-segal-A x y z g k)
+  : (comp-Segal A is-segal-A x y z f h) = (comp-Segal A is-segal-A x y z g k)
   :=
     idJ
       ( ( hom A y z),
         ( h),
         ( \ k' q' →
-          (Segal-comp A is-segal-A x y z f h) =
-          (Segal-comp A is-segal-A x y z g k')),
+          (comp-Segal A is-segal-A x y z f h) =
+          (comp-Segal A is-segal-A x y z g k')),
         ( idJ
           ( ( hom A x y ),
             ( f),
             ( \ g' p' →
-              (Segal-comp A is-segal-A x y z f h) =
-              (Segal-comp A is-segal-A x y z g' h)),
+              (comp-Segal A is-segal-A x y z f h) =
+              (comp-Segal A is-segal-A x y z g' h)),
             ( refl),
             ( g),
             (p))),
@@ -1183,72 +1183,72 @@ composition:
 As a special case of the above:
 
 ```rzk
-#def Segal-homotopy-postwhisker
+#def homotopy-postwhisker-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f g : hom A x y)
   (h : hom A y z)
   (p : f = g)
-  : (Segal-comp A is-segal-A x y z f h) = (Segal-comp A is-segal-A x y z g h)
-  := Segal-homotopy-congruence A is-segal-A x y z f g h h p refl
+  : (comp-Segal A is-segal-A x y z f h) = (comp-Segal A is-segal-A x y z g h)
+  := homotopy-congruence-Segal A is-segal-A x y z f g h h p refl
 ```
 
 As a special case of the above:
 
 ```rzk
-#def Segal-homotopy-prewhisker
+#def homotopy-prewhisker-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (w x y : A)
   (k : hom A w x)
   (f g : hom A x y)
   (p : f = g)
-  : (Segal-comp A is-segal-A w x y k f) = (Segal-comp A is-segal-A w x y k g)
-  := Segal-homotopy-congruence A is-segal-A w x y k k f g refl p
+  : (comp-Segal A is-segal-A w x y k f) = (comp-Segal A is-segal-A w x y k g)
+  := homotopy-congruence-Segal A is-segal-A w x y k k f g refl p
 ```
 
 ```rzk title="RS17, Proposition 5.14(a)"
-#def Segal-homotopy-postwhisker-is-ap
+#def homotopy-postwhisker-is-ap-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f g : hom A x y)
   (h : hom A y z)
   (p : f = g)
-  : (Segal-homotopy-postwhisker A is-segal-A x y z f g h p) =
-    ap (hom A x y) (hom A x z) f g (\ k → Segal-comp A is-segal-A x y z k h) p
+  : (homotopy-postwhisker-Segal A is-segal-A x y z f g h p) =
+    ap (hom A x y) (hom A x z) f g (\ k → comp-Segal A is-segal-A x y z k h) p
   :=
     idJ
     ( hom A x y,
       f,
       \ g' p' →
-      (Segal-homotopy-postwhisker A is-segal-A x y z f g' h p') =
+      (homotopy-postwhisker-Segal A is-segal-A x y z f g' h p') =
       ap
         (hom A x y) (hom A x z)
-        f g' (\ k → Segal-comp A is-segal-A x y z k h) p' ,
+        f g' (\ k → comp-Segal A is-segal-A x y z k h) p' ,
       refl ,
       g ,
       p)
 ```
 
 ```rzk title="RS17, Proposition 5.14(b)"
-#def Segal-homotopy-prewhisker-is-ap
+#def homotopy-prewhisker-is-ap-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (w x y : A)
   (k : hom A w x)
   (f g : hom A x y)
   (p : f = g)
-  : (Segal-homotopy-prewhisker A is-segal-A w x y k f g p) =
-    ap (hom A x y) (hom A w y) f g (Segal-comp A is-segal-A w x y k) p
+  : (homotopy-prewhisker-Segal A is-segal-A w x y k f g p) =
+    ap (hom A x y) (hom A w y) f g (comp-Segal A is-segal-A w x y k) p
   :=
     idJ
     ( hom A x y ,
       f ,
       \ g' p' →
-      (Segal-homotopy-prewhisker A is-segal-A w x y k f g' p') =
-      ap (hom A x y) (hom A w y) f g' (Segal-comp A is-segal-A w x y k) p' ,
+      (homotopy-prewhisker-Segal A is-segal-A w x y k f g' p') =
+      ap (hom A x y) (hom A w y) f g' (comp-Segal A is-segal-A w x y k) p' ,
       refl ,
       g ,
       p)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -423,37 +423,37 @@ then $(x : X) → A x$ is a Segal type.
   : is-local-horn-inclusion ((s : ψ) → A s)
   :=
     is-equiv-triple-comp
-    ( Δ² → (s : ψ) → A s)
-    ( (s : ψ) → Δ² → A s)
-    ( (s : ψ) → Λ → A s)
-    ( Λ → (s : ψ) → A s)
-    ( \ g s t → g t s)  -- first equivalence
-    ( second
-      ( fubini
-        ( 2 × 2)
-        ( I)
-        ( Δ²)
-        ( \ t → BOT)
-        ( ψ)
-        ( \ s → BOT)
-        ( \ t s → A s)
-        ( \ u → recBOT)))
-    ( \ h s t → h s t) -- second equivalence
-    ( second (equiv-extension-equiv-fibered extext I ψ
-      ( \ s → Δ² → A s)
-      ( \ s → Λ → A s)
-      ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s))))
-    ( \ h t s → (h s) t) -- third equivalence
-    ( second
-      ( fubini
-        ( I)
-        ( 2 × 2)
-        ( ψ)
-        ( \ s → BOT)
-        ( Λ)
-        ( \ t → BOT)
-        ( \ s t → A s)
-        ( \ u → recBOT)))
+      ( Δ² → (s : ψ) → A s)
+      ( (s : ψ) → Δ² → A s)
+      ( (s : ψ) → Λ → A s)
+      ( Λ → (s : ψ) → A s)
+      ( \ g s t → g t s)  -- first equivalence
+      ( second
+        ( fubini
+          ( 2 × 2)
+          ( I)
+          ( Δ²)
+          ( \ t → BOT)
+          ( ψ)
+          ( \ s → BOT)
+          ( \ t s → A s)
+          ( \ u → recBOT)))
+      ( \ h s t → h s t) -- second equivalence
+      ( second (equiv-extension-equiv-fibered extext I ψ
+        ( \ s → Δ² → A s)
+        ( \ s → Λ → A s)
+        ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s))))
+      ( \ h t s → (h s) t) -- third equivalence
+      ( second
+        ( fubini
+          ( I)
+          ( 2 × 2)
+          ( ψ)
+          ( \ s → BOT)
+          ( Λ)
+          ( \ t → BOT)
+          ( \ s t → A s)
+          ( \ u → recBOT)))
 ```
 
 In particular, the arrow type of a Segal type is Segal. First, we define the
@@ -489,8 +489,8 @@ For later use, an equivalent characterization of the arrow type.
 
 ```rzk title="RS17, Corollary 5.6(ii), special case for locality at the horn inclusion"
 #def Segal'-arrow-types uses (extext)
-  (A : U)
-  (is-segal-A : is-local-horn-inclusion A)
+  ( A : U)
+  ( is-segal-A : is-local-horn-inclusion A)
   : is-local-horn-inclusion (arr A)
   :=
     extension-types-Segal
@@ -644,14 +644,14 @@ that the type of arrows in a Segal type is itself a Segal type.
 
 ```rzk
 #def unfolding-square
-  (A : U)
-  (triangle : Δ² → A)
+  ( A : U)
+  ( triangle : Δ² → A)
   : Δ¹×Δ¹ → A
   :=
     \ (t , s) →
     recOR
-      ( ( t ≤ s ↦ triangle (s , t)) ,
-        ( s ≤ t ↦ triangle (t , s)))
+      ( t ≤ s ↦ triangle (s , t) ,
+        s ≤ t ↦ triangle (t , s))
 ```
 
 For use in the proof of associativity:

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -100,20 +100,20 @@ arguments in `is-segal`.
 
 ```rzk
 #def comp-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : hom A x z
   := first (first (is-segal-A x y z f g))
 
-#def comp-witness-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+#def witness-comp-Segal
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : hom2 A x y z f g (comp-Segal A is-segal-A x y z f g)
   := second (first (is-segal-A x y z f g))
 ```
@@ -149,20 +149,20 @@ composite equals $h$.
 </svg>
 
 ```rzk
-#def comp-uniqueness-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
-  (h : hom A x z)
-  (alpha : hom2 A x y z f g h)
-  : (comp-Segal A is-segal-A x y z f g) = h
+#def uniqueness-comp-Segal
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
+  ( h : hom A x z)
+  ( alpha : hom2 A x y z f g h)
+  : ( comp-Segal A is-segal-A x y z f g) = h
   := first-path-Σ
       (hom A x z)
       (\ k → hom2 A x y z f g k)
       (comp-Segal A is-segal-A x y z f g ,
-        comp-witness-Segal A is-segal-A x y z f g)
+        witness-comp-Segal A is-segal-A x y z f g)
       (h , alpha)
       (contracting-htpy
         (Σ (k : hom A x z) , hom2 A x y z f g k)
@@ -189,10 +189,10 @@ A pair of composable arrows form a horn.
 
 ```rzk
 #def horn
-  (A : U)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : Λ → A
   :=
     \ (t , s) →
@@ -224,12 +224,12 @@ witnesses of the equivalence).
 
 ```rzk
 #def compositions-are-horn-fillings
-  (A : U)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : Equiv
-    ( Σ (h : hom A x z) , hom2 A x y z f g h)
+    ( Σ (h : hom A x z) , (hom2 A x y z f g h))
     ( (t : Δ²) → A [ Λ t ↦ horn A x y z f g t ])
   :=
     ( \ hh t → (second hh) t ,
@@ -239,7 +239,7 @@ witnesses of the equivalence).
           \ hh → refl)))
 
 #def equiv-horn-restriction
-  (A : U)
+  ( A : U)
   : Equiv
     ( Δ² → A)
     ( Σ ( k : Λ → A) ,
@@ -261,8 +261,8 @@ witnesses of the equivalence).
 
 ```rzk title="RS17, Theorem 5.5 (the hard direction)"
 #def equiv-horn-restriction-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
+  ( A : U)
+  ( is-segal-A : is-segal A)
   : Equiv (Δ² → A) (Λ → A)
   :=
     equiv-comp
@@ -301,7 +301,7 @@ We verify that the mapping in `Segal-equiv-horn-restriction A is-segal-A` is
 exactly `horn-restriction A`.
 
 ```rzk
-#def test-Segal-equiv-horn-restriction
+#def test-equiv-horn-restriction-Segal
   ( A : U)
   ( is-segal-A : is-segal A)
   : (first (equiv-horn-restriction-Segal A is-segal-A)) = (horn-restriction A)
@@ -376,7 +376,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
 ```rzk title="RS17, Corollary 5.6(i)"
 #def function-types-Segal uses (funext)
   (X : U)
-  (A : (_ : X) → U)
+  (A : X → U)
   (fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
   : is-local-horn-inclusion ((x : X) → A x)
   :=
@@ -416,41 +416,43 @@ then $(x : X) → A x$ is a Segal type.
 ```rzk title="RS17, Corollary 5.6(ii)"
 #def extension-types-Segal uses (extext)
   (I : CUBE)
-  (ψ : (s : I) → TOPE)
-  (A : (s : ψ) → U )
-  (fiberwise-is-segal-A : (s : ψ) → is-local-horn-inclusion (A s) )
-  : is-local-horn-inclusion ((s : ψ) → A s )
+  (ψ : I → TOPE)
+  (A : ψ → U)
+  (fiberwise-is-segal-A : (s : ψ) → is-local-horn-inclusion (A s))
+  : is-local-horn-inclusion ((s : ψ) → A s)
   :=
     triple-comp-is-equiv
-    ( Δ² → (s : ψ) → A s  )
-    ( (s : ψ) → Δ² → A s  )
-    ( (s : ψ) → Λ → A s  )
-    ( Λ → (s : ψ) → A s  )
+    ( Δ² → (s : ψ) → A s)
+    ( (s : ψ) → Δ² → A s)
+    ( (s : ψ) → Λ → A s)
+    ( Λ → (s : ψ) → A s)
     ( \ g s t → g t s)  -- first equivalence
-    ( second (fubini
-      ( 2 × 2)
-      ( I)
-      ( Δ²)
-      ( \ t → BOT)
-      ( ψ)
-      ( \ s → BOT)
-      ( \ t s → A s)
-      ( \ u → recBOT)))
+    ( second
+      ( fubini
+        ( 2 × 2)
+        ( I)
+        ( Δ²)
+        ( \ t → BOT)
+        ( ψ)
+        ( \ s → BOT)
+        ( \ t s → A s)
+        ( \ u → recBOT)))
     ( \ h s t → h s t) -- second equivalence
     ( second (equiv-extension-equiv-fibered extext I ψ
-      ( \ s → Δ² → A s )
-      ( \ s → Λ → A s )
-      ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s)) ))
+      ( \ s → Δ² → A s)
+      ( \ s → Λ → A s)
+      ( \ s → (horn-restriction (A s) , fiberwise-is-segal-A s))))
     ( \ h t s → (h s) t) -- third equivalence
-    ( second (fubini
-      ( I)
-      ( 2 × 2)
-      ( ψ)
-      ( \ s → BOT)
-      ( Λ)
-      ( \ t → BOT)
-      ( \ s t → A s)
-      ( \ u → recBOT)))
+    ( second
+      ( fubini
+        ( I)
+        ( 2 × 2)
+        ( ψ)
+        ( \ s → BOT)
+        ( Λ)
+        ( \ t → BOT)
+        ( \ s t → A s)
+        ( \ u → recBOT)))
 ```
 
 In particular, the arrow type of a Segal type is Segal. First, we define the
@@ -460,19 +462,28 @@ arrow type:
 #def arr
   (A : U)
   : U
-  := (t : Δ¹) → A
+  := Δ¹ → A
 ```
 
 For later use, an equivalent characterization of the arrow type.
 
 ```rzk
-#def Eq-arr
+#def arr-Σ-hom
+  (A : U)
+  : (arr A) → (Σ (x : A) , (Σ (y : A) , hom A x y))
+  := \ f → (f 0₂ , (f 1₂ , f))
+
+#def is-equiv-arr-Σ-hom
+  (A : U)
+  : is-equiv (arr A) (Σ (x : A) , (Σ (y : A) , hom A x y)) (arr-Σ-hom A)
+  :=
+    ( ( \ (x , (y , f)) → f , \ f → refl) ,
+      ( \ (x , (y , f)) → f , \ xyf → refl))
+
+#def equiv-arr-Σ-hom
   (A : U)
   : Equiv (arr A) (Σ (x : A) , (Σ (y : A) , hom A x y))
-  :=
-    ( \ f → (f 0₂ , (f 1₂ , f)) ,
-      ( ( \ (x , (y , f)) → f , \ f → refl) ,
-        ( \ (x , (y , f)) → f , \ xyf → refl)))
+  := (arr-Σ-hom A , is-equiv-arr-Σ-hom A)
 ```
 
 ```rzk title="RS17, Corollary 5.6(ii), special case for locality at the horn inclusion"
@@ -583,7 +594,7 @@ needed in the definition of Segal types.
   (f : hom A x y)
   : (comp-Segal A is-segal-A x y y f (id-arr A y)) = f
   :=
-    comp-uniqueness-Segal
+    uniqueness-comp-Segal
       ( A)
       ( is-segal-A)
       x y y
@@ -601,7 +612,7 @@ needed in the definition of Segal types.
   (f : hom A x y)
   : (comp-Segal A is-segal-A x x y (id-arr A x) f) =_{hom A x y} f
   :=
-    comp-uniqueness-Segal
+    uniqueness-comp-Segal
       ( A)
       ( is-segal-A)
       x x y
@@ -670,7 +681,7 @@ For use in the proof of associativity:
   (f : hom A x y)
   (g : hom A y z)
   : Δ¹×Δ¹ → A
-  := unfolding-square A (comp-witness-Segal A is-segal-A x y z f g)
+  := unfolding-square A (witness-comp-Segal A is-segal-A x y z f g)
 ```
 
 The `Segal-comp-witness-square` as an arrow in the arrow type:
@@ -739,7 +750,7 @@ The `Segal-comp-witness-square` as an arrow in the arrow type:
       (arr-in-arr-Segal A is-segal-A w x y f g)
       (arr-in-arr-Segal A is-segal-A x y z g h))
   :=
-    comp-witness-Segal
+    witness-comp-Segal
       ( arr A)
       ( arrow-types-Segal A is-segal-A)
       f g h
@@ -908,7 +919,7 @@ The front face:
   : (comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
     (triple-composite-Segal A is-segal-A w x y z f g h)
   :=
-    comp-uniqueness-Segal
+    uniqueness-comp-Segal
       A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h
       ( triple-composite-Segal A is-segal-A w x y z f g h)
       ( left-associativity-witness-Segal A is-segal-A w x y z f g h)
@@ -922,7 +933,7 @@ The front face:
   (h : hom A y z)
   : (comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)) =
       (triple-composite-Segal A is-segal-A w x y z f g h)
-  := comp-uniqueness-Segal
+  := uniqueness-comp-Segal
         A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)
       ( triple-composite-Segal A is-segal-A w x y z f g h)
       ( right-associativity-witness-Segal A is-segal-A w x y z f g h)
@@ -1096,7 +1107,7 @@ the data provided by a commutative triangle with that boundary.
   : (hom2 A x y z f g h)
   := idJ (hom A x z , (comp-Segal A is-segal-A x y z f g) ,
           \ h' p' → (hom2 A x y z f g h') ,
-          comp-witness-Segal A is-segal-A x y z f g , h , p)
+          witness-comp-Segal A is-segal-A x y z f g , h , p)
 
 #def eq-to-hom2-total-map-Segal
   (A : U)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -415,7 +415,7 @@ If $X$ is a shape and $A : X → U$ is such that $A x$ is a Segal type for all $
 then $(x : X) → A x$ is a Segal type.
 
 ```rzk title="RS17, Corollary 5.6(ii)"
-#def extension-types-Segal uses (extext)
+#def extension-types-Segal' uses (extext)
   (I : CUBE)
   (ψ : I → TOPE)
   (A : ψ → U)
@@ -454,6 +454,19 @@ then $(x : X) → A x$ is a Segal type.
           ( \ t → BOT)
           ( \ s t → A s)
           ( \ u → recBOT)))
+
+#def extension-types-Segal uses (extext)
+  ( I : CUBE)
+  ( ψ : I → TOPE)
+  ( A : ψ → U)
+  ( fiberwise-is-segal-A : (s : ψ) → is-segal (A s))
+  : is-segal((s : ψ) → A s)
+  :=
+    is-segal-is-local-horn-inclusion
+      ( (s : ψ) → A s)
+      ( extension-types-Segal'
+        ( I) (ψ) (A)
+        ( \s → is-local-horn-inclusion-is-segal (A s) (fiberwise-is-segal-A s)))
 ```
 
 In particular, the arrow type of a Segal type is Segal. First, we define the
@@ -488,16 +501,16 @@ For later use, an equivalent characterization of the arrow type.
 ```
 
 ```rzk title="RS17, Corollary 5.6(ii), special case for locality at the horn inclusion"
-#def Segal'-arrow-types uses (extext)
+#def arrow-types-Segal' uses (extext)
   ( A : U)
   ( is-segal-A : is-local-horn-inclusion A)
   : is-local-horn-inclusion (arr A)
   :=
-    extension-types-Segal
+    extension-types-Segal'
       ( 2)
       ( Δ¹)
-      ( \ t → A)
-      ( \ t → is-segal-A)
+      ( \ _ → A)
+      ( \ _ → is-segal-A)
 ```
 
 ```rzk title="RS17, Corollary 5.6(ii), special case for the Segal condition"
@@ -506,12 +519,11 @@ For later use, an equivalent characterization of the arrow type.
   (is-segal-A : is-segal A)
   : is-segal (arr A)
   :=
-    is-segal-is-local-horn-inclusion (arr A)
-      ( extension-types-Segal
-          ( 2)
-          ( Δ¹)
-          ( \ t → A)
-          ( \ t → (is-local-horn-inclusion-is-segal A is-segal-A)))
+    extension-types-Segal
+      ( 2)
+      ( Δ¹)
+      ( \ _ → A)
+      ( \ _ → is-segal-A)
 ```
 
 ## Identity

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -526,9 +526,9 @@ All types have identity arrows and witnesses to the identity composition law.
 </svg>
 
 ```rzk title="RS17, Definition 5.7"
-#def id-arr
-  (A : U)
-  (x : A)
+#def id-hom
+  ( A : U)
+  ( x : A)
   : hom A x x
   := \ t → x
 ```
@@ -551,10 +551,10 @@ Witness for the right identity law:
 
 ```rzk title="RS17, Proposition 5.8a"
 #def comp-id-witness
-  (A : U)
-  (x y : A)
-  (f : hom A x y)
-  : hom2 A x y y f (id-arr A y) f
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
+  : hom2 A x y y f (id-hom A y) f
   := \ (t, s) → f t
 ```
 
@@ -576,10 +576,10 @@ Witness for the left identity law:
 
 ```rzk title="RS17, Proposition 5.8b"
 #def id-comp-witness
-  (A : U)
-  (x y : A)
-  (f : hom A x y)
-  : hom2 A x x y (id-arr A x) f f
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
+  : hom2 A x x y (id-hom A x) f f
   := \ (t, s) → f s
 ```
 
@@ -593,31 +593,31 @@ needed in the definition of Segal types.
   (is-segal-A : is-segal A)
   (x y : A)
   (f : hom A x y)
-  : (comp-Segal A is-segal-A x y y f (id-arr A y)) = f
+  : (comp-Segal A is-segal-A x y y f (id-hom A y)) = f
   :=
     uniqueness-comp-Segal
       ( A)
       ( is-segal-A)
-      x y y
+      ( x) (y) (y)
       ( f)
-      ( id-arr A y)
+      ( id-hom A y)
       ( f)
       ( comp-id-witness A x y f)
 ```
 
 ```rzk title="If A is Segal then the left unit law holds"
 #def id-comp-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  : (comp-Segal A is-segal-A x x y (id-arr A x) f) =_{hom A x y} f
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : (comp-Segal A is-segal-A x x y (id-hom A x) f) =_{hom A x y} f
   :=
     uniqueness-comp-Segal
       ( A)
       ( is-segal-A)
-      x x y
-      ( id-arr A x)
+      ( x) (x) (y)
+      ( id-hom A x)
       ( f)
       ( f)
       ( id-comp-witness A x y f)
@@ -649,8 +649,9 @@ that the type of arrows in a Segal type is itself a Segal type.
   : Δ¹×Δ¹ → A
   :=
     \ (t , s) →
-    recOR ( t ≤ s ↦ triangle (s , t) ,
-            s ≤ t ↦ triangle (t , s))
+    recOR
+      ( ( t ≤ s ↦ triangle (s , t)) ,
+        ( s ≤ t ↦ triangle (t , s)))
 ```
 
 For use in the proof of associativity:
@@ -701,13 +702,13 @@ The `#!rzk witness-square-comp-Segal` as an arrow in the arrow type:
 
 ```rzk
 #def arr-in-arr-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : hom (arr A) f g
-  := \ t s → (witness-square-comp-Segal A is-segal-A x y z f g) (t , s)
+  := \ t s → witness-square-comp-Segal A is-segal-A x y z f g (t , s)
 ```
 
 <svg style="float: right" viewBox="0 0 200 250" width="150" height="200">
@@ -778,7 +779,7 @@ The `#!rzk witness-square-comp-Segal` as an arrow in the arrow type:
 </svg>
 
 The `#!rzk Segal-associativity-witness` curries to define a diagram $Δ²×Δ¹ → A$.
-The `#!rzk Segal-associativity-tetrahedron` is extracted via the middle-simplex
+The `#!rzk associativity-tetrahedron-Segal` is extracted via the middle-simplex
 map $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
 
 ```rzk
@@ -814,10 +815,10 @@ map $((t , s) , r) ↦ ((t , r) , s)$ from $Δ³$ to $Δ²×Δ¹$.
 </svg>
 
 The diagonal composite of three arrows extracted from the
-`#!rzk Segal-associativity-tetrahedron`.
+`#!rzk associativity-tetrahedron-Segal`.
 
 ```rzk
-#def triple-composite-Segal uses (extext)
+#def triple-comp-Segal uses (extext)
   (A : U)
   (is-segal-A : is-segal A)
   (w x y z : A)
@@ -827,7 +828,7 @@ The diagonal composite of three arrows extracted from the
   : hom A w z
   :=
     \ t →
-    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
+    associativity-tetrahedron-Segal A is-segal-A w x y z f g h
       ( (t , t) , t)
 ```
 
@@ -862,10 +863,10 @@ The diagonal composite of three arrows extracted from the
   : hom2 A w y z
     (comp-Segal A is-segal-A w x y f g)
     h
-    (triple-composite-Segal A is-segal-A w x y z f g h)
+    (triple-comp-Segal A is-segal-A w x y z f g h)
   :=
     \ (t , s) →
-    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
+    associativity-tetrahedron-Segal A is-segal-A w x y z f g h
       ( (t , t) , s)
 ```
 
@@ -893,20 +894,20 @@ The front face:
 
 ```rzk
 #def right-associativity-witness-Segal uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (w x y z : A)
-  (f : hom A w x)
-  (g : hom A x y)
-  (h : hom A y z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( w x y z : A)
+  ( f : hom A w x)
+  ( g : hom A x y)
+  ( h : hom A y z)
   : hom2 A w x z
-    f
-    (comp-Segal A is-segal-A x y z g h)
-    (triple-composite-Segal A is-segal-A w x y z f g h)
+    ( f)
+    ( comp-Segal A is-segal-A x y z g h)
+    ( triple-comp-Segal A is-segal-A w x y z f g h)
   :=
     \ (t , s) →
-    ( associativity-tetrahedron-Segal A is-segal-A w x y z f g h)
-      ((t , s) , s)
+    associativity-tetrahedron-Segal A is-segal-A w x y z f g h
+      ( (t , s) , s)
 ```
 
 ```rzk
@@ -918,59 +919,59 @@ The front face:
   (g : hom A x y)
   (h : hom A y z)
   : (comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
-    (triple-composite-Segal A is-segal-A w x y z f g h)
+    (triple-comp-Segal A is-segal-A w x y z f g h)
   :=
     uniqueness-comp-Segal
       A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h
-      ( triple-composite-Segal A is-segal-A w x y z f g h)
+      ( triple-comp-Segal A is-segal-A w x y z f g h)
       ( left-associativity-witness-Segal A is-segal-A w x y z f g h)
 
 #def right-associativity-Segal uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (w x y z : A)
-  (f : hom A w x)
-  (g : hom A x y)
-  (h : hom A y z)
-  : (comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)) =
-      (triple-composite-Segal A is-segal-A w x y z f g h)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( w x y z : A)
+  ( f : hom A w x)
+  ( g : hom A x y)
+  ( h : hom A y z)
+  : ( comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)) =
+    ( triple-comp-Segal A is-segal-A w x y z f g h)
   := uniqueness-comp-Segal
-        A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h)
-      ( triple-composite-Segal A is-segal-A w x y z f g h)
+      ( A) (is-segal-A) (w) (x) (z) (f) (comp-Segal A is-segal-A x y z g h)
+      ( triple-comp-Segal A is-segal-A w x y z f g h)
       ( right-associativity-witness-Segal A is-segal-A w x y z f g h)
 
 #def associativity-Segal uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (w x y z : A)
-  (f : hom A w x)
-  (g : hom A x y)
-  (h : hom A y z)
-  : (comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
-      (comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h))
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( w x y z : A)
+  ( f : hom A w x)
+  ( g : hom A x y)
+  ( h : hom A y z)
+  : ( comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h) =
+    ( comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h))
   :=
     zig-zag-concat
     ( hom A w z)
     ( comp-Segal A is-segal-A w y z (comp-Segal A is-segal-A w x y f g) h)
-    ( triple-composite-Segal A is-segal-A w x y z f g h)
+    ( triple-comp-Segal A is-segal-A w x y z f g h)
     ( comp-Segal A is-segal-A w x z f (comp-Segal A is-segal-A x y z g h))
     ( left-associativity-Segal A is-segal-A w x y z f g h)
     ( right-associativity-Segal A is-segal-A w x y z f g h)
 
 
 #def postcomp-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
   : (z : A) → (hom A z x) → (hom A z y)
   := \ z → \ g → (comp-Segal A is-segal-A z x y g f)
 
 #def precomp-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
   : (z : A) → (hom A y z) → (hom A x z)
   := \ z → \ g → (comp-Segal A is-segal-A x y z f g)
 ```
@@ -983,59 +984,59 @@ arrow.
 
 ```rzk
 #def homotopy-to-hom2
-  (A : U)
-  (x y : A)
-  (f g : hom A x y)
-  (p : f = g)
-  : (hom2 A x x y (id-arr A x) f g)
+  ( A : U)
+  ( x y : A)
+  ( f g : hom A x y)
+  ( p : f = g)
+  : (hom2 A x x y (id-hom A x) f g)
   :=
     ind-path
       ( hom A x y)
       ( f)
-      ( \ g' p' → (hom2 A x x y (id-arr A x) f g'))
+      ( \ g' p' → (hom2 A x x y (id-hom A x) f g'))
       ( id-comp-witness A x y f)
       ( g)
       ( p)
 
 #def homotopy-to-hom2-total-map
-  (A : U)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
   : (Σ (g : hom A x y) , f = g) →
-      (Σ (g : hom A x y) , (hom2 A x x y (id-arr A x) f g))
+      (Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
   := \ (g , p) → (g , homotopy-to-hom2 A x y f g p)
 
 #def homotopy-to-hom2-total-map-is-equiv-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
   : is-equiv
       (Σ (g : hom A x y) , f = g)
-      (Σ (g : hom A x y) , (hom2 A x x y (id-arr A x) f g))
+      (Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
       (homotopy-to-hom2-total-map A x y f)
   :=
     is-equiv-are-contr
     ( Σ (g : hom A x y) , f = g)
-    ( Σ (g : hom A x y) , (hom2 A x x y (id-arr A x) f g))
+    ( Σ (g : hom A x y) , (hom2 A x x y (id-hom A x) f g))
     ( is-contr-based-paths (hom A x y) f)
-    ( is-segal-A x x y (id-arr A x) f)
+    ( is-segal-A x x y (id-hom A x) f)
     ( homotopy-to-hom2-total-map A x y f)
 ```
 
 ```rzk title="RS17, Proposition 5.10"
 #def Eq-Segal-homotopy-hom2
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f h : hom A x y)
-  : Equiv (f = h) (hom2 A x x y (id-arr A x) f h)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f h : hom A x y)
+  : Equiv (f = h) (hom2 A x x y (id-hom A x) f h)
   :=
     ( ( homotopy-to-hom2 A x y f h) ,
       ( total-equiv-family-of-equiv
         ( hom A x y)
         ( \ k → (f = k))
-        ( \ k → (hom2 A x x y (id-arr A x) f k))
+        ( \ k → (hom2 A x x y (id-hom A x) f k))
         ( homotopy-to-hom2 A x y f)
         ( homotopy-to-hom2-total-map-is-equiv-Segal A is-segal-A x y f)
         ( h)))
@@ -1045,59 +1046,59 @@ A dual notion of homotopy can be defined similarly.
 
 ```rzk
 #def homotopy-to-hom2'
-  (A : U)
-  (x y : A)
-  (f g : hom A x y)
-  (p : f = g)
-  : (hom2 A x y y f (id-arr A y) g)
+  ( A : U)
+  ( x y : A)
+  ( f g : hom A x y)
+  ( p : f = g)
+  : (hom2 A x y y f (id-hom A y) g)
   :=
     ind-path
       ( hom A x y)
       ( f)
-      ( \ g' p' → (hom2 A x y y f (id-arr A y) g'))
+      ( \ g' p' → (hom2 A x y y f (id-hom A y) g'))
       ( comp-id-witness A x y f)
       ( g)
       ( p)
 
 #def homotopy-to-hom2'-total-map
-  (A : U)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( x y : A)
+  ( f : hom A x y)
   : (Σ (g : hom A x y) , f = g) →
-      (Σ (g : hom A x y) , (hom2 A x y y f (id-arr A y) g))
+      (Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
   := \ (g , p) → (g , homotopy-to-hom2' A x y f g p)
 
 #def homotopy-to-hom2'-total-map-is-equiv-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
   : is-equiv
       (Σ (g : hom A x y) , f = g)
-      (Σ (g : hom A x y) , (hom2 A x y y f (id-arr A y) g))
+      (Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
       (homotopy-to-hom2'-total-map A x y f)
   :=
     is-equiv-are-contr
     ( Σ (g : hom A x y) , f = g)
-    ( Σ (g : hom A x y) , (hom2 A x y y f (id-arr A y) g))
+    ( Σ (g : hom A x y) , (hom2 A x y y f (id-hom A y) g))
     ( is-contr-based-paths (hom A x y) f)
-    ( is-segal-A x y y f (id-arr A y))
+    ( is-segal-A x y y f (id-hom A y))
     ( homotopy-to-hom2'-total-map A x y f)
 ```
 
 ```rzk title="RS17, Proposition 5.10"
 #def Eq-Segal-homotopy-hom2'
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f h : hom A x y)
-  : Equiv (f = h) (hom2 A x y y f (id-arr A y) h)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f h : hom A x y)
+  : Equiv (f = h) (hom2 A x y y f (id-hom A y) h)
   :=
     ( ( homotopy-to-hom2' A x y f h) ,
       ( total-equiv-family-of-equiv
         ( hom A x y)
         ( \ k → (f = k))
-        ( \ k → (hom2 A x y y f (id-arr A y) k))
+        ( \ k → (hom2 A x y y f (id-hom A y) k))
         ( homotopy-to-hom2' A x y f)
         ( homotopy-to-hom2'-total-map-is-equiv-Segal A is-segal-A x y f)
         ( h)))
@@ -1108,13 +1109,13 @@ the data provided by a commutative triangle with that boundary.
 
 ```rzk
 #def eq-to-hom2-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
-  (h : hom A x z)
-  (p : (comp-Segal A is-segal-A x y z f g) = h)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
+  ( h : hom A x z)
+  ( p : (comp-Segal A is-segal-A x y z f g) = h)
   : (hom2 A x y z f g h)
   :=
     ind-path
@@ -1126,21 +1127,21 @@ the data provided by a commutative triangle with that boundary.
       ( p)
 
 #def eq-to-hom2-total-map-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : (Σ (h : hom A x z) , (comp-Segal A is-segal-A x y z f g) = h) →
       (Σ (h : hom A x z) , (hom2 A x y z f g h))
   := \ (h , p) → (h , eq-to-hom2-Segal A is-segal-A x y z f g h p)
 
 #def eq-to-hom2-total-map-is-equiv-Segal
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
   : is-equiv
       (Σ (h : hom A x z) , (comp-Segal A is-segal-A x y z f g) = h)
       (Σ (h : hom A x z) , (hom2 A x y z f g h))
@@ -1156,12 +1157,12 @@ the data provided by a commutative triangle with that boundary.
 
 ```rzk title="RS17, Proposition 5.12"
 #def Eq-Segal-eq-hom2
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y z : A)
-  (f : hom A x y)
-  (g : hom A y z)
-  (k : hom A x z)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y z : A)
+  ( f : hom A x y)
+  ( g : hom A y z)
+  ( k : hom A x z)
   : Equiv ((comp-Segal A is-segal-A x y z f g) = k) (hom2 A x y z f g k)
   :=
     ( eq-to-hom2-Segal A is-segal-A x y z f g k ,

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -380,7 +380,7 @@ all $x$ then $(x : X) → A x$ is a Segal type.
   (fiberwise-is-segal-A : (x : X) → is-local-horn-inclusion (A x))
   : is-local-horn-inclusion ((x : X) → A x)
   :=
-    triple-comp-is-equiv
+    is-equiv-triple-comp
       ( Δ² → ((x : X) → A x) )
       ( (x : X) → Δ² → A x )
       ( (x : X) → Λ → A x )
@@ -421,7 +421,7 @@ then $(x : X) → A x$ is a Segal type.
   (fiberwise-is-segal-A : (s : ψ) → is-local-horn-inclusion (A s))
   : is-local-horn-inclusion ((s : ψ) → A s)
   :=
-    triple-comp-is-equiv
+    is-equiv-triple-comp
     ( Δ² → (s : ψ) → A s)
     ( (s : ψ) → Δ² → A s)
     ( (s : ψ) → Λ → A s)

--- a/src/simplicial-hott/05-segal-types.rzk.md
+++ b/src/simplicial-hott/05-segal-types.rzk.md
@@ -1151,7 +1151,7 @@ Homotopies form a congruence, meaning that homotopies are respected by
 composition:
 
 ```rzk title="RS17, Proposition 5.13"
-#def homotopy-congruence-Segal
+#def congruence-homotopy-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
@@ -1183,7 +1183,7 @@ composition:
 As a special case of the above:
 
 ```rzk
-#def homotopy-postwhisker-Segal
+#def postwhisker-homotopy-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
@@ -1191,13 +1191,13 @@ As a special case of the above:
   (h : hom A y z)
   (p : f = g)
   : (comp-Segal A is-segal-A x y z f h) = (comp-Segal A is-segal-A x y z g h)
-  := homotopy-congruence-Segal A is-segal-A x y z f g h h p refl
+  := congruence-homotopy-Segal A is-segal-A x y z f g h h p refl
 ```
 
 As a special case of the above:
 
 ```rzk
-#def homotopy-prewhisker-Segal
+#def prewhisker-homotopy-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (w x y : A)
@@ -1205,25 +1205,25 @@ As a special case of the above:
   (f g : hom A x y)
   (p : f = g)
   : (comp-Segal A is-segal-A w x y k f) = (comp-Segal A is-segal-A w x y k g)
-  := homotopy-congruence-Segal A is-segal-A w x y k k f g refl p
+  := congruence-homotopy-Segal A is-segal-A w x y k k f g refl p
 ```
 
 ```rzk title="RS17, Proposition 5.14(a)"
-#def homotopy-postwhisker-is-ap-Segal
+#def postwhisker-homotopy-is-ap-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (x y z : A)
   (f g : hom A x y)
   (h : hom A y z)
   (p : f = g)
-  : (homotopy-postwhisker-Segal A is-segal-A x y z f g h p) =
+  : (postwhisker-homotopy-Segal A is-segal-A x y z f g h p) =
     ap (hom A x y) (hom A x z) f g (\ k → comp-Segal A is-segal-A x y z k h) p
   :=
     idJ
     ( hom A x y,
       f,
       \ g' p' →
-      (homotopy-postwhisker-Segal A is-segal-A x y z f g' h p') =
+      (postwhisker-homotopy-Segal A is-segal-A x y z f g' h p') =
       ap
         (hom A x y) (hom A x z)
         f g' (\ k → comp-Segal A is-segal-A x y z k h) p' ,
@@ -1233,21 +1233,21 @@ As a special case of the above:
 ```
 
 ```rzk title="RS17, Proposition 5.14(b)"
-#def homotopy-prewhisker-is-ap-Segal
+#def prewhisker-homotopy-is-ap-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (w x y : A)
   (k : hom A w x)
   (f g : hom A x y)
   (p : f = g)
-  : (homotopy-prewhisker-Segal A is-segal-A w x y k f g p) =
+  : (prewhisker-homotopy-Segal A is-segal-A w x y k f g p) =
     ap (hom A x y) (hom A w y) f g (comp-Segal A is-segal-A w x y k) p
   :=
     idJ
     ( hom A x y ,
       f ,
       \ g' p' →
-      (homotopy-prewhisker-Segal A is-segal-A w x y k f g' p') =
+      (prewhisker-homotopy-Segal A is-segal-A w x y k f g' p') =
       ap (hom A x y) (hom A w y) f g' (comp-Segal A is-segal-A w x y k) p' ,
       refl ,
       g ,

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -84,21 +84,21 @@ Preservation of composition requires the Segal hypothesis.
   (f : hom A x y)
   (g : hom A y z)
   :
-    ( Segal-comp B is-segal-B
+    ( comp-Segal B is-segal-B
       ( F x) (F y) (F z)
       ( ap-hom A B F x y f)
       ( ap-hom A B F y z g))
     =
-    ( ap-hom A B F x z (Segal-comp A is-segal-A x y z f g))
+    ( ap-hom A B F x z (comp-Segal A is-segal-A x y z f g))
   :=
-    Segal-comp-uniqueness B is-segal-B
+    comp-uniqueness-Segal B is-segal-B
       ( F x) (F y) (F z)
       ( ap-hom A B F x y f)
       ( ap-hom A B F y z g)
-      ( ap-hom A B F x z (Segal-comp A is-segal-A x y z f g))
+      ( ap-hom A B F x z (comp-Segal A is-segal-A x y z f g))
       ( ap-hom2 A B F x y z f g
-        ( Segal-comp A is-segal-A x y z f g)
-        ( Segal-comp-witness A is-segal-A x y z f g))
+        ( comp-Segal A is-segal-A x y z f g)
+        ( comp-witness-Segal A is-segal-A x y z f g))
 ```
 
 ## Natural transformations
@@ -212,7 +212,7 @@ Segal types.
   (η : nat-trans-components A B f g)
   (η' : nat-trans-components A B g h)
   : nat-trans-components A B f h
-  := \ x → Segal-comp (B x) (is-segal-B x) (f x) (g x) (h x) (η x) (η' x)
+  := \ x → comp-Segal (B x) (is-segal-B x) (f x) (g x) (h x) (η x) (η' x)
 
 #def vertical-comp-nat-trans
   (A : U)

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -91,14 +91,14 @@ Preservation of composition requires the Segal hypothesis.
     =
     ( ap-hom A B F x z (comp-Segal A is-segal-A x y z f g))
   :=
-    comp-uniqueness-Segal B is-segal-B
+    uniqueness-comp-Segal B is-segal-B
       ( F x) (F y) (F z)
       ( ap-hom A B F x y f)
       ( ap-hom A B F y z g)
       ( ap-hom A B F x z (comp-Segal A is-segal-A x y z f g))
       ( ap-hom2 A B F x y z f g
         ( comp-Segal A is-segal-A x y z f g)
-        ( comp-witness-Segal A is-segal-A x y z f g))
+        ( witness-comp-Segal A is-segal-A x y z f g))
 ```
 
 ## Natural transformations

--- a/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
+++ b/src/simplicial-hott/06-2cat-of-segal-types.rzk.md
@@ -58,7 +58,7 @@ pointwise equal.
   (A B : U)
   (F : A → B)
   (x : A)
-  : (ap-hom A B F x x (id-arr A x)) = (id-arr B (F x))
+  : (ap-hom A B F x x (id-hom A x)) = (id-hom B (F x))
   := eq-ext-htpy
       extext
       2
@@ -68,8 +68,8 @@ pointwise equal.
       (\ t → recOR
       ( t ≡ 0₂ ↦ F x ,
         t ≡ 1₂ ↦ F x))
-      (ap-hom A B F x x (id-arr A x))
-      (id-arr B (F x))
+      (ap-hom A B F x x (id-hom A x))
+      (id-hom B (F x))
       (\ t → refl)
 ```
 
@@ -241,6 +241,6 @@ The identity natural transformation is identity arrows on components
   (B : A → U)
   (f : (x : A) → (B x))
   (a : A)
-  : (\ t → id-arr ((x : A) → B x) f t a) =_{Δ¹ → B a} id-arr (B a) (f a)
+  : (\ t → id-hom ((x : A) → B x) f t a) =_{Δ¹ → B a} id-hom (B a) (f a)
   := refl
 ```

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -36,7 +36,7 @@ identity types.
   (x y : A)
   (p : x = y)
   : hom A x y
-  := ind-path (A) (x) (\ y' → \ p' → hom A x y') ((id-arr A x)) (y) (p)
+  := ind-path (A) (x) (\ y' → \ p' → hom A x y') ((id-hom A x)) (y) (p)
 
 #def is-discrete
   (A : U)
@@ -717,7 +717,7 @@ The extension types that appear in the Segal condition are retracts of this type
   (A : U)
   (x y : A)
   (f g : hom A x y)
-  (α : hom2 A x y y f (id-arr A y) g)
+  (α : hom2 A x y y f (id-hom A y) g)
   : ((t , s) : Δ¹×Δ¹) → A
     [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
       (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
@@ -729,7 +729,7 @@ The extension types that appear in the Segal condition are retracts of this type
   ( A : U)
   ( x y : A)
   ( f : hom A x y)
-  ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
+  ( (d , α) : Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d)
   : Σ ( g : hom A x y) ,
       ( ((t , s) : Δ¹×Δ¹) → A
         [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
@@ -749,7 +749,7 @@ The extension types that appear in the Segal condition are retracts of this type
           (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
           (Δ¹ t) ∧ (s ≡ 0₂) ↦ x ,
           (Δ¹ t) ∧ (s ≡ 1₂) ↦ y ]))
-  : Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d
+  : Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d
   := ((\ t → σ (t , t)) , (\ (t , s) → σ (s , t)))
 
 #def sigma-triangle-to-sigma-square-retract
@@ -757,7 +757,7 @@ The extension types that appear in the Segal condition are retracts of this type
   ( x y : A)
   ( f : hom A x y)
   : is-retract-of
-      ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
+      ( Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d)
       ( Σ (g : hom A x y) ,
           ( ((t , s) : Δ¹×Δ¹) → A
             [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
@@ -779,10 +779,10 @@ the second arrow is an identity.
   ( is-discrete-A : is-discrete A)
   ( x y : A)
   ( f : hom A x y)
-  : is-contr ( Σ (d : hom A x y) , hom2 A x y y f (id-arr A y) d)
+  : is-contr ( Σ (d : hom A x y) , hom2 A x y y f (id-hom A y) d)
   :=
     is-contr-is-retract-of-is-contr
-      ( Σ ( d : hom A x y) , (hom2 A x y y f (id-arr A y) d))
+      ( Σ ( d : hom A x y) , (hom2 A x y y f (id-hom A y) d))
       ( Σ ( g : hom A x y) ,
           ( ((t , s) : Δ¹×Δ¹) → A
             [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -57,7 +57,7 @@ of discrete types is discrete.
   ( f g : (x : X) → A x)
   : Equiv (f = g) (hom ((x : X) → A x) f g)
   :=
-    triple-comp-equiv
+    equiv-triple-comp
       ( f = g)
       ( (x : X) → f x = g x)
       ( (x : X) → hom (A x) (f x) (g x))
@@ -124,7 +124,7 @@ only, extending from BOT, that's all we prove here for now.
   ( f g : (t : ψ) → A t)
   : Equiv (f = g) (hom ((t : ψ) → A t) f g)
   :=
-    triple-comp-equiv
+    equiv-triple-comp
       ( f = g)
       ( (t : ψ) → f t = g t)
       ( (t : ψ) → hom (A t) (f t) (g t))
@@ -304,7 +304,7 @@ The equivalence underlying `equiv-arr-Σ-hom`:
                 (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
                 (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
   :=
-    left-cancel-equiv
+    equiv-left-cancel
       ( f =_{Δ¹ → A} g)
       ( Σ ( p : x = z) ,
           ( Σ ( q : y = w) ,

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -238,14 +238,18 @@ Discrete types are automatically Segal types.
           ( \ σ → refl))))
 ```
 
-The equivalence underlying `Eq-arr`:
+The equivalence underlying `equiv-arr-Σ-hom`:
 
 ```rzk
 #def fibered-arr-free-arr
   : (arr A) → (Σ (u : A) , (Σ (v : A) , hom A u v))
   := \ k → (k 0₂ , (k 1₂ , k))
 
-#def id-equiv-Eq-arr uses (w x y z)
+#def is-equiv-fibered-arr-free-arr
+  : is-equiv (arr A) (Σ (u : A) , (Σ (v : A) , hom A u v)) (fibered-arr-free-arr)
+  := is-equiv-arr-Σ-hom A
+
+#def is-equiv-ap-fibered-arr-free-arr uses (w x y z)
   : is-equiv
       ( f =_{Δ¹ → A} g)
       ( fibered-arr-free-arr f = fibered-arr-free-arr g)
@@ -259,18 +263,19 @@ The equivalence underlying `Eq-arr`:
     is-equiv-ap-is-equiv
       ( arr A)
       ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
-      fibered-arr-free-arr
-      ( second (Eq-arr A))
+      ( fibered-arr-free-arr)
+      ( is-equiv-fibered-arr-free-arr)
       ( f)
       ( g)
 
-#def id-Eq-Eq-arr uses (w x y z)
+#def id-Eq-equiv-arr-Σ-hom uses (w x y z)
   : Equiv (f =_{Δ¹ → A} g) (fibered-arr-free-arr f = fibered-arr-free-arr g)
   :=
     equiv-ap-is-equiv
       ( arr A)
-      ( Σ (u : A) , (Σ (v : A) , (hom A u v))) (fibered-arr-free-arr)
-      ( second (Eq-arr A))
+      ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
+      ( fibered-arr-free-arr)
+      ( is-equiv-fibered-arr-free-arr)
       ( f)
       ( g)
 
@@ -288,16 +293,16 @@ The equivalence underlying `Eq-arr`:
 
 #def equiv-square-sigma-over-product uses (extext is-discrete-A)
   : Equiv
-      ( Σ ( p : x = z) ,
-          ( Σ (q : y = w) ,
-              ( product-transport A A (hom A) x z y w p q f = g)))
-      ( Σ ( h : hom A x z) ,
-          ( Σ ( k : hom A y w) ,
-              ( ((t , s) : Δ¹×Δ¹) → A
-                [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
-                  (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
-                  (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
-                  (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
+    ( Σ ( p : x = z) ,
+        ( Σ (q : y = w) ,
+            ( product-transport A A (hom A) x z y w p q f = g)))
+    ( Σ ( h : hom A x z) ,
+        ( Σ ( k : hom A y w) ,
+            ( ((t , s) : Δ¹×Δ¹) → A
+              [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ f s ,
+                (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
+                (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
+                (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
   :=
     left-cancel-equiv
       ( f =_{Δ¹ → A} g)
@@ -317,7 +322,7 @@ The equivalence underlying `Eq-arr`:
         ( Σ ( p : x = z) ,
             ( Σ ( q : y = w) ,
                 ( product-transport A A (hom A) x z y w p q f = g)))
-        id-Eq-Eq-arr
+        id-Eq-equiv-arr-Σ-hom
         equiv-sigma-over-product-arr-eq)
       ( equiv-comp
         ( f =_{Δ¹ → A} g)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -62,7 +62,7 @@ of discrete types is discrete.
       ( (x : X) → f x = g x)
       ( (x : X) → hom (A x) (f x) (g x))
       ( hom ((x : X) → A x) f g)
-      ( FunExt-equiv funext X A f g)
+      ( equiv-FunExt funext X A f g)
       ( equiv-function-equiv-fibered funext X
         ( \ x → (f x = g x)) (\ x → hom (A x) (f x) (g x))
         ( \ x → (arr-eq (A x) (f x) (g x) , (is-discrete-A x (f x) (g x)))))
@@ -267,7 +267,7 @@ The equivalence underlying `Eq-arr`:
 #def id-Eq-Eq-arr uses (w x y z)
   : Equiv (f =_{Δ¹ → A} g) (fibered-arr-free-arr f = fibered-arr-free-arr g)
   :=
-    Eq-ap-is-equiv
+    equiv-ap-is-equiv
       ( arr A)
       ( Σ (u : A) , (Σ (v : A) , (hom A u v))) (fibered-arr-free-arr)
       ( second (Eq-arr A))
@@ -311,7 +311,7 @@ The equivalence underlying `Eq-arr`:
                   (t ≡ 1₂) ∧ (Δ¹ s) ↦ g s ,
                   (Δ¹ t) ∧ (s ≡ 0₂) ↦ h t ,
                   (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
-      ( comp-equiv
+      ( equiv-comp
         ( f =_{Δ¹ → A} g)
         ( fibered-arr-free-arr f = fibered-arr-free-arr g)
         ( Σ ( p : x = z) ,
@@ -319,7 +319,7 @@ The equivalence underlying `Eq-arr`:
                 ( product-transport A A (hom A) x z y w p q f = g)))
         id-Eq-Eq-arr
         equiv-sigma-over-product-arr-eq)
-      ( comp-equiv
+      ( equiv-comp
         ( f =_{Δ¹ → A} g)
         ( hom (arr A) f g)
         ( Σ ( h : hom A x z) ,
@@ -523,7 +523,7 @@ We close the section so we can use path induction.
                 (Δ¹ t) ∧ (s ≡ 1₂) ↦ k t ])))
     ( square-sigma-over-product A is-discrete-A x y z w f g)
   :=
-    is-equiv-rev-homotopic-is-equiv
+    is-equiv-rev-homotopy
     ( Σ ( p : x = z) ,
          ( Σ ( q : y = w) ,
             ( product-transport A A (hom A) x z y w p q f = g)))

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -102,7 +102,7 @@ of discrete types is discrete.
   : is-discrete ((x : X) → A x)
   :=
     \ f g →
-    is-equiv-homotopic-is-equiv
+    is-equiv-homotopy
       ( f = g)
       ( hom ((x : X) → A x) f g)
       ( arr-eq ((x : X) → A x) f g)
@@ -177,7 +177,7 @@ only, extending from BOT, that's all we prove here for now.
   : is-discrete ((t : ψ) → A t)
   :=
     \ f g →
-    is-equiv-homotopic-is-equiv
+    is-equiv-homotopy
       ( f = g)
       ( hom ((t : ψ) → A t) f g)
       ( arr-eq ((t : ψ) → A t) f g)

--- a/src/simplicial-hott/07-discrete.rzk.md
+++ b/src/simplicial-hott/07-discrete.rzk.md
@@ -260,7 +260,7 @@ The equivalence underlying `equiv-arr-Σ-hom`:
         ( g)
         ( fibered-arr-free-arr))
   :=
-    is-equiv-ap-is-equiv
+    is-emb-is-equiv
       ( arr A)
       ( Σ (u : A) , (Σ (v : A) , (hom A u v)))
       ( fibered-arr-free-arr)

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -451,7 +451,7 @@ Now we introduce the hypothesis that A is Segal type.
   : Equiv (dhom-from-representable A a x y f u)
     (Σ (d : hom A a y) , (hom2 A a x y u f d))
   :=
-    comp-equiv
+    equiv-comp
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
       ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
@@ -514,7 +514,7 @@ we argue as follows:
         ( dhom-from-representable A x y z g f)
         ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
           Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
-        ( comp-equiv
+        ( equiv-comp
           ( dhom-from-representable A x y z g f)
           ( Σ (h : hom A x z) ,
             ( product
@@ -589,7 +589,7 @@ types as follows.
         (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t])
     (hom A a y)
   :=
-    comp-equiv
+    equiv-comp
     ( ((t , s) : ∂□) → A
         [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
           (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
@@ -1079,7 +1079,7 @@ By uncurrying (RS 4.2) we have an equivalence:
   : Equiv
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
-  := comp-equiv
+  := equiv-comp
       (dhom-to-representable A a x y f v)
       (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
       (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
@@ -1182,7 +1182,7 @@ Now we introduce the hypothesis that A is Segal type.
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) , (hom2 A x y a f v d))
   :=
-    comp-equiv
+    equiv-comp
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) ,
       ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
@@ -1247,7 +1247,7 @@ we argue as follows:
           ( dhom-to-representable A z x y f g)
           ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
             Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
-          ( comp-equiv
+          ( equiv-comp
             ( dhom-to-representable A z x y f g)
             ( Σ (h : hom A x z) ,
               ( product

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -329,7 +329,7 @@ By uncurrying (RS 4.2) we have an equivalence:
       ( Σ (v : hom A a y) ,
         product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
   :=
-    triple-comp-equiv
+    equiv-triple-comp
     ( dhom-from-representable A a x y f u)
     ( Σ (v : hom A a y) ,
       ( ((t , s) : Δ¹×Δ¹) → A [
@@ -360,7 +360,7 @@ By uncurrying (RS 4.2) we have an equivalence:
         ( hom2 A a x y u f d)
         ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
       ( product
@@ -398,7 +398,7 @@ Now we introduce the hypothesis that A is Segal type.
     ( Σ (d : hom A a y) ,
       ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
       ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
@@ -654,7 +654,7 @@ types as follows.
               (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-from-representable A a x y f u)
     ( Σ (sq : ((t , s) : ∂□) → A
             [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -714,7 +714,7 @@ types as follows.
                 (Δ¹ t) ∧ (s ≡ 0₂) ↦ a ,
                 (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t] )
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-from-representable A a x y f u)
     ( ((t , s) : Δ¹×Δ¹) → A
         [ (t ≡ 0₂) ∧ (Δ¹ s) ↦ u s ,
@@ -1052,7 +1052,7 @@ By uncurrying (RS 4.2) we have an equivalence:
       (Σ (u : hom A x a) ,
         product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
   :=
-    triple-comp-equiv
+    equiv-triple-comp
     ( dhom-to-representable A a x y f v)
     ( Σ (u : hom A x a) ,
         (((t , s) : Δ¹×Δ¹) → A
@@ -1104,7 +1104,7 @@ By uncurrying (RS 4.2) we have an equivalence:
           ( hom2 A x y a f v d)
           ( Σ (u : hom A x a ) , hom2 A x a a u (id-arr A a) d)))
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a ) ,
       ( product
@@ -1145,7 +1145,7 @@ Now we introduce the hypothesis that A is Segal type.
     ( Σ (d : hom A x a) ,
       ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
   :=
-    right-cancel-equiv
+    equiv-right-cancel
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a) ,
       ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -303,7 +303,7 @@ By uncurrying (RS 4.2) we have an equivalence:
                       (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
     ( Σ (v : hom A a y) ,
       ( Σ (d : hom A a y) ,
-        product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+        product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
   :=
     total-equiv-family-equiv
     ( hom A a y)
@@ -315,8 +315,8 @@ By uncurrying (RS 4.2) we have an equivalence:
                       (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
     ( \ v →
       ( Σ (d : hom A a y) ,
-        product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
-    ( \ v → Eq-square-hom2-pushout A a x a y u f (id-arr A a) v)
+        product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
+    ( \ v → Eq-square-hom2-pushout A a x a y u f (id-hom A a) v)
 
 #def representable-dhom-from-hom2
   (A : U)
@@ -327,7 +327,7 @@ By uncurrying (RS 4.2) we have an equivalence:
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
       ( Σ (v : hom A a y) ,
-        product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+        product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
   :=
     equiv-triple-comp
     ( dhom-from-representable A a x y f u)
@@ -339,14 +339,14 @@ By uncurrying (RS 4.2) we have an equivalence:
                       (Δ¹ t) ∧ (s ≡ 1₂) ↦ f t ]))
     ( Σ (v : hom A a y) ,
       ( Σ (d : hom A a y) ,
-        product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+        product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
     ( Σ (d : hom A a y) ,
       ( Σ (v : hom A a y) ,
-      product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+      product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
     ( uncurried-dhom-from-representable A a x y f u)
     ( representable-dhom-from-uncurry-hom2 A a x y f u)
     ( fubini-Σ (hom A a y) (hom A a y)
-      ( \ v d → product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+      ( \ v d → product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
 
 #def representable-dhom-from-hom2-dist
   (A : U)
@@ -358,30 +358,30 @@ By uncurrying (RS 4.2) we have an equivalence:
     ( Σ (d : hom A a y) ,
       ( product
         ( hom2 A a x y u f d)
-        ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+        ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
   :=
     equiv-right-cancel
     ( dhom-from-representable A a x y f u)
     ( Σ (d : hom A a y) ,
       ( product
         ( hom2 A a x y u f d)
-        ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+        ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
     ( Σ (d : hom A a y) ,
       ( Σ (v : hom A a y) ,
-        product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+        product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
     ( representable-dhom-from-hom2 A a x y f u)
     ( total-equiv-family-equiv
       ( hom A a y)
       ( \ d →
         ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+          ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
       ( \ d →
         ( Σ (v : hom A a y) ,
-          product (hom2 A a x y u f d) (hom2 A a a y (id-arr A a) v d)))
+          product (hom2 A a x y u f d) (hom2 A a a y (id-hom A a) v d)))
       ( \ d →
         ( distributive-product-Σ (hom2 A a x y u f d) (hom A a y)
-          ( \ v → hom2 A a a y (id-arr A a) v d))))
+          ( \ v → hom2 A a a y (id-hom A a) v d))))
 ```
 
 Now we introduce the hypothesis that A is Segal type.
@@ -405,7 +405,7 @@ Now we introduce the hypothesis that A is Segal type.
     ( Σ (d : hom A a y) ,
       ( product
         ( hom2 A a x y u f d)
-        ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+        ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
     ( representable-dhom-from-hom2-dist A a x y f u)
     ( total-equiv-family-equiv
       ( hom A a y)
@@ -413,17 +413,17 @@ Now we introduce the hypothesis that A is Segal type.
       ( \ d →
         ( product
           ( hom2 A a x y u f d)
-          ( Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d)))
+          ( Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d)))
       ( \ d →
         ( total-equiv-family-equiv
           ( hom2 A a x y u f d)
           ( \ alpha → (Σ (v : hom A a y) , (v = d)))
-          ( \ alpha → (Σ (v : hom A a y) , hom2 A a a y (id-arr A a) v d))
+          ( \ alpha → (Σ (v : hom A a y) , hom2 A a a y (id-hom A a) v d))
           ( \ alpha →
             ( total-equiv-family-equiv
               ( hom A a y)
               ( \ v → (v = d))
-              ( \ v → hom2 A a a y (id-arr A a) v d)
+              ( \ v → hom2 A a a y (id-hom A a) v d)
               ( \ v → (Eq-Segal-homotopy-hom2 A is-segal-A a y v d)))))))
 
 
@@ -504,29 +504,29 @@ we argue as follows:
     \ x y z f g →
     is-contr-base-is-contr-Σ
     ( Σ (h : hom A x z) , hom2 A x y z f g h)
-    ( \ hk → Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
+    ( \ hk → Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk))
     ( \ hk → (first hk , \ (t , s) → first hk s))
     ( is-contr-is-equiv-to-contr
       ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-        Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
+        Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk))
       ( dhom-from-representable A x y z g f)
       ( inv-equiv
         ( dhom-from-representable A x y z g f)
         ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-          Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
+          Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk))
         ( equiv-comp
           ( dhom-from-representable A x y z g f)
           ( Σ (h : hom A x z) ,
             ( product
               ( hom2 A x y z f g h)
-              ( Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v h)))
+              ( Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v h)))
           ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-            Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v (first hk))
+            Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v (first hk))
           ( representable-dhom-from-hom2-dist A x y z g f)
           ( associative-Σ
             ( hom A x z)
             ( \ h → hom2 A x y z f g h)
-            ( \ h _ → Σ (v : hom A x z) , hom2 A x x z (id-arr A x) v h))))
+            ( \ h _ → Σ (v : hom A x z) , hom2 A x x z (id-hom A x) v h))))
       ( repiscovfam x y z g f))
 ```
 
@@ -788,12 +788,12 @@ arrows in the base on terms in the fibers. In particular, there is an identity
 transport law.
 
 ```rzk
-#def d-id-arr
+#def id-dhom
   (A : U)
   (x : A)
   (C : A → U)
   (u : C x)
-  : dhom A x x (id-arr A x) C u u
+  : dhom A x x (id-hom A x) C u u
   := \ t → u
 ```
 
@@ -804,10 +804,10 @@ transport law.
   (C : A → U)
   (is-covariant-C : is-covariant A C)
   (u : C x)
-  : (covariant-transport A x x (id-arr A x) C is-covariant-C u) = u
+  : (covariant-transport A x x (id-hom A x) C is-covariant-C u) = u
   :=
     covariant-uniqueness
-      A x x (id-arr A x) C is-covariant-C u (u , d-id-arr A x C u)
+      A x x (id-hom A x) C is-covariant-C u (u , id-dhom A x C u)
 ```
 
 ## Natural transformations
@@ -1027,7 +1027,7 @@ By uncurrying (RS 4.2) we have an equivalence:
                       (Δ¹ t) ∧ (s ≡ 1₂) ↦ a ]))
     (Σ (u : hom A x a) ,
       (Σ (d : hom A x a) ,
-        product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
+        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d) ))
   :=
     total-equiv-family-equiv (hom A x a)
     ( \ u →
@@ -1038,8 +1038,8 @@ By uncurrying (RS 4.2) we have an equivalence:
                       (Δ¹ t) ∧ (s ≡ 1₂) ↦ a ]))
     ( \ u →
       (Σ (d : hom A x a) ,
-          product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
-    ( \ u → Eq-square-hom2-pushout A x a y a u (id-arr A a) f v)
+          product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d) ))
+    ( \ u → Eq-square-hom2-pushout A x a y a u (id-hom A a) f v)
 
 #def representable-dhom-to-hom2
   (A : U)
@@ -1050,7 +1050,7 @@ By uncurrying (RS 4.2) we have an equivalence:
     (dhom-to-representable A a x y f v)
     (Σ (d : hom A x a) ,
       (Σ (u : hom A x a) ,
-        product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
+        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d) ))
   :=
     equiv-triple-comp
     ( dhom-to-representable A a x y f v)
@@ -1062,14 +1062,14 @@ By uncurrying (RS 4.2) we have an equivalence:
               (Δ¹ t) ∧ (s ≡ 1₂) ↦ a ]))
     ( Σ (u : hom A x a ) ,
       (Σ (d : hom A x a) ,
-        product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
+        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
     ( Σ (d : hom A x a ) ,
       (Σ (u : hom A x a) ,
-        product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
+        product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
     ( uncurried-dhom-to-representable A a x y f v)
     ( representable-dhom-to-uncurry-hom2 A a x y f v)
     ( fubini-Σ (hom A x a) (hom A x a)
-      (\ u d → product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d)))
+      (\ u d → product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d)))
 
 #def representable-dhom-to-hom2-swap
   (A : U)
@@ -1078,19 +1078,19 @@ By uncurrying (RS 4.2) we have an equivalence:
   (v : hom A y a)
   : Equiv
     ( dhom-to-representable A a x y f v)
-    ( Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+    ( Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d) ))
   := equiv-comp
       (dhom-to-representable A a x y f v)
-      (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
-      (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+      (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d) ))
+      (Σ (d : hom A x a) , (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d) ))
       (representable-dhom-to-hom2 A a x y f v)
       (total-equiv-family-equiv (hom A x a)
-        (\ d → (Σ (u : hom A x a) , product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d) ))
-        (\ d → (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+        (\ d → (Σ (u : hom A x a) , product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d) ))
+        (\ d → (Σ (u : hom A x a) , product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d) ))
         (\ d → total-equiv-family-equiv (hom A x a)
-          (\ u → product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))
-          (\ u → product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d))
-          (\ u → sym-product (hom2 A x a a u (id-arr A a) d) (hom2 A x y a f v d))))
+          (\ u → product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))
+          (\ u → product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d))
+          (\ u → sym-product (hom2 A x a a u (id-hom A a) d) (hom2 A x y a f v d))))
 
 #def representable-dhom-to-hom2-dist
   (A : U)
@@ -1102,33 +1102,33 @@ By uncurrying (RS 4.2) we have an equivalence:
       (Σ (d : hom A x a ) ,
         ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a ) , hom2 A x a a u (id-arr A a) d)))
+          ( Σ (u : hom A x a ) , hom2 A x a a u (id-hom A a) d)))
   :=
     equiv-right-cancel
     ( dhom-to-representable A a x y f v)
     ( Σ (d : hom A x a ) ,
       ( product
         ( hom2 A x y a f v d)
-        ( Σ (u : hom A x a ) , hom2 A x a a u (id-arr A a) d)))
+        ( Σ (u : hom A x a ) , hom2 A x a a u (id-hom A a) d)))
     ( Σ (d : hom A x a) ,
       ( Σ (u : hom A x a) ,
         product
         ( hom2 A x y a f v d)
-        ( hom2 A x a a u (id-arr A a) d)))
+        ( hom2 A x a a u (id-hom A a) d)))
     ( representable-dhom-to-hom2-swap A a x y f v)
     ( total-equiv-family-equiv (hom A x a)
       ( \ d →
         ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a ) , hom2 A x a a u (id-arr A a) d)))
+          ( Σ (u : hom A x a ) , hom2 A x a a u (id-hom A a) d)))
       ( \ d →
         ( Σ (u : hom A x a) ,
-          product (hom2 A x y a f v d) (hom2 A x a a u (id-arr A a) d) ))
+          product (hom2 A x y a f v d) (hom2 A x a a u (id-hom A a) d) ))
       ( \ d →
         ( distributive-product-Σ
           ( hom2 A x y a f v d)
           ( hom A x a)
-          ( \ u → hom2 A x a a u (id-arr A a) d))))
+          ( \ u → hom2 A x a a u (id-hom A a) d))))
 ```
 
 Now we introduce the hypothesis that A is Segal type.
@@ -1152,24 +1152,24 @@ Now we introduce the hypothesis that A is Segal type.
     ( Σ (d : hom A x a) ,
       ( product
         ( hom2 A x y a f v d)
-        ( Σ (u : hom A x a) , (hom2 A x a a u (id-arr A a) d))))
+        ( Σ (u : hom A x a) , (hom2 A x a a u (id-hom A a) d))))
     ( representable-dhom-to-hom2-dist A a x y f v)
     ( total-equiv-family-equiv (hom A x a)
       ( \ d → (product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
       ( \ d →
         ( product
           ( hom2 A x y a f v d)
-          ( Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d)))
+          ( Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d)))
       ( \ d →
         ( total-equiv-family-equiv
           ( hom2 A x y a f v d)
           ( \ α → (Σ (u : hom A x a) , (u = d)))
-          ( \ α → (Σ (u : hom A x a) , hom2 A x a a u (id-arr A a) d))
+          ( \ α → (Σ (u : hom A x a) , hom2 A x a a u (id-hom A a) d))
           ( \ α →
           ( total-equiv-family-equiv
             ( hom A x a)
             ( \ u → (u = d))
-            ( \ u → hom2 A x a a u (id-arr A a) d)
+            ( \ u → hom2 A x a a u (id-hom A a) d)
             ( \ u → (Eq-Segal-homotopy-hom2' A is-segal-A x a u d)))))))
 
 #def is-segal-representable-dhom-to-hom2
@@ -1237,29 +1237,29 @@ we argue as follows:
     \ x y z f g →
       is-contr-base-is-contr-Σ
       ( Σ (h : hom A x z) , hom2 A x y z f g h)
-      ( \ hk → Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
+      ( \ hk → Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk))
       ( \ hk → (first hk , \ (t , s) → first hk t))
       ( is-contr-is-equiv-to-contr
         ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-          Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
+          Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk))
         ( dhom-to-representable A z x y f g)
         ( inv-equiv
           ( dhom-to-representable A z x y f g)
           ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-            Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
+            Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk))
           ( equiv-comp
             ( dhom-to-representable A z x y f g)
             ( Σ (h : hom A x z) ,
               ( product
                 ( hom2 A x y z f g h)
-                ( Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) h)))
+                ( Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) h)))
             ( Σ (hk : Σ (h : hom A x z) , hom2 A x y z f g h) ,
-              Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) (first hk))
+              Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) (first hk))
             ( representable-dhom-to-hom2-dist A z x y f g)
             ( associative-Σ
               ( hom A x z)
               ( \ h → hom2 A x y z f g h)
-              ( \ h _ → Σ (u : hom A x z) , hom2 A x z z u (id-arr A z) h))))
+              ( \ h _ → Σ (u : hom A x z) , hom2 A x z z u (id-hom A z) h))))
               ( repiscontrafam z x y f g))
 ```
 
@@ -1326,10 +1326,10 @@ identity transport law.
   (C : A → U)
   (is-contravariant-C : is-contravariant A C)
   (u : C x)
-  : (contravariant-transport A x x (id-arr A x) C is-contravariant-C u) = u
+  : (contravariant-transport A x x (id-hom A x) C is-contravariant-C u) = u
   :=
-    contravariant-uniqueness A x x (id-arr A x) C is-contravariant-C u
-      (u , d-id-arr A x C u)
+    contravariant-uniqueness A x x (id-hom A x) C is-contravariant-C u
+      (u , id-dhom A x C u)
 ```
 
 ## Contravariant natural transformations

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -95,7 +95,7 @@ unique lift with specified domain.
 
 ```rzk title="The type of covariant families over a fixed type"
 #def covariant-family (A : U) : U
-  := (Σ (C : ((a : A) → U)) , is-covariant A C)
+  := (Σ (C : (A → U)) , is-covariant A C)
 ```
 
 The notion of having a unique lift with a fixed domain may also be expressed by

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -387,7 +387,7 @@ By uncurrying (RS 4.2) we have an equivalence:
 Now we introduce the hypothesis that A is Segal type.
 
 ```rzk
-#def Segal-representable-dhom-from-path-space
+#def representable-dhom-from-path-space-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (a x y : A)
@@ -456,7 +456,7 @@ Now we introduce the hypothesis that A is Segal type.
     ( Σ (d : hom A a y) ,
       ( product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d))))
     ( Σ (d : hom A a y) , (hom2 A a x y u f d))
-    ( Segal-representable-dhom-from-path-space A is-segal-A a x y f u)
+    ( representable-dhom-from-path-space-Segal A is-segal-A a x y f u)
     ( total-equiv-family-equiv
       ( hom A a y)
       ( \ d → product (hom2 A a x y u f d) (Σ (v : hom A a y) , (v = d)))
@@ -1134,7 +1134,7 @@ By uncurrying (RS 4.2) we have an equivalence:
 Now we introduce the hypothesis that A is Segal type.
 
 ```rzk
-#def Segal-representable-dhom-to-path-space
+#def representable-dhom-to-path-space-Segal
   (A : U)
   (is-segal-A : is-segal A)
   (a x y : A)
@@ -1188,7 +1188,7 @@ Now we introduce the hypothesis that A is Segal type.
       ( product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d))))
     ( Σ (d : hom A x a) ,
       ( hom2 A x y a f v d))
-    ( Segal-representable-dhom-to-path-space A is-segal-A a x y f v)
+    ( representable-dhom-to-path-space-Segal A is-segal-A a x y f v)
     ( total-equiv-family-equiv
       ( hom A x a)
       ( \ d → product (hom2 A x y a f v d) (Σ (u : hom A x a) , (u = d)))

--- a/src/simplicial-hott/08-covariant.rzk.md
+++ b/src/simplicial-hott/08-covariant.rzk.md
@@ -17,6 +17,12 @@ This is a literate `rzk` file:
 - `5-segal-types.md` - We make use of the notion of Segal types and their
   structures.
 
+Some of the definitions in this file rely on extension extensionality:
+
+```rzk
+#assume extext : ExtExt
+```
+
 ## Dependent hom types
 
 In a type family over a base type, there is a dependent hom type of arrows that
@@ -103,7 +109,7 @@ contractibility of the type of extensions along the domain inclusion into the
 1-simplex.
 
 ```rzk
-#def has-unique-lifts-with-fixed-domain
+#def has-unique-fixed-domain-lifts
   (A : U)
   (C : A → U)
   : U
@@ -137,11 +143,11 @@ By the equivalence-invariance of contractibility, this proves the desired
 logical equivalence
 
 ```rzk title="RS17, Proposition 8.4"
-#def has-unique-lifts-with-fixed-domain-iff-is-covariant
+#def has-unique-fixed-domain-lifts-iff-is-covariant
   (A : U)
   (C : A → U)
   : iff
-      (has-unique-lifts-with-fixed-domain A C)
+      (has-unique-fixed-domain-lifts A C)
       (is-covariant A C)
   :=
     ( \ C-has-unique-lifts x y f u →
@@ -846,6 +852,150 @@ with the covariant lifts.
           A x y f C D is-covariant-C ϕ u)
 ```
 
+## Covariant equivalence
+
+A family of types that is equivalent to a covariant family is itself covariant.
+
+To prove this we first show that the corresponding types of lifts with fixed
+domain are equivalent:
+
+```rzk
+#def equiv-covariant-total-dhom
+  (A : U)
+  (C : A → U)
+  (x y : A)
+  (f : hom A x y)
+  : Equiv
+    ( (t : Δ¹) → C (f t))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    ( \ h → (h 0₂ , \ t → h t) ,
+      ( ( \ k t → (second k) t , \ h → refl) ,
+        ( ( \ k t → (second k) t , \ h → refl))))
+```
+
+```rzk
+#section dhom-from-equivalence
+
+#variable A : U
+#variables B C : A → U
+#variable equiv-BC : (a : A) → Equiv (B a) (C a)
+#variables x y : A
+#variable f : hom A x y
+
+#def equiv-total-dhom-equiv uses (A x y)
+  : Equiv ((t : Δ¹) → B (f t)) ((t : Δ¹) → C (f t))
+  :=
+    equiv-extension-equiv-fibered
+      ( extext)
+      ( 2)
+      ( Δ¹)
+      ( \ t → B (f t))
+      ( \ t → C (f t))
+      ( \ t → equiv-BC (f t))
+
+#def equiv-total-covariant-dhom-equiv uses (extext equiv-BC)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    equiv-triple-comp
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( (t : Δ¹) → B (f t))
+    ( (t : Δ¹) → C (f t))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+    ( inv-equiv
+      ( (t : Δ¹) → B (f t))
+      ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+      ( equiv-covariant-total-dhom A B x y f))
+    ( equiv-total-dhom-equiv)
+    ( equiv-covariant-total-dhom A C x y f)
+
+#def equiv-pullback-total-covariant-dhom-equiv uses (A y)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+  :=
+    total-equiv-pullback-is-equiv
+      ( B x)
+      ( C x)
+      ( first (equiv-BC x))
+      ( second (equiv-BC x))
+      ( \ u → ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+
+#def is-equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
+  : is-equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)))
+  :=
+    is-equiv-right-factor
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+    ( Σ (u : C x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ u]))
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)))
+    ( first (equiv-pullback-total-covariant-dhom-equiv))
+    ( second (equiv-pullback-total-covariant-dhom-equiv))
+    ( second (equiv-total-covariant-dhom-equiv))
+
+#def equiv-to-pullback-total-covariant-dhom-equiv uses (extext A y)
+  : Equiv
+    ( Σ (i : B x), ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i]))
+    ( Σ (i : B x), ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i]))
+  :=
+    ( \ (i, h) → (i, \ t → (first (equiv-BC (f t))) (h t)),
+      is-equiv-to-pullback-total-covariant-dhom-equiv)
+
+#def family-equiv-dhom-family-equiv uses (extext A y)
+  (i : B x)
+  : Equiv
+    ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i])
+    ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+  :=
+    family-equiv-total-equiv
+    ( B x)
+    ( \ii → ((t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ ii]))
+    ( \ii → ((t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) ii]))
+    ( \ii h t → (first (equiv-BC (f t))) (h t))
+    ( is-equiv-to-pullback-total-covariant-dhom-equiv)
+    ( i)
+
+#end dhom-from-equivalence
+```
+
+Now we introduce the hypothesis that $C$ is covariant in the form of
+`has-unique-fixed-domain-lifts`.
+
+```rzk
+#def equiv-has-unique-fixed-domain-lifts uses (extext)
+  (A : U)
+  (B C : A → U)
+  (equiv-BC : (a : A) → Equiv (B a) (C a))
+  (has-unique-fixed-domain-lifts-C :
+    has-unique-fixed-domain-lifts A C)
+  : has-unique-fixed-domain-lifts A B
+  :=
+    \ x y f i →
+    is-contr-is-equiv-to-contr
+    ( (t : Δ¹) → B (f t) [ t ≡ 0₂ ↦ i])
+    ( (t : Δ¹) → C (f t) [ t ≡ 0₂ ↦ (first (equiv-BC x)) i])
+    ( family-equiv-dhom-family-equiv A B C equiv-BC x y f i)
+    ( has-unique-fixed-domain-lifts-C x y f ((first (equiv-BC x)) i))
+
+#def equiv-is-covariant uses (extext)
+  (A : U)
+  (B C : A → U)
+  (equiv-BC : (a : A) → Equiv (B a) (C a))
+  (is-covariant-C : is-covariant A C)
+  : is-covariant A B
+  :=
+    ( first (has-unique-fixed-domain-lifts-iff-is-covariant A B))
+      ( equiv-has-unique-fixed-domain-lifts
+        A B C equiv-BC
+        ( (second (has-unique-fixed-domain-lifts-iff-is-covariant A C))
+          is-covariant-C))
+```
+
 ## Contravariant families
 
 A family of types over a base type is contravariant if every arrow in the base
@@ -882,7 +1032,7 @@ by contractibility of the type of extensions along the codomain inclusion into
 the 1-simplex.
 
 ```rzk
-#def has-unique-lifts-with-fixed-codomain
+#def has-unique-fixed-codomain-lifts
   (A : U)
   (C : A → U)
   : U
@@ -916,11 +1066,11 @@ By the equivalence-invariance of contractibility, this proves the desired
 logical equivalence
 
 ```rzk title="RS17, Proposition 8.4"
-#def has-unique-lifts-with-fixed-codomain-iff-is-contravariant
+#def has-unique-fixed-codomain-lifts-iff-is-contravariant
   (A : U)
   (C : A → U)
   : iff
-      (has-unique-lifts-with-fixed-codomain A C)
+      (has-unique-fixed-codomain-lifts A C)
       (is-contravariant A C)
   :=
     ( \ C-has-unique-lifts x y f v →

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -242,7 +242,10 @@ though it requires some work to prove that the domain is covariant.
   (is-covariant-C : is-covariant A C)
   (ϕ : (z : A) → hom A a z → C z)
   : (covariant-transport A a b f C is-covariant-C (evid A a C ϕ)) =
-    (evid A b C (covariant-transport A a b f ( \ x -> (z : A) → hom A x z → C z)     (is-covariant-yoneda-domain A is-segal-A C is-covariant-C) ϕ))
+    (evid A b C
+      (covariant-transport A a b f
+        ( \ x -> (z : A) → hom A x z → C z)
+        ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C) ϕ))
   :=
     naturality-covariant-fiberwise-transformation
     ( A)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -79,7 +79,7 @@ representable functor at the identity arrow.
   (a : A)
   (C : A → U)
   : ((z : A) → hom A a z → C z) → C a
-  := \ ϕ → ϕ a (id-arr A a)
+  := \ ϕ → ϕ a (id-hom A a)
 ```
 
 The inverse map only exists for Segal types.
@@ -139,14 +139,14 @@ The composite `#!rzk yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
     concat
       ( C x)
       ( ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f)
-      ( ϕ x (comp-Segal A is-segal-A a a x (id-arr A a) f))
+      ( ϕ x (comp-Segal A is-segal-A a a x (id-hom A a) f))
       ( ϕ x f)
       ( naturality-covariant-fiberwise-representable-transformation
-        A is-segal-A a a x (id-arr A a) f C is-covariant-C ϕ )
+        A is-segal-A a a x (id-hom A a) f C is-covariant-C ϕ )
       ( ap
         ( hom A a x)
         ( C x)
-        ( comp-Segal A is-segal-A a a x (id-arr A a) f)
+        ( comp-Segal A is-segal-A a a x (id-hom A a) f)
         ( f)
         ( ϕ x)
         ( id-comp-Segal A is-segal-A a x f))
@@ -353,7 +353,7 @@ a representable functor at the identity arrow.
   (a : A)
   (C : A → U)
   : ( (z : A) → hom A z a → C z) → C a
-  := \ ϕ → ϕ a (id-arr A a)
+  := \ ϕ → ϕ a (id-hom A a)
 ```
 
 The inverse map only exists for Segal types and contravariant families.
@@ -413,14 +413,14 @@ The composite `#!rzk contra-yon-evid` of `#!rzk ϕ` equals `#!rzk ϕ` at all
       ( C x)
       ( ((contra-yon A is-segal-A a C is-contravariant-C)
             ((contra-evid A a C) ϕ )) x f)
-      ( ϕ x (comp-Segal A is-segal-A x a a f (id-arr A a)))
+      ( ϕ x (comp-Segal A is-segal-A x a a f (id-hom A a)))
       ( ϕ x f)
       ( naturality-contravariant-fiberwise-representable-transformation
-          A is-segal-A a x a (id-arr A a) f C is-contravariant-C ϕ )
+          A is-segal-A a x a (id-hom A a) f C is-contravariant-C ϕ )
       ( ap
         ( hom A x a)
         ( C x)
-        ( comp-Segal A is-segal-A x a a f (id-arr A a))
+        ( comp-Segal A is-segal-A x a a f (id-hom A a))
         ( f)
         ( ϕ x)
         ( comp-id-Segal A is-segal-A x a f))
@@ -625,8 +625,8 @@ Initial objects satisfy an induction principle relative to covariant families.
   := contraction-center (hom A a x) (is-initial-a x)
 
 #def identity-component-arrows-from-initial
-  : arrows-from-initial a = id-arr A a
-  := contracting-htpy (hom A a a) (is-initial-a a) (id-arr A a)
+  : arrows-from-initial a = id-hom A a
+  := contracting-htpy (hom A a a) (is-initial-a a) (id-hom A a)
 
 #def ind-initial uses (is-initial-a)
   (u : C a)
@@ -644,13 +644,13 @@ Initial objects satisfy an induction principle relative to covariant families.
           ( covariant-transport A a a
             ( arrows-from-initial a) C is-covariant-C u)
           ( covariant-transport A a a
-            ( id-arr A a) C is-covariant-C u)
+            ( id-hom A a) C is-covariant-C u)
           ( u)
           ( ap
             ( hom A a a)
             ( C a)
             ( arrows-from-initial a)
-            ( id-arr A a)
+            ( id-hom A a)
             ( \ f →
               covariant-transport A a a f C is-covariant-C u)
             ( identity-component-arrows-from-initial))
@@ -720,8 +720,8 @@ given by the identity arrow at $a$. This makes use of the following equivalence.
   (a x : A)
   (f : hom A a x)
   : Equiv
-    ( hom (coslice A a) (a, id-arr A a) (x, f))
-    ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
+    ( hom (coslice A a) (a, id-hom A a) (x, f))
+    ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
   :=
     ( \ h t s → (second (h s)) t,
       (( \ k s → ( k 1₂ s, \ t → k t s),
@@ -739,7 +739,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A a x)
-  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
   :=
     ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
                 A (\ z → hom A a z)))
@@ -747,22 +747,22 @@ contractible.
       ( a)
       ( x)
       ( f)
-      ( id-arr A a)
+      ( id-hom A a)
 ```
 
 This proves the initiality of identity arrows in the coslice of a Segal type.
 
 ```rzk title="RS17, Lemma 9.8"
-#def is-initial-id-arr-is-segal
+#def is-initial-id-hom-is-segal
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  : is-initial (coslice A a) (a, id-arr A a)
+  : is-initial (coslice A a) (a, id-hom A a)
   :=
     \ (x, f) →
     is-contr-is-equiv-to-contr
-      ( hom (coslice A a) (a, id-arr A a) (x, f))
-      ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-arr A a])
+      ( hom (coslice A a) (a, id-hom A a) (x, f))
+      ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
       ( equiv-hom-in-coslice A a x f)
       ( is-contr-is-segal-hom-in-coslice A is-segal-A a x f)
 ```
@@ -776,8 +776,8 @@ The dependent Yoneda lemma now follows by specializing these results.
   (A : U)
   (a : A)
   (C : (coslice A a) → U)
-  : ((p : coslice A a) → C p) → C (a, id-arr A a)
-  := \ s → s (a, id-arr A a)
+  : ((p : coslice A a) → C p) → C (a, id-hom A a)
+  := \ s → s (a, id-hom A a)
 
 #def dependent-yoneda-lemma' uses (funext)
   (A : U)
@@ -787,13 +787,13 @@ The dependent Yoneda lemma now follows by specializing these results.
   (is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
       ( (p : coslice A a) → C p)
-      ( C (a, id-arr A a))
+      ( C (a, id-hom A a))
       ( dependent-ev-id A a C)
   :=
     is-equiv-covariant-ev-initial
       ( coslice A a)
-      ( (a, id-arr A a))
-      ( is-initial-id-arr-is-segal A is-segal-A a)
+      ( (a, id-hom A a))
+      ( is-initial-id-hom-is-segal A is-segal-A a)
       ( C)
       ( is-covariant-C)
 ```
@@ -810,16 +810,16 @@ an equivalent type in the domain of the evaluation map.
   (is-covariant-C : is-covariant (coslice A a) C)
   : is-equiv
       ( (x : A) → (f : hom A a x) → C (x, f))
-      ( C (a, id-arr A a))
-      ( \ s → s a (id-arr A a))
+      ( C (a, id-hom A a))
+      ( \ s → s a (id-hom A a))
   :=
     is-equiv-left-factor
       ( (p : coslice A a) → C p)
       ( (x : A) → (f : hom A a x) → C (x, f))
-      ( C (a, id-arr A a))
+      ( C (a, id-hom A a))
       ( first (equiv-dependent-curry A (\ z → hom A a z)(\ x f → C (x, f))))
       ( second (equiv-dependent-curry A (\ z → hom A a z)(\ x f → C (x, f))))
-      ( \ s → s a (id-arr A a))
+      ( \ s → s a (id-hom A a))
       ( dependent-yoneda-lemma' A is-segal-A a C is-covariant-C)
 ```
 
@@ -853,8 +853,8 @@ Final objects satisfy an induction principle relative to contravariant families.
   := contraction-center (hom A x a) (is-final-a x)
 
 #def identity-component-arrows-to-final
-  : arrows-to-final a = id-arr A a
-  := contracting-htpy (hom A a a) (is-final-a a) (id-arr A a)
+  : arrows-to-final a = id-hom A a
+  := contracting-htpy (hom A a a) (is-final-a a) (id-hom A a)
 
 #def ind-final uses (is-final-a)
   (u : C a)
@@ -873,13 +873,13 @@ Final objects satisfy an induction principle relative to contravariant families.
           ( contravariant-transport A a a
             ( arrows-to-final a) C is-contravariant-C u)
           ( contravariant-transport A a a
-            ( id-arr A a) C is-contravariant-C u)
+            ( id-hom A a) C is-contravariant-C u)
           ( u)
           ( ap
             ( hom A a a)
             ( C a)
             ( arrows-to-final a)
-            ( id-arr A a)
+            ( id-hom A a)
             ( \ f →
               contravariant-transport A a a f C is-contravariant-C u)
             ( identity-component-arrows-to-final))
@@ -949,8 +949,8 @@ by the identity arrow at $a$. This makes use of the following equivalence.
   (a x : A)
   (f : hom A x a)
   : Equiv
-    ( hom (slice A a) (x, f) (a, id-arr A a))
-    ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
+    ( hom (slice A a) (x, f) (a, id-hom A a))
+    ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
   :=
     ( \ h t s → (second (h s)) t,
       (( \ k s → ( k 0₂ s, \ t → k t s),
@@ -968,7 +968,7 @@ contractible.
   (is-segal-A : is-segal A)
   (a x : A)
   (f : hom A x a)
-  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
+  : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
   :=
     ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
                 A (\ z → hom A z a)))
@@ -976,22 +976,22 @@ contractible.
       ( x)
       ( a)
       ( f)
-      ( id-arr A a)
+      ( id-hom A a)
 ```
 
 This proves the finality of identity arrows in the slice of a Segal type.
 
 ```rzk title="RS17, Lemma 9.8, dual"
-#def is-final-id-arr-is-segal
+#def is-final-id-hom-is-segal
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
-  : is-final (slice A a) (a, id-arr A a)
+  : is-final (slice A a) (a, id-hom A a)
   :=
     \ (x, f) →
     is-contr-is-equiv-to-contr
-      ( hom (slice A a) (x, f) (a, id-arr A a))
-      ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-arr A a])
+      ( hom (slice A a) (x, f) (a, id-hom A a))
+      ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
       ( equiv-hom-in-slice A a x f)
       ( is-contr-is-segal-hom-in-slice A is-segal-A a x f)
 ```
@@ -1006,8 +1006,8 @@ specializing these results.
   (A : U)
   (a : A)
   (C : (slice A a) → U)
-  : ((p : slice A a) → C p) → C (a, id-arr A a)
-  := \ s → s (a, id-arr A a)
+  : ((p : slice A a) → C p) → C (a, id-hom A a)
+  := \ s → s (a, id-hom A a)
 
 #def contra-dependent-yoneda-lemma' uses (funext)
   (A : U)
@@ -1017,13 +1017,13 @@ specializing these results.
   (is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
       ( (p : slice A a) → C p)
-      ( C (a, id-arr A a))
+      ( C (a, id-hom A a))
       ( contra-dependent-ev-id A a C)
   :=
     is-equiv-contravariant-ev-final
       ( slice A a)
-      ( (a, id-arr A a))
-      ( is-final-id-arr-is-segal A is-segal-A a)
+      ( (a, id-hom A a))
+      ( is-final-id-hom-is-segal A is-segal-A a)
       ( C)
       ( is-contravariant-C)
 ```
@@ -1040,16 +1040,16 @@ proven, just with an equivalent type in the domain of the evaluation map.
   (is-contravariant-C : is-contravariant (slice A a) C)
   : is-equiv
       ( (x : A) → (f : hom A x a) → C (x, f))
-      ( C (a, id-arr A a))
-      ( \ s → s a (id-arr A a))
+      ( C (a, id-hom A a))
+      ( \ s → s a (id-hom A a))
   :=
     is-equiv-left-factor
       ( (p : slice A a) → C p)
       ( (x : A) → (f : hom A x a) → C (x, f))
-      ( C (a, id-arr A a))
+      ( C (a, id-hom A a))
       ( first (equiv-dependent-curry A (\ z → hom A z a)(\ x f → C (x, f))))
       ( second (equiv-dependent-curry A (\ z → hom A z a)(\ x f → C (x, f))))
-      ( \ s → s a (id-arr A a))
+      ( \ s → s a (id-hom A a))
       ( contra-dependent-yoneda-lemma'
           A is-segal-A a C is-contravariant-C)
 ```

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -808,7 +808,7 @@ an equivalent type in the domain of the evaluation map.
       ( C (a, id-arr A a))
       ( \ s → s a (id-arr A a))
   :=
-    LeftCancel-is-equiv
+    is-equiv-left-factor
       ( (p : coslice A a) → C p)
       ( (x : A) → (f : hom A a x) → C (x, f))
       ( C (a, id-arr A a))
@@ -1038,7 +1038,7 @@ proven, just with an equivalent type in the domain of the evaluation map.
       ( C (a, id-arr A a))
       ( \ s → s a (id-arr A a))
   :=
-    LeftCancel-is-equiv
+    is-equiv-left-factor
       ( (p : slice A a) → C p)
       ( (x : A) → (f : hom A x a) → C (x, f))
       ( C (a, id-arr A a))

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -222,8 +222,8 @@ Naturality in $C$ is not automatic but can be proven easily:
   (C D : A → U)
   (ψ : (z : A) → C z → D z)
   (φ : (z : A) → hom A a z → C z)
-  : (composition ((z : A) → hom A a z → C z) (C a) (D a) (ψ a) (evid A a C)) φ =
-    (composition ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z) (D a)
+  : (comp ((z : A) → hom A a z → C z) (C a) (D a) (ψ a) (evid A a C)) φ =
+    (comp ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z) (D a)
     (evid A a D) ( \ α z g → ψ z (α z g))) φ
   := refl
 ```
@@ -240,9 +240,9 @@ Naturality in $C$ is not automatic but can be proven easily:
   (u : C a)
   (x : A)
   (f : hom A a x)
-  : (composition (C a) (D a) ((z : A) → hom A a z → D z)
+  : (comp (C a) (D a) ((z : A) → hom A a z → D z)
       (yon A is-segal-A a D is-covariant-D) (ψ a)) u x f =
-    (composition (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+    (comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       (\ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x f
   := naturality-covariant-fiberwise-transformation
       A a x f C D is-covariant-C is-covariant-D ψ u
@@ -257,19 +257,19 @@ Naturality in $C$ is not automatic but can be proven easily:
   (ψ : (z : A) → C z → D z)
   (u : C a)
   (x : A)
-  : (composition (C a) (D a) ((z : A) → hom A a z → D z)
+  : (comp (C a) (D a) ((z : A) → hom A a z → D z)
       (yon A is-segal-A a D is-covariant-D) (ψ a)) u x =
-    (composition (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+    (comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       (\ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x
   :=
     eq-htpy funext
       ( hom A a x)
       ( \ f → D x)
       ( \ f →
-        ( composition (C a) (D a) ((z : A) → hom A a z → D z)
+        ( comp (C a) (D a) ((z : A) → hom A a z → D z)
           ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x f)
       ( \ f →
-        ( composition (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
+        ( comp (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x f)
       ( \ f →
         is-natural-yon-twice-pointwise
@@ -284,19 +284,19 @@ Naturality in $C$ is not automatic but can be proven easily:
   (is-covariant-D : is-covariant A D)
   (ψ : (z : A) → C z → D z)
   (u : C a)
-  : (composition (C a) (D a) ((z : A) → hom A a z → D z)
+  : (comp (C a) (D a) ((z : A) → hom A a z → D z)
       (yon A is-segal-A a D is-covariant-D) (ψ a)) u =
-    (composition (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
+    (comp (C a) ((z : A) → hom A a z → C z) ((z : A) → hom A a z → D z)
       (\ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u
   :=
     eq-htpy funext
       ( A )
       ( \ x → hom A a x → D x)
       ( \ x →
-        ( composition (C a) (D a) ((z : A) → hom A a z → D z)
+        ( comp (C a) (D a) ((z : A) → hom A a z → D z)
           ( yon A is-segal-A a D is-covariant-D) (ψ a)) u x)
       ( \ x →
-        ( composition (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
+        ( comp (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x)
       ( \ x →
         is-natural-yon-once-pointwise
@@ -497,9 +497,9 @@ Naturality in $C$ is not automatic but can be proven easily:
   (C D : A → U)
   (ψ : (z : A) → C z → D z)
   (φ : (z : A) → hom A z a → C z)
-  : (composition ((z : A) → hom A z a → C z) (C a) (D a)
+  : (comp ((z : A) → hom A z a → C z) (C a) (D a)
       (ψ a) (contra-evid A a C)) φ =
-    (composition ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z) (D a)
+    (comp ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z) (D a)
       (contra-evid A a D) ( \ α z g → ψ z (α z g))) φ
   := refl
 ```
@@ -516,9 +516,9 @@ Naturality in $C$ is not automatic but can be proven easily:
   (u : C a)
   (x : A)
   (f : hom A x a)
-  : (composition (C a) (D a) ((z : A) → hom A z a → D z)
+  : (comp (C a) (D a) ((z : A) → hom A z a → D z)
       (contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x f =
-    (composition (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+    (comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
       (\ α z g → ψ z (α z g))
       (contra-yon A is-segal-A a C is-contravariant-C)) u x f
   := naturality-contravariant-fiberwise-transformation
@@ -534,9 +534,9 @@ Naturality in $C$ is not automatic but can be proven easily:
   (ψ : (z : A) → C z → D z)
   (u : C a)
   (x : A)
-  : (composition (C a) (D a) ((z : A) → hom A z a → D z)
+  : (comp (C a) (D a) ((z : A) → hom A z a → D z)
       (contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x =
-    (composition (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+    (comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
       (\ α z g → ψ z (α z g))
       (contra-yon A is-segal-A a C is-contravariant-C)) u x
   :=
@@ -544,10 +544,10 @@ Naturality in $C$ is not automatic but can be proven easily:
       ( hom A x a)
       ( \ f → D x)
       ( \ f →
-        ( composition (C a) (D a) ((z : A) → hom A z a → D z)
+        ( comp (C a) (D a) ((z : A) → hom A z a → D z)
           ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x f)
       ( \ f →
-        ( composition (C a)((z : A) → hom A z a → C z)((z : A) → hom A z a → D z)
+        ( comp (C a)((z : A) → hom A z a → C z)((z : A) → hom A z a → D z)
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x f)
       ( \ f →
@@ -563,9 +563,9 @@ Naturality in $C$ is not automatic but can be proven easily:
   (is-contravariant-D : is-contravariant A D)
   (ψ : (z : A) → C z → D z)
   (u : C a)
-  : (composition (C a) (D a) ((z : A) → hom A z a → D z)
+  : (comp (C a) (D a) ((z : A) → hom A z a → D z)
       (contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u =
-    (composition (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
+    (comp (C a) ((z : A) → hom A z a → C z) ((z : A) → hom A z a → D z)
       (\ α z g → ψ z (α z g))
       (contra-yon A is-segal-A a C is-contravariant-C)) u
   :=
@@ -573,10 +573,10 @@ Naturality in $C$ is not automatic but can be proven easily:
       ( A )
       ( \ x → hom A x a → D x)
       ( \ x →
-        ( composition (C a) (D a) ((z : A) → hom A z a → D z)
+        ( comp (C a) (D a) ((z : A) → hom A z a → D z)
           ( contra-yon A is-segal-A a D is-contravariant-D) (ψ a)) u x)
       ( \ x →
-        ( composition (C a)((z : A) → hom A z a → C z)((z : A) → hom A z a → D z)
+        ( comp (C a)((z : A) → hom A z a → C z)((z : A) → hom A z a → D z)
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x)
       ( \ x →

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -19,10 +19,12 @@ This is a literate `rzk` file:
 - `5-segal-types.md` - We make heavy use of the notion of Segal types
 - `8-covariant.md` - We use covariant type families.
 
-Some of the definitions in this file rely on function extensionality:
+Some of the definitions in this file rely on function extensionality and
+extension extensionality:
 
 ```rzk
 #assume funext : FunExt
+#assume extext : ExtExt
 ```
 
 ## Natural transformations involving a representable functor
@@ -213,13 +215,80 @@ The equivalence of the Yoneda lemma is natural in both $a : A$ and $C : A → U$
 
 Naturality in $a$ follows from the fact that the maps `#!rzk evid` and
 `#!rzk yon` are fiberwise equivalences between covariant families over $A$,
-though it requires some work, which has not yet been formalized, to prove that
-the domain is covariant.
+though it requires some work to prove that the domain is covariant.
+
+```rzk
+#def is-covariant-yoneda-domain uses (funext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (C : A → U)
+  (is-covariant-C : is-covariant A C)
+  : is-covariant A (\ a → (z : A) → hom A a z → C z)
+  :=
+    equiv-is-covariant
+    ( extext)
+    ( A)
+    ( \ a -> (z : A) → hom A a z → C z)
+    ( C)
+    ( \ a -> (evid A a C, Yoneda-lemma A is-segal-A a C is-covariant-C))
+    ( is-covariant-C)
+
+#def is-natural-in-object-evid uses (funext extext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a b : A)
+  (f : hom A a b)
+  (C : A -> U)
+  (is-covariant-C : is-covariant A C)
+  (ϕ : (z : A) → hom A a z → C z)
+  : (covariant-transport A a b f C is-covariant-C (evid A a C ϕ)) =
+    (evid A b C (covariant-transport A a b f ( \ x -> (z : A) → hom A x z → C z)     (is-covariant-yoneda-domain A is-segal-A C is-covariant-C) ϕ))
+  :=
+    naturality-covariant-fiberwise-transformation
+    ( A)
+    ( a)
+    ( b)
+    ( f)
+    ( \ x -> (z : A) → hom A x z → C z)
+    ( C)
+    ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+    ( is-covariant-C)
+    ( \ x -> evid A x C)
+    ( ϕ)
+
+#def is-natural-in-object-yon uses (funext extext)
+  (A : U)
+  (is-segal-A : is-segal A)
+  (a b : A)
+  (f : hom A a b)
+  (C : A -> U)
+  (is-covariant-C : is-covariant A C)
+  (u : C a)
+  : ( covariant-transport
+      A a b f
+      ( \ x -> (z : A) → hom A x z → C z)
+      ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+      ( yon A is-segal-A a C is-covariant-C u)) =
+    ( yon A is-segal-A b C is-covariant-C
+      ( covariant-transport A a b f C is-covariant-C u))
+  :=
+    naturality-covariant-fiberwise-transformation
+    ( A)
+    ( a)
+    ( b)
+    ( f)
+    ( C)
+    ( \ x -> (z : A) → hom A x z → C z)
+    ( is-covariant-C)
+    ( is-covariant-yoneda-domain A is-segal-A C is-covariant-C)
+    ( \ x -> yon A is-segal-A x C is-covariant-C)
+    ( u)
+```
 
 Naturality in $C$ is not automatic but can be proven easily:
 
 ```rzk title="RS17, Lemma 9.2(i)"
-#def is-natural-evid
+#def is-natural-in-family-evid
   (A : U)
   (a : A)
   (C D : A → U)
@@ -232,7 +301,7 @@ Naturality in $C$ is not automatic but can be proven easily:
 ```
 
 ```rzk title="RS17, Lemma 9.2(ii)"
-#def is-natural-yon-twice-pointwise
+#def is-natural-in-family-yon-twice-pointwise
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -250,7 +319,7 @@ Naturality in $C$ is not automatic but can be proven easily:
   := naturality-covariant-fiberwise-transformation
       A a x f C D is-covariant-C is-covariant-D ψ u
 
-#def is-natural-yon-once-pointwise uses (funext)
+#def is-natural-in-family-yon-once-pointwise uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -275,10 +344,10 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( comp (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x f)
       ( \ f →
-        is-natural-yon-twice-pointwise
+        is-natural-in-family-yon-twice-pointwise
           A is-segal-A a C D is-covariant-C is-covariant-D ψ u x f)
 
-#def is-natural-yon uses (funext)
+#def is-natural-in-family-yon uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -302,7 +371,7 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( comp (C a)((z : A) → hom A a z → C z)((z : A) → hom A a z → D z)
         ( \ α z g → ψ z (α z g)) (yon A is-segal-A a C is-covariant-C)) u x)
       ( \ x →
-        is-natural-yon-once-pointwise
+        is-natural-in-family-yon-once-pointwise
           A is-segal-A a C D is-covariant-C is-covariant-D ψ u x)
 ```
 
@@ -496,7 +565,7 @@ the domain is contravariant.
 Naturality in $C$ is not automatic but can be proven easily:
 
 ```rzk title="RS17, Lemma 9.2(i), dual"
-#def is-natural-contra-evid
+#def is-natural-in-family-contra-evid
   (A : U)
   (a : A)
   (C D : A → U)
@@ -510,7 +579,7 @@ Naturality in $C$ is not automatic but can be proven easily:
 ```
 
 ```rzk title="RS17, Lemma 9.2(ii), dual"
-#def is-natural-contra-yon-twice-pointwise
+#def is-natural-in-family-contra-yon-twice-pointwise
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -529,7 +598,7 @@ Naturality in $C$ is not automatic but can be proven easily:
   := naturality-contravariant-fiberwise-transformation
       A x a f C D is-contravariant-C is-contravariant-D ψ u
 
-#def is-natural-contra-yon-once-pointwise uses (funext)
+#def is-natural-in-family-contra-yon-once-pointwise uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -556,10 +625,10 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x f)
       ( \ f →
-        is-natural-contra-yon-twice-pointwise
+        is-natural-in-family-contra-yon-twice-pointwise
           A is-segal-A a C D is-contravariant-C is-contravariant-D ψ u x f)
 
-#def is-natural-contra-yon uses (funext)
+#def is-natural-in-family-contra-yon uses (funext)
   (A : U)
   (is-segal-A : is-segal A)
   (a : A)
@@ -585,7 +654,7 @@ Naturality in $C$ is not automatic but can be proven easily:
         ( \ α z g → ψ z (α z g))
         ( contra-yon A is-segal-A a C is-contravariant-C)) u x)
       ( \ x →
-        is-natural-contra-yon-once-pointwise
+        is-natural-in-family-contra-yon-once-pointwise
           A is-segal-A a C D is-contravariant-C is-contravariant-D ψ u x)
 ```
 
@@ -741,7 +810,7 @@ contractible.
   (f : hom A a x)
   : is-contr ( (t : Δ¹) → hom A a (f t) [t ≡ 0₂ ↦ id-hom A a])
   :=
-    ( second (has-unique-lifts-with-fixed-domain-iff-is-covariant
+    ( second (has-unique-fixed-domain-lifts-iff-is-covariant
                 A (\ z → hom A a z)))
       ( is-segal-representable-is-covariant A is-segal-A a)
       ( a)
@@ -970,7 +1039,7 @@ contractible.
   (f : hom A x a)
   : is-contr ( (t : Δ¹) → hom A (f t) a [t ≡ 1₂ ↦ id-hom A a])
   :=
-    ( second (has-unique-lifts-with-fixed-codomain-iff-is-contravariant
+    ( second (has-unique-fixed-codomain-lifts-iff-is-contravariant
                 A (\ z → hom A z a)))
       ( is-segal-representable-is-contravariant A is-segal-A a)
       ( x)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -772,7 +772,7 @@ This proves the initiality of identity arrows in the coslice of a Segal type.
 The dependent Yoneda lemma now follows by specializing these results.
 
 ```rzk
-#def dependent-ev-id
+#def dependent-evid
   (A : U)
   (a : A)
   (C : (coslice A a) → U)
@@ -788,7 +788,7 @@ The dependent Yoneda lemma now follows by specializing these results.
   : is-equiv
       ( (p : coslice A a) → C p)
       ( C (a, id-hom A a))
-      ( dependent-ev-id A a C)
+      ( dependent-evid A a C)
   :=
     is-equiv-covariant-ev-initial
       ( coslice A a)
@@ -1002,7 +1002,7 @@ The contravariant version of the dependent Yoneda lemma now follows by
 specializing these results.
 
 ```rzk
-#def contra-dependent-ev-id
+#def contra-dependent-evid
   (A : U)
   (a : A)
   (C : (slice A a) → U)
@@ -1018,7 +1018,7 @@ specializing these results.
   : is-equiv
       ( (p : slice A a) → C p)
       ( C (a, id-hom A a))
-      ( contra-dependent-ev-id A a C)
+      ( contra-dependent-evid A a C)
   :=
     is-equiv-contravariant-ev-final
       ( slice A a)

--- a/src/simplicial-hott/09-yoneda.rzk.md
+++ b/src/simplicial-hott/09-yoneda.rzk.md
@@ -49,7 +49,7 @@ naturality-covariant-fiberwise-transformation naturality is automatic.
   (is-covariant-C : is-covariant A C)
   (ϕ : (z : A) → hom A a z → C z)
   : (covariant-transport A x y g C is-covariant-C (ϕ x f)) =
-    (ϕ y (Segal-comp A is-segal-A a x y f g))
+    (ϕ y (comp-Segal A is-segal-A a x y f g))
   :=
     naturality-covariant-fiberwise-transformation A x y g
       (\ z → hom A a z)
@@ -138,17 +138,17 @@ The composite `yon-evid` of `ϕ` equals `ϕ` at all `x : A` and `f : hom A a x`.
     concat
       ( C x)
       ( ((yon A is-segal-A a C is-covariant-C) ((evid A a C) ϕ )) x f)
-      ( ϕ x (Segal-comp A is-segal-A a a x (id-arr A a) f))
+      ( ϕ x (comp-Segal A is-segal-A a a x (id-arr A a) f))
       ( ϕ x f)
       ( naturality-covariant-fiberwise-representable-transformation
         A is-segal-A a a x (id-arr A a) f C is-covariant-C ϕ )
       ( ap
         ( hom A a x)
         ( C x)
-        ( Segal-comp A is-segal-A a a x (id-arr A a) f)
+        ( comp-Segal A is-segal-A a a x (id-arr A a) f)
         ( f)
         ( ϕ x)
-        ( Segal-id-comp A is-segal-A a x f))
+        ( id-comp-Segal A is-segal-A a x f))
 ```
 
 By `funext`, these are equals as functions of `f` pointwise in `x`.
@@ -323,7 +323,7 @@ automatic.
   (is-contravariant-C : is-contravariant A C)
   (ϕ : (z : A) → hom A z a → C z)
   : (contravariant-transport A x y g C is-contravariant-C (ϕ y f)) =
-    (ϕ x (Segal-comp A is-segal-A x y a g f))
+    (ϕ x (comp-Segal A is-segal-A x y a g f))
   :=
     naturality-contravariant-fiberwise-transformation A x y g
       ( \ z → hom A z a) C
@@ -410,17 +410,17 @@ The composite `contra-yon-evid` of `ϕ` equals `ϕ` at all `x : A` and
       ( C x)
       ( ((contra-yon A is-segal-A a C is-contravariant-C)
             ((contra-evid A a C) ϕ )) x f)
-      ( ϕ x (Segal-comp A is-segal-A x a a f (id-arr A a)))
+      ( ϕ x (comp-Segal A is-segal-A x a a f (id-arr A a)))
       ( ϕ x f)
       ( naturality-contravariant-fiberwise-representable-transformation
           A is-segal-A a x a (id-arr A a) f C is-contravariant-C ϕ )
       ( ap
         ( hom A x a)
         ( C x)
-        ( Segal-comp A is-segal-A x a a f (id-arr A a))
+        ( comp-Segal A is-segal-A x a a f (id-arr A a))
         ( f)
         ( ϕ x)
-        ( Segal-comp-id A is-segal-A x a f))
+        ( comp-id-Segal A is-segal-A x a f))
 ```
 
 By `funext`, these are equals as functions of `f` pointwise in `x`.

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -22,7 +22,7 @@ Some of the definitions in this file rely on extension extensionality:
     (f : hom A x y)
     (g : hom A y x)
     : U
-    := (comp-Segal A is-segal-A x y x f g) =_{hom A x x} (id-arr A x)
+    := (comp-Segal A is-segal-A x y x f g) =_{hom A x x} (id-hom A x)
 
 #def arrow-Retraction
     (A : U)
@@ -39,7 +39,7 @@ Some of the definitions in this file rely on extension extensionality:
     (f : hom A x y)
     (h : hom A y x)
     : U
-    := (comp-Segal A is-segal-A y x y h f) =_{hom A y y} (id-arr A y)
+    := (comp-Segal A is-segal-A y x y h f) =_{hom A y y} (id-hom A y)
 
 #def arrow-Section
     (A : U)
@@ -92,27 +92,27 @@ Some of the definitions in this file rely on extension extensionality:
             (hom A y y)
             (comp-Segal A is-segal-A y x y g f)
             (comp-Segal A is-segal-A y x y h f)
-            (id-arr A y)
+            (id-hom A y)
             (postwhisker-homotopy-Segal A is-segal-A y x y g h f
                 (alternating-quintuple-concat (hom A y x)
-                g (comp-Segal A is-segal-A y y x (id-arr A y) g) -- a0 = g and a1 = g o id_y
-                (rev (hom A y x) (comp-Segal A is-segal-A y y x (id-arr A y) g) g (id-comp-Segal A is-segal-A y x g)) -- p1 = identity law
+                g (comp-Segal A is-segal-A y y x (id-hom A y) g) -- a0 = g and a1 = g o id_y
+                (rev (hom A y x) (comp-Segal A is-segal-A y y x (id-hom A y) g) g (id-comp-Segal A is-segal-A y x g)) -- p1 = identity law
 
                 (comp-Segal A is-segal-A y y x (comp-Segal A is-segal-A y x y h f) g) -- a2 = g o (f o h)
                 (postwhisker-homotopy-Segal A is-segal-A y y x                      -- p2 = postwhiskering
-        (id-arr A y)
+        (id-hom A y)
         (comp-Segal A is-segal-A y x y h f)
         g
-        (rev (hom A y y) (comp-Segal A is-segal-A y x y h f) (id-arr A y) q)
+        (rev (hom A y y) (comp-Segal A is-segal-A y x y h f) (id-hom A y) q)
                 )
 
                 (comp-Segal A is-segal-A y x x h (comp-Segal A is-segal-A x y x f g)) -- a3 = (g o f) o h
                 (associativity-Segal extext A is-segal-A y x y x h f g)             -- p3 = associativity
 
-                (comp-Segal A is-segal-A y x x h (id-arr A x)) -- a4 = id_x o h
+                (comp-Segal A is-segal-A y x x h (id-hom A x)) -- a4 = id_x o h
                 (prewhisker-homotopy-Segal A is-segal-A y x x h -- p4 = prewhiskering
                 (comp-Segal A is-segal-A x y x f g)
-                (id-arr A x)
+                (id-hom A x)
                 p)
                 h -- a5 = h
                 (comp-id-Segal A is-segal-A y x h) -- p5 = connect through identity law
@@ -148,10 +148,10 @@ Some of the definitions in this file rely on extension extensionality:
         (hom A z x) -- k is an arrow z → x
         (comp-Segal A is-segal-A z y x (comp-Segal A is-segal-A z x y k f) g) -- g(fk)
         (comp-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g)) -- (gf)k
-        (comp-Segal A is-segal-A z x x k (id-arr A x)) -- id_x k
+        (comp-Segal A is-segal-A z x x k (id-hom A x)) -- id_x k
         k --k
       (associativity-Segal extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
-      (prewhisker-homotopy-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
+      (prewhisker-homotopy-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-hom A x) gg)  -- (gf)k = id_x k from (gf) = id_x
       (comp-id-Segal A is-segal-A z x k) -- id_x k = k
       )
   )
@@ -172,10 +172,10 @@ Some of the definitions in this file rely on extension extensionality:
         (hom A z y) -- k is an arrow z to y
         (comp-Segal A is-segal-A z x y (comp-Segal A is-segal-A z y x k h) f) -- f(hk)
         (comp-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f)) -- (fh)k
-        (comp-Segal A is-segal-A z y y k (id-arr A y)) -- id_y k
+        (comp-Segal A is-segal-A z y y k (id-hom A y)) -- id_y k
         k --k
       (associativity-Segal extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
-      (prewhisker-homotopy-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
+      (prewhisker-homotopy-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-hom A y) hh)  -- (fh)k = id_y k from (fh) = id_y
       (comp-id-Segal A is-segal-A z y k) -- id_y k = k
       )
   )
@@ -211,7 +211,7 @@ Some of the definitions in this file rely on extension extensionality:
         (hom A y z) -- k is an arrow y → z
         (comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k)) -- (kf)h
         (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k) -- k(fh)
-        (comp-Segal A is-segal-A y y z (id-arr A y) k) -- k id_y
+        (comp-Segal A is-segal-A y y z (id-hom A y) k) -- k id_y
         k --k
       (rev (hom A y z)
           (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k)
@@ -219,7 +219,7 @@ Some of the definitions in this file rely on extension extensionality:
           (associativity-Segal extext A is-segal-A y x y z h f k)
       ) -- (kf)h = k(fh)
 
-      (postwhisker-homotopy-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
+      (postwhisker-homotopy-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-hom A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
       (id-comp-Segal A is-segal-A y z k) -- k id_y = k
       )
   )
@@ -240,14 +240,14 @@ Some of the definitions in this file rely on extension extensionality:
         (hom A x z) -- k is an arrow x → z
         (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k)) -- (kg)f
         (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k) -- k(gf)
-        (comp-Segal A is-segal-A x x z (id-arr A x) k) -- k id_x
+        (comp-Segal A is-segal-A x x z (id-hom A x) k) -- k id_x
         k --k
       (rev (hom A x z)
           (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k)
           (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k))
           (associativity-Segal extext A is-segal-A x y x z f g k)
       ) -- (kg)f = k(gf)
-      (postwhisker-homotopy-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
+      (postwhisker-homotopy-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-hom A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
       (id-comp-Segal A is-segal-A x z k) -- k id_x = k
       )
   )
@@ -279,7 +279,7 @@ Some of the definitions in this file rely on extension extensionality:
   : is-contr (arrow-Retraction A is-segal-A x y f)
   := (is-contr-map-is-equiv (hom A y x) (hom A x x) (precomp-Segal A is-segal-A x y f x)
                           (if-iso-then-precomp-is-equiv A is-segal-A x y f g gg h hh x))
-      (id-arr A x)
+      (id-hom A x)
 
 #def iso-inhabited-implies-hasSec-contr uses (extext)
   (A : U)
@@ -293,7 +293,7 @@ Some of the definitions in this file rely on extension extensionality:
   : is-contr (arrow-Section A is-segal-A x y f)
   := (is-contr-map-is-equiv (hom A y x) (hom A y y) (postcomp-Segal A is-segal-A x y f y)
                           (if-iso-then-postcomp-is-equiv A is-segal-A x y f g gg h hh y))
-      (id-arr A y)
+      (id-hom A y)
 
 #def iso-inhabited-implies-iso-contr uses (extext)
   (A : U)
@@ -328,15 +328,15 @@ Some of the definitions in this file rely on extension extensionality:
   :=
     \ x →
     (
-    (id-arr A x) ,
+    (id-hom A x) ,
     (
     (
-      (id-arr A x) ,
-      (id-comp-Segal A is-segal-A x x (id-arr A x))
+      (id-hom A x) ,
+      (id-comp-Segal A is-segal-A x x (id-hom A x))
     ) ,
     (
-      (id-arr A x) ,
-      (id-comp-Segal A is-segal-A x x (id-arr A x))
+      (id-hom A x) ,
+      (id-comp-Segal A is-segal-A x x (id-hom A x))
     )
       )
   )
@@ -374,7 +374,7 @@ In a Segal type, initial objects are isomorphic.
             ( comp-Segal A is-segal-A a b a
               ( first (ainitial b))
               ( first (binitial a)))
-            ( id-arr A a)) ,
+            ( id-hom A a)) ,
         ( first (binitial a) ,
           contractible-connecting-htpy
             ( hom A b b)
@@ -382,7 +382,7 @@ In a Segal type, initial objects are isomorphic.
             ( comp-Segal A is-segal-A b a b
               ( first (binitial a))
               ( first (ainitial b)))
-            ( id-arr A b))))
+            ( id-hom A b))))
 ```
 
 In a Segal type, final objects are isomorphic.
@@ -405,7 +405,7 @@ In a Segal type, final objects are isomorphic.
             ( comp-Segal A is-segal-A a b a
               ( first (bfinal a))
               ( first (afinal b)))
-            ( id-arr A a)) ,
+            ( id-hom A a)) ,
         ( first (afinal b) ,
           contractible-connecting-htpy
             ( hom A b b)
@@ -413,5 +413,5 @@ In a Segal type, final objects are isomorphic.
             ( comp-Segal A is-segal-A b a b
               ( first (afinal b))
               ( first (bfinal a)))
-            ( id-arr A b))))
+            ( id-hom A b))))
 ```

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -93,13 +93,13 @@ Some of the definitions in this file rely on extension extensionality:
             (comp-Segal A is-segal-A y x y g f)
             (comp-Segal A is-segal-A y x y h f)
             (id-arr A y)
-            (homotopy-postwhisker-Segal A is-segal-A y x y g h f
+            (postwhisker-homotopy-Segal A is-segal-A y x y g h f
                 (alternating-quintuple-concat (hom A y x)
                 g (comp-Segal A is-segal-A y y x (id-arr A y) g) -- a0 = g and a1 = g o id_y
                 (rev (hom A y x) (comp-Segal A is-segal-A y y x (id-arr A y) g) g (id-comp-Segal A is-segal-A y x g)) -- p1 = identity law
 
                 (comp-Segal A is-segal-A y y x (comp-Segal A is-segal-A y x y h f) g) -- a2 = g o (f o h)
-                (homotopy-postwhisker-Segal A is-segal-A y y x                      -- p2 = postwhiskering
+                (postwhisker-homotopy-Segal A is-segal-A y y x                      -- p2 = postwhiskering
         (id-arr A y)
         (comp-Segal A is-segal-A y x y h f)
         g
@@ -110,7 +110,7 @@ Some of the definitions in this file rely on extension extensionality:
                 (associativity-Segal extext A is-segal-A y x y x h f g)             -- p3 = associativity
 
                 (comp-Segal A is-segal-A y x x h (id-arr A x)) -- a4 = id_x o h
-                (homotopy-prewhisker-Segal A is-segal-A y x x h -- p4 = prewhiskering
+                (prewhisker-homotopy-Segal A is-segal-A y x x h -- p4 = prewhiskering
                 (comp-Segal A is-segal-A x y x f g)
                 (id-arr A x)
                 p)
@@ -151,7 +151,7 @@ Some of the definitions in this file rely on extension extensionality:
         (comp-Segal A is-segal-A z x x k (id-arr A x)) -- id_x k
         k --k
       (associativity-Segal extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
-      (homotopy-prewhisker-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
+      (prewhisker-homotopy-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
       (comp-id-Segal A is-segal-A z x k) -- id_x k = k
       )
   )
@@ -175,7 +175,7 @@ Some of the definitions in this file rely on extension extensionality:
         (comp-Segal A is-segal-A z y y k (id-arr A y)) -- id_y k
         k --k
       (associativity-Segal extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
-      (homotopy-prewhisker-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
+      (prewhisker-homotopy-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
       (comp-id-Segal A is-segal-A z y k) -- id_y k = k
       )
   )
@@ -219,7 +219,7 @@ Some of the definitions in this file rely on extension extensionality:
           (associativity-Segal extext A is-segal-A y x y z h f k)
       ) -- (kf)h = k(fh)
 
-      (homotopy-postwhisker-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
+      (postwhisker-homotopy-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
       (id-comp-Segal A is-segal-A y z k) -- k id_y = k
       )
   )
@@ -247,7 +247,7 @@ Some of the definitions in this file rely on extension extensionality:
           (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k))
           (associativity-Segal extext A is-segal-A x y x z f g k)
       ) -- (kg)f = k(gf)
-      (homotopy-postwhisker-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
+      (postwhisker-homotopy-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
       (id-comp-Segal A is-segal-A x z k) -- k id_x = k
       )
   )

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -12,316 +12,356 @@ Some of the definitions in this file rely on extension extensionality:
 #assume extext : ExtExt
 ```
 
+## Isomorphisms
+
 ```rzk
-#section isomorphisms
+#def has-retraction-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  : U
+  := ( comp-Segal A is-segal-A x y x f g) =_{hom A x x} (id-hom A x)
 
-#def arrow-has-retraction
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    (g : hom A y x)
-    : U
-    := (comp-Segal A is-segal-A x y x f g) =_{hom A x x} (id-hom A x)
+#def Retraction-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : U
+  := Σ ( g : hom A y x) , ( has-retraction-arrow A is-segal-A x y f g)
 
-#def arrow-Retraction
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : U
-    := Σ (g : hom A y x) , (arrow-has-retraction A is-segal-A x y f g)
+#def has-section-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( h : hom A y x)
+  : U
+  := ( comp-Segal A is-segal-A y x y h f) =_{hom A y y} (id-hom A y)
 
-#def arrow-has-section
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    (h : hom A y x)
-    : U
-    := (comp-Segal A is-segal-A y x y h f) =_{hom A y y} (id-hom A y)
+#def Section-arrow
+  (A : U)
+  (is-segal-A : is-segal A)
+  (x y : A)
+  (f : hom A x y)
+  : U
+  := Σ (h : hom A y x) , (has-section-arrow A is-segal-A x y f h)
 
-#def arrow-Section
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : U
-    := Σ (h : hom A y x) , (arrow-has-section A is-segal-A x y f h)
-
-#def arrow-is-iso
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : U
-    := product (arrow-Retraction A is-segal-A x y f) (arrow-Section A is-segal-A x y f)
+#def is-iso-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : U
+  :=
+    product
+    ( Retraction-arrow A is-segal-A x y f)
+    ( Section-arrow A is-segal-A x y f)
 
 #def Iso
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    : U
-    := Σ (f : hom A x y) , arrow-is-iso A is-segal-A x y f
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  : U
+  := Σ ( f : hom A x y) , is-iso-arrow A is-segal-A x y f
 
-#def arrow-has-inverse
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : U
-    := Σ (g : hom A y x) , product (arrow-has-retraction A is-segal-A x y f g) (arrow-has-section A is-segal-A x y f g)
+#def has-inverse-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : U
+  :=
+    Σ ( g : hom A y x) ,
+      product
+      ( has-retraction-arrow A is-segal-A x y f g)
+      ( has-section-arrow A is-segal-A x y f g)
 
-#def arrow-inverse-to-iso
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : (arrow-has-inverse A is-segal-A x y f) → (arrow-is-iso A is-segal-A x y f)
-    := (\ (g , (p , q)) → ((g , p) , (g , q)))
+#def is-iso-arrow-has-inverse-arrow
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : ( has-inverse-arrow A is-segal-A x y f) → (is-iso-arrow A is-segal-A x y f)
+  :=
+    ( \ (g , (p , q)) → ((g , p) , (g , q)))
 
-#def arrow-iso-to-inverse uses (extext)
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : (arrow-is-iso A is-segal-A x y f) → (arrow-has-inverse A is-segal-A x y f)
-    := (\ ((g , p) , (h , q))
-        → (g , (p ,
-            (concat
-            (hom A y y)
-            (comp-Segal A is-segal-A y x y g f)
-            (comp-Segal A is-segal-A y x y h f)
-            (id-hom A y)
-            (postwhisker-homotopy-Segal A is-segal-A y x y g h f
-                (alternating-quintuple-concat (hom A y x)
-                g (comp-Segal A is-segal-A y y x (id-hom A y) g) -- a0 = g and a1 = g o id_y
-                (rev (hom A y x) (comp-Segal A is-segal-A y y x (id-hom A y) g) g (id-comp-Segal A is-segal-A y x g)) -- p1 = identity law
+#def has-inverse-arrow-is-iso-arrow uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : (is-iso-arrow A is-segal-A x y f) → (has-inverse-arrow A is-segal-A x y f)
+  :=
+    ( \ ((g , p) , (h , q)) →
+      ( g ,
+        ( p ,
+          ( concat
+            ( hom A y y)
+            ( comp-Segal A is-segal-A y x y g f)
+            ( comp-Segal A is-segal-A y x y h f)
+            ( id-hom A y)
+            ( postwhisker-homotopy-Segal A is-segal-A y x y g h f
+              ( alternating-quintuple-concat
+                ( hom A y x)
+                ( g)
+                ( comp-Segal A is-segal-A y y x (id-hom A y) g)
+                ( rev
+                  ( hom A y x)
+                  ( comp-Segal A is-segal-A y y x (id-hom A y) g)
+                  ( g)
+                  ( id-comp-Segal A is-segal-A y x g))
+                ( comp-Segal A is-segal-A y y x
+                  ( comp-Segal A is-segal-A y x y h f) ( g))
+                ( postwhisker-homotopy-Segal A is-segal-A y y x
+                  ( id-hom A y)
+                  ( comp-Segal A is-segal-A y x y h f)
+                  ( g)
+                  ( rev
+                    ( hom A y y)
+                    ( comp-Segal A is-segal-A y x y h f)
+                    ( id-hom A y)
+                    ( q)))
+                ( comp-Segal A is-segal-A y x x
+                  ( h)
+                  ( comp-Segal A is-segal-A x y x f g))
+                ( associativity-Segal extext A is-segal-A y x y x h f g)
+                ( comp-Segal A is-segal-A y x x h (id-hom A x))
+                ( prewhisker-homotopy-Segal A is-segal-A y x x h
+                  ( comp-Segal A is-segal-A x y x f g)
+                  ( id-hom A x) p)
+                ( h)
+                ( comp-id-Segal A is-segal-A y x h)))
+            ( q)))))
 
-                (comp-Segal A is-segal-A y y x (comp-Segal A is-segal-A y x y h f) g) -- a2 = g o (f o h)
-                (postwhisker-homotopy-Segal A is-segal-A y y x                      -- p2 = postwhiskering
-        (id-hom A y)
-        (comp-Segal A is-segal-A y x y h f)
-        g
-        (rev (hom A y y) (comp-Segal A is-segal-A y x y h f) (id-hom A y) q)
-                )
+#def inverse-iff-iso-arrow uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : iff (has-inverse-arrow A is-segal-A x y f) (is-iso-arrow A is-segal-A x y f)
+  :=
+    ( is-iso-arrow-has-inverse-arrow A is-segal-A x y f ,
+      has-inverse-arrow-is-iso-arrow A is-segal-A x y f)
 
-                (comp-Segal A is-segal-A y x x h (comp-Segal A is-segal-A x y x f g)) -- a3 = (g o f) o h
-                (associativity-Segal extext A is-segal-A y x y x h f g)             -- p3 = associativity
+#def has-retraction-postcomp-has-retraction uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  : ( z : A) →
+    has-retraction (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+  :=
+    \ z →
+    ( ( postcomp-Segal A is-segal-A y x g z) ,
+        \ k →
+      ( triple-concat
+        ( hom A z x)
+        ( comp-Segal A is-segal-A z y x (comp-Segal A is-segal-A z x y k f) g)
+        ( comp-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g))
+        ( comp-Segal A is-segal-A z x x k (id-hom A x))
+        ( k)
+        ( associativity-Segal extext A is-segal-A z x y x k f g)
+        ( prewhisker-homotopy-Segal A is-segal-A z x x k
+          ( comp-Segal A is-segal-A x y x f g) (id-hom A x) gg)
+        ( comp-id-Segal A is-segal-A z x k)))
 
-                (comp-Segal A is-segal-A y x x h (id-hom A x)) -- a4 = id_x o h
-                (prewhisker-homotopy-Segal A is-segal-A y x x h -- p4 = prewhiskering
-                (comp-Segal A is-segal-A x y x f g)
-                (id-hom A x)
-                p)
-                h -- a5 = h
-                (comp-id-Segal A is-segal-A y x h) -- p5 = connect through identity law
-                )
-                )
-            q
-            )
+#def has-section-postcomp-has-section uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : ( z : A) →
+    has-section (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+  :=
+    \ z →
+    ( ( postcomp-Segal A is-segal-A y x h z) ,
+        \ k →
+        ( triple-concat
+          ( hom A z y)
+          ( comp-Segal A is-segal-A z x y (comp-Segal A is-segal-A z y x k h) f)
+          ( comp-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f))
+          ( comp-Segal A is-segal-A z y y k (id-hom A y))
+          ( k)
+          ( associativity-Segal extext A is-segal-A z y x y k h f)
+          ( prewhisker-homotopy-Segal A is-segal-A z y y k
+            ( comp-Segal A is-segal-A y x y h f) (id-hom A y) hh)
+          ( comp-id-Segal A is-segal-A z y k)))
+
+#def is-equiv-postcomp-is-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : (z : A) →
+    is-equiv (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+  :=
+    \ z →
+    ( ( has-retraction-postcomp-has-retraction A is-segal-A x y f g gg z) ,
+      ( has-section-postcomp-has-section A is-segal-A x y f h hh z))
+
+#def has-retraction-precomp-has-section uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : (z : A) →
+    has-retraction (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
+  :=
+    \ z →
+    ( ( precomp-Segal A is-segal-A y x h z) ,
+        \ k →
+        ( triple-concat
+          ( hom A y z)
+          ( comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k))
+          ( comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k)
+          ( comp-Segal A is-segal-A y y z (id-hom A y) k)
+          ( k)
+          ( rev
+            ( hom A y z)
+            ( comp-Segal A is-segal-A y y z
+              ( comp-Segal A is-segal-A y x y h f) k)
+            ( comp-Segal A is-segal-A y x z
+              h (comp-Segal A is-segal-A x y z f k))
+            ( associativity-Segal extext A is-segal-A y x y z h f k))
+          ( postwhisker-homotopy-Segal A is-segal-A y y z
+            ( comp-Segal A is-segal-A y x y h f)
+            ( id-hom A y) k hh)
+          ( id-comp-Segal A is-segal-A y z k)
         )
     )
- )
 
-#def arrow-inverse-iff-iso uses (extext)
-    (A : U)
-    (is-segal-A : is-segal A)
-    (x y : A)
-    (f : hom A x y)
-    : iff (arrow-has-inverse A is-segal-A x y f) (arrow-is-iso A is-segal-A x y f)
-    := (arrow-inverse-to-iso A is-segal-A x y f , arrow-iso-to-inverse A is-segal-A x y f)
-
-#def if-iso-then-postcomp-has-retraction uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) → has-retraction (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+#def has-section-precomp-has-retraction uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  : (z : A) →
+    has-section (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (postcomp-Segal A is-segal-A y x g z) ,
+    ( ( precomp-Segal A is-segal-A y x g z) ,
         \ k →
-      (triple-concat
-        (hom A z x) -- k is an arrow z → x
-        (comp-Segal A is-segal-A z y x (comp-Segal A is-segal-A z x y k f) g) -- g(fk)
-        (comp-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g)) -- (gf)k
-        (comp-Segal A is-segal-A z x x k (id-hom A x)) -- id_x k
-        k --k
-      (associativity-Segal extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
-      (prewhisker-homotopy-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-hom A x) gg)  -- (gf)k = id_x k from (gf) = id_x
-      (comp-id-Segal A is-segal-A z x k) -- id_x k = k
-      )
-  )
+        ( triple-concat
+          ( hom A x z)
+          ( comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k))
+          ( comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k)
+          ( comp-Segal A is-segal-A x x z (id-hom A x) k)
+          ( k)
+          ( rev
+            ( hom A x z)
+            ( comp-Segal A is-segal-A x x z
+              ( comp-Segal A is-segal-A x y x f g) k)
+            ( comp-Segal A is-segal-A x y z
+              f (comp-Segal A is-segal-A y x z g k))
+            ( associativity-Segal extext A is-segal-A x y x z f g k))
+          ( postwhisker-homotopy-Segal A is-segal-A x x z
+            ( comp-Segal A is-segal-A x y x f g)
+            ( id-hom A x)
+            ( k)
+            ( gg))
+          ( id-comp-Segal A is-segal-A x z k)))
 
-#def if-iso-then-postcomp-has-section uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → has-section (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+#def is-equiv-precomp-is-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : (z : A) →
+    is-equiv (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (postcomp-Segal A is-segal-A y x h z) ,
-        \ k →
-      (triple-concat
-        (hom A z y) -- k is an arrow z to y
-        (comp-Segal A is-segal-A z x y (comp-Segal A is-segal-A z y x k h) f) -- f(hk)
-        (comp-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f)) -- (fh)k
-        (comp-Segal A is-segal-A z y y k (id-hom A y)) -- id_y k
-        k --k
-      (associativity-Segal extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
-      (prewhisker-homotopy-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-hom A y) hh)  -- (fh)k = id_y k from (fh) = id_y
-      (comp-id-Segal A is-segal-A z y k) -- id_y k = k
-      )
-  )
+      ( ( has-retraction-precomp-has-section A is-segal-A x y f h hh z) ,
+        ( has-section-precomp-has-retraction A is-segal-A x y f g gg z))
 
-#def if-iso-then-postcomp-is-equiv uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → is-equiv (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
+#def is-contr-Retraction-arrow-is-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : is-contr (Retraction-arrow A is-segal-A x y f)
   :=
-    \ z →
-    ( (if-iso-then-postcomp-has-retraction A is-segal-A x y f g gg z) ,
-      (if-iso-then-postcomp-has-section A is-segal-A x y f h hh z))
+    ( is-contr-map-is-equiv
+      ( hom A y x)
+      ( hom A x x)
+      ( precomp-Segal A is-segal-A x y f x)
+      ( is-equiv-precomp-is-iso A is-segal-A x y f g gg h hh x))
+    ( id-hom A x)
 
-#def if-iso-then-precomp-has-retraction uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → has-retraction (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
+#def is-contr-Section-arrow-is-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : is-contr (Section-arrow A is-segal-A x y f)
   :=
-    \ z →
-    ( (precomp-Segal A is-segal-A y x h z) ,
-        \ k →
-      (triple-concat
-        (hom A y z) -- k is an arrow y → z
-        (comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k)) -- (kf)h
-        (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k) -- k(fh)
-        (comp-Segal A is-segal-A y y z (id-hom A y) k) -- k id_y
-        k --k
-      (rev (hom A y z)
-          (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k)
-          (comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k))
-          (associativity-Segal extext A is-segal-A y x y z h f k)
-      ) -- (kf)h = k(fh)
+    ( is-contr-map-is-equiv
+      ( hom A y x)
+      ( hom A y y)
+      ( postcomp-Segal A is-segal-A x y f y)
+      ( is-equiv-postcomp-is-iso A is-segal-A x y f g gg h hh y))
+    ( id-hom A y)
 
-      (postwhisker-homotopy-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-hom A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
-      (id-comp-Segal A is-segal-A y z k) -- k id_y = k
-      )
-  )
-
-#def if-iso-then-precomp-has-section uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) → has-section (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
+#def is-contr-is-iso-arrow-is-iso uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  ( g : hom A y x)
+  ( gg : has-retraction-arrow A is-segal-A x y f g)
+  ( h : hom A y x)
+  ( hh : has-section-arrow A is-segal-A x y f h)
+  : is-contr (is-iso-arrow A is-segal-A x y f)
   :=
-    \ z →
-    ( (precomp-Segal A is-segal-A y x g z) ,
-        \ k →
-      (triple-concat
-        (hom A x z) -- k is an arrow x → z
-        (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k)) -- (kg)f
-        (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k) -- k(gf)
-        (comp-Segal A is-segal-A x x z (id-hom A x) k) -- k id_x
-        k --k
-      (rev (hom A x z)
-          (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k)
-          (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k))
-          (associativity-Segal extext A is-segal-A x y x z f g k)
-      ) -- (kg)f = k(gf)
-      (postwhisker-homotopy-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-hom A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
-      (id-comp-Segal A is-segal-A x z k) -- k id_x = k
-      )
-  )
+    ( is-contr-product
+      ( Retraction-arrow A is-segal-A x y f)
+      ( Section-arrow A is-segal-A x y f)
+      ( is-contr-Retraction-arrow-is-iso A is-segal-A x y f g gg h hh)
+      ( is-contr-Section-arrow-is-iso A is-segal-A x y f g gg h hh))
 
-#def if-iso-then-precomp-is-equiv uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → is-equiv (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
+#def is-prop-is-iso-arrow uses (extext)
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
+  ( f : hom A x y)
+  : (is-prop (is-iso-arrow A is-segal-A x y f))
   :=
-    \ z →
-    ( (if-iso-then-precomp-has-retraction A is-segal-A x y f h hh z) ,
-    (if-iso-then-precomp-has-section A is-segal-A x y f g gg z))
+    ( is-prop-is-contr-is-inhabited
+      ( is-iso-arrow A is-segal-A x y f)
+      ( \ is-isof →
+        ( is-contr-is-iso-arrow-is-iso A is-segal-A x y f
+          ( first (first is-isof))
+          ( second (first is-isof))
+          ( first (second is-isof))
+          ( second (second is-isof)))))
 
-#def iso-inhabited-implies-hasRetr-contr uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : is-contr (arrow-Retraction A is-segal-A x y f)
-  := (is-contr-map-is-equiv (hom A y x) (hom A x x) (precomp-Segal A is-segal-A x y f x)
-                          (if-iso-then-precomp-is-equiv A is-segal-A x y f g gg h hh x))
-      (id-hom A x)
-
-#def iso-inhabited-implies-hasSec-contr uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : is-contr (arrow-Section A is-segal-A x y f)
-  := (is-contr-map-is-equiv (hom A y x) (hom A y y) (postcomp-Segal A is-segal-A x y f y)
-                          (if-iso-then-postcomp-is-equiv A is-segal-A x y f g gg h hh y))
-      (id-hom A y)
-
-#def iso-inhabited-implies-iso-contr uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-  (g : hom A y x)
-  (gg : arrow-has-retraction A is-segal-A x y f g)
-  (h : hom A y x)
-  (hh : arrow-has-section A is-segal-A x y f h)
-  : is-contr (arrow-is-iso A is-segal-A x y f)
-  := (is-contr-product (arrow-Retraction A is-segal-A x y f) (arrow-Section A is-segal-A x y f)
-      (iso-inhabited-implies-hasRetr-contr A is-segal-A x y f g gg h hh)
-      (iso-inhabited-implies-hasSec-contr A is-segal-A x y f g gg h hh)
-    )
-
-#def iso-is-prop uses (extext)
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
-  (f : hom A x y)
-   : (is-prop (arrow-is-iso A is-segal-A x y f))
-  := (is-prop-is-contr-is-inhabited (arrow-is-iso A is-segal-A x y f)
-      (\ is-isof → (iso-inhabited-implies-iso-contr A is-segal-A x y f (first (first is-isof)) (second (first is-isof))
-        (first (second is-isof)) (second (second is-isof))))
-    )
-
-#def id-iso
+#def iso-id-arrow
   (A : U)
   (is-segal-A : is-segal A)
   : (x : A) → Iso A is-segal-A x x
@@ -341,29 +381,41 @@ Some of the definitions in this file rely on extension extensionality:
       )
   )
 
-#def idtoiso
-  (A : U)
-  (is-segal-A : is-segal A)
-  (x y : A)
+#def iso-id
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( x y : A)
   : (x = y) → Iso A is-segal-A x y
-  := \ p → ind-path (A) (x) (\ y' p' → Iso A is-segal-A x y') ((id-iso A is-segal-A x)) (y) (p)
+  :=
+    \ p →
+    ind-path
+      ( A)
+      ( x)
+      ( \ y' p' → Iso A is-segal-A x y')
+      ( iso-id-arrow A is-segal-A x)
+      ( y)
+      ( p)
 
 #def is-rezk
   (A : U)
   : U
-  := Σ (is-segal-A : is-segal A) , (x : A) → (y : A) → is-equiv (x = y) (Iso A is-segal-A x y) (idtoiso A is-segal-A x y)
-#end isomorphisms
+  :=
+    Σ ( is-segal-A : is-segal A) ,
+      (x : A) → (y : A) →
+        is-equiv (x = y) (Iso A is-segal-A x y) (iso-id A is-segal-A x y)
 ```
+
+## Uniqueness of initial and final objects
 
 In a Segal type, initial objects are isomorphic.
 
 ```rzk
-#def initial-iso
-  (A : U)
-  (is-segal-A : is-segal A)
-  (a b : A)
-  (ainitial : is-initial A a)
-  (binitial : is-initial A b)
+#def iso-initial
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( a b : A)
+  ( ainitial : is-initial A a)
+  ( binitial : is-initial A b)
   : Iso A is-segal-A a b
   :=
     ( first (ainitial b) ,
@@ -388,13 +440,13 @@ In a Segal type, initial objects are isomorphic.
 In a Segal type, final objects are isomorphic.
 
 ```rzk
-#def final-iso
-  (A : U)
-  (is-segal-A : is-segal A)
-  (a b : A)
-  (afinal : is-final A a)
-  (bfinal : is-final A b)
-  (iso : Iso A is-segal-A a b)
+#def iso-final
+  ( A : U)
+  ( is-segal-A : is-segal A)
+  ( a b : A)
+  ( afinal : is-final A a)
+  ( bfinal : is-final A b)
+  ( iso : Iso A is-segal-A a b)
   : Iso A is-segal-A a b
   :=
     ( first (bfinal a) ,

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -22,7 +22,7 @@ Some of the definitions in this file rely on extension extensionality:
     (f : hom A x y)
     (g : hom A y x)
     : U
-    := (Segal-comp A is-segal-A x y x f g) =_{hom A x x} (id-arr A x)
+    := (comp-Segal A is-segal-A x y x f g) =_{hom A x x} (id-arr A x)
 
 #def arrow-Retraction
     (A : U)
@@ -39,7 +39,7 @@ Some of the definitions in this file rely on extension extensionality:
     (f : hom A x y)
     (h : hom A y x)
     : U
-    := (Segal-comp A is-segal-A y x y h f) =_{hom A y y} (id-arr A y)
+    := (comp-Segal A is-segal-A y x y h f) =_{hom A y y} (id-arr A y)
 
 #def arrow-Section
     (A : U)
@@ -90,32 +90,32 @@ Some of the definitions in this file rely on extension extensionality:
         → (g , (p ,
             (concat
             (hom A y y)
-            (Segal-comp A is-segal-A y x y g f)
-            (Segal-comp A is-segal-A y x y h f)
+            (comp-Segal A is-segal-A y x y g f)
+            (comp-Segal A is-segal-A y x y h f)
             (id-arr A y)
-            (Segal-homotopy-postwhisker A is-segal-A y x y g h f
+            (homotopy-postwhisker-Segal A is-segal-A y x y g h f
                 (alternating-quintuple-concat (hom A y x)
-                g (Segal-comp A is-segal-A y y x (id-arr A y) g) -- a0 = g and a1 = g o id_y
-                (rev (hom A y x) (Segal-comp A is-segal-A y y x (id-arr A y) g) g (Segal-id-comp A is-segal-A y x g)) -- p1 = identity law
+                g (comp-Segal A is-segal-A y y x (id-arr A y) g) -- a0 = g and a1 = g o id_y
+                (rev (hom A y x) (comp-Segal A is-segal-A y y x (id-arr A y) g) g (id-comp-Segal A is-segal-A y x g)) -- p1 = identity law
 
-                (Segal-comp A is-segal-A y y x (Segal-comp A is-segal-A y x y h f) g) -- a2 = g o (f o h)
-                (Segal-homotopy-postwhisker A is-segal-A y y x                      -- p2 = postwhiskering
+                (comp-Segal A is-segal-A y y x (comp-Segal A is-segal-A y x y h f) g) -- a2 = g o (f o h)
+                (homotopy-postwhisker-Segal A is-segal-A y y x                      -- p2 = postwhiskering
         (id-arr A y)
-        (Segal-comp A is-segal-A y x y h f)
+        (comp-Segal A is-segal-A y x y h f)
         g
-        (rev (hom A y y) (Segal-comp A is-segal-A y x y h f) (id-arr A y) q)
+        (rev (hom A y y) (comp-Segal A is-segal-A y x y h f) (id-arr A y) q)
                 )
 
-                (Segal-comp A is-segal-A y x x h (Segal-comp A is-segal-A x y x f g)) -- a3 = (g o f) o h
-                (Segal-associativity extext A is-segal-A y x y x h f g)             -- p3 = associativity
+                (comp-Segal A is-segal-A y x x h (comp-Segal A is-segal-A x y x f g)) -- a3 = (g o f) o h
+                (associativity-Segal extext A is-segal-A y x y x h f g)             -- p3 = associativity
 
-                (Segal-comp A is-segal-A y x x h (id-arr A x)) -- a4 = id_x o h
-                (Segal-homotopy-prewhisker A is-segal-A y x x h -- p4 = prewhiskering
-                (Segal-comp A is-segal-A x y x f g)
+                (comp-Segal A is-segal-A y x x h (id-arr A x)) -- a4 = id_x o h
+                (homotopy-prewhisker-Segal A is-segal-A y x x h -- p4 = prewhiskering
+                (comp-Segal A is-segal-A x y x f g)
                 (id-arr A x)
                 p)
                 h -- a5 = h
-                (Segal-comp-id A is-segal-A y x h) -- p5 = connect through identity law
+                (comp-id-Segal A is-segal-A y x h) -- p5 = connect through identity law
                 )
                 )
             q
@@ -139,20 +139,20 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (g : hom A y x)
   (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) → has-retraction (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → has-retraction (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (Segal-postcomp A is-segal-A y x g z) ,
+    ( (postcomp-Segal A is-segal-A y x g z) ,
         \ k →
       (triple-concat
         (hom A z x) -- k is an arrow z → x
-        (Segal-comp A is-segal-A z y x (Segal-comp A is-segal-A z x y k f) g) -- g(fk)
-        (Segal-comp A is-segal-A z x x k (Segal-comp A is-segal-A x y x f g)) -- (gf)k
-        (Segal-comp A is-segal-A z x x k (id-arr A x)) -- id_x k
+        (comp-Segal A is-segal-A z y x (comp-Segal A is-segal-A z x y k f) g) -- g(fk)
+        (comp-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g)) -- (gf)k
+        (comp-Segal A is-segal-A z x x k (id-arr A x)) -- id_x k
         k --k
-      (Segal-associativity extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
-      (Segal-homotopy-prewhisker A is-segal-A z x x k (Segal-comp A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
-      (Segal-comp-id A is-segal-A z x k) -- id_x k = k
+      (associativity-Segal extext A is-segal-A z x y x k f g) -- g(fk) = (gf)k
+      (homotopy-prewhisker-Segal A is-segal-A z x x k (comp-Segal A is-segal-A x y x f g) (id-arr A x) gg)  -- (gf)k = id_x k from (gf) = id_x
+      (comp-id-Segal A is-segal-A z x k) -- id_x k = k
       )
   )
 
@@ -163,20 +163,20 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → has-section (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → has-section (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (Segal-postcomp A is-segal-A y x h z) ,
+    ( (postcomp-Segal A is-segal-A y x h z) ,
         \ k →
       (triple-concat
         (hom A z y) -- k is an arrow z to y
-        (Segal-comp A is-segal-A z x y (Segal-comp A is-segal-A z y x k h) f) -- f(hk)
-        (Segal-comp A is-segal-A z y y k (Segal-comp A is-segal-A y x y h f)) -- (fh)k
-        (Segal-comp A is-segal-A z y y k (id-arr A y)) -- id_y k
+        (comp-Segal A is-segal-A z x y (comp-Segal A is-segal-A z y x k h) f) -- f(hk)
+        (comp-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f)) -- (fh)k
+        (comp-Segal A is-segal-A z y y k (id-arr A y)) -- id_y k
         k --k
-      (Segal-associativity extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
-      (Segal-homotopy-prewhisker A is-segal-A z y y k (Segal-comp A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
-      (Segal-comp-id A is-segal-A z y k) -- id_y k = k
+      (associativity-Segal extext A is-segal-A z y x y k h f) -- f(hk) = (fh)k
+      (homotopy-prewhisker-Segal A is-segal-A z y y k (comp-Segal A is-segal-A y x y h f) (id-arr A y) hh)  -- (fh)k = id_y k from (fh) = id_y
+      (comp-id-Segal A is-segal-A z y k) -- id_y k = k
       )
   )
 
@@ -189,7 +189,7 @@ Some of the definitions in this file rely on extension extensionality:
   (gg : arrow-has-retraction A is-segal-A x y f g)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → is-equiv (hom A z x) (hom A z y) (Segal-postcomp A is-segal-A x y f z)
+  : (z : A) → is-equiv (hom A z x) (hom A z y) (postcomp-Segal A is-segal-A x y f z)
   :=
     \ z →
     ( (if-iso-then-postcomp-has-retraction A is-segal-A x y f g gg z) ,
@@ -202,25 +202,25 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → has-retraction (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → has-retraction (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (Segal-precomp A is-segal-A y x h z) ,
+    ( (precomp-Segal A is-segal-A y x h z) ,
         \ k →
       (triple-concat
         (hom A y z) -- k is an arrow y → z
-        (Segal-comp A is-segal-A y x z h (Segal-comp A is-segal-A x y z f k)) -- (kf)h
-        (Segal-comp A is-segal-A y y z (Segal-comp A is-segal-A y x y h f) k) -- k(fh)
-        (Segal-comp A is-segal-A y y z (id-arr A y) k) -- k id_y
+        (comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k)) -- (kf)h
+        (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k) -- k(fh)
+        (comp-Segal A is-segal-A y y z (id-arr A y) k) -- k id_y
         k --k
       (rev (hom A y z)
-          (Segal-comp A is-segal-A y y z (Segal-comp A is-segal-A y x y h f) k)
-          (Segal-comp A is-segal-A y x z h (Segal-comp A is-segal-A x y z f k))
-          (Segal-associativity extext A is-segal-A y x y z h f k)
+          (comp-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) k)
+          (comp-Segal A is-segal-A y x z h (comp-Segal A is-segal-A x y z f k))
+          (associativity-Segal extext A is-segal-A y x y z h f k)
       ) -- (kf)h = k(fh)
 
-      (Segal-homotopy-postwhisker A is-segal-A y y z (Segal-comp A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
-      (Segal-id-comp A is-segal-A y z k) -- k id_y = k
+      (homotopy-postwhisker-Segal A is-segal-A y y z (comp-Segal A is-segal-A y x y h f) (id-arr A y) k hh)  -- k(fh) = k id_y from (fh) = id_y
+      (id-comp-Segal A is-segal-A y z k) -- k id_y = k
       )
   )
 
@@ -231,24 +231,24 @@ Some of the definitions in this file rely on extension extensionality:
   (f : hom A x y)
   (g : hom A y x)
   (gg : arrow-has-retraction A is-segal-A x y f g)
-  : (z : A) → has-section (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → has-section (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
   :=
     \ z →
-    ( (Segal-precomp A is-segal-A y x g z) ,
+    ( (precomp-Segal A is-segal-A y x g z) ,
         \ k →
       (triple-concat
         (hom A x z) -- k is an arrow x → z
-        (Segal-comp A is-segal-A x y z f (Segal-comp A is-segal-A y x z g k)) -- (kg)f
-        (Segal-comp A is-segal-A x x z (Segal-comp A is-segal-A x y x f g) k) -- k(gf)
-        (Segal-comp A is-segal-A x x z (id-arr A x) k) -- k id_x
+        (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k)) -- (kg)f
+        (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k) -- k(gf)
+        (comp-Segal A is-segal-A x x z (id-arr A x) k) -- k id_x
         k --k
       (rev (hom A x z)
-          (Segal-comp A is-segal-A x x z (Segal-comp A is-segal-A x y x f g) k)
-          (Segal-comp A is-segal-A x y z f (Segal-comp A is-segal-A y x z g k))
-          (Segal-associativity extext A is-segal-A x y x z f g k)
+          (comp-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) k)
+          (comp-Segal A is-segal-A x y z f (comp-Segal A is-segal-A y x z g k))
+          (associativity-Segal extext A is-segal-A x y x z f g k)
       ) -- (kg)f = k(gf)
-      (Segal-homotopy-postwhisker A is-segal-A x x z (Segal-comp A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
-      (Segal-id-comp A is-segal-A x z k) -- k id_x = k
+      (homotopy-postwhisker-Segal A is-segal-A x x z (comp-Segal A is-segal-A x y x f g) (id-arr A x) k gg)  -- k(gf) = k id_x from (gf) = id_x
+      (id-comp-Segal A is-segal-A x z k) -- k id_x = k
       )
   )
 
@@ -261,7 +261,7 @@ Some of the definitions in this file rely on extension extensionality:
   (gg : arrow-has-retraction A is-segal-A x y f g)
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
-  : (z : A) → is-equiv (hom A y z) (hom A x z) (Segal-precomp A is-segal-A x y f z)
+  : (z : A) → is-equiv (hom A y z) (hom A x z) (precomp-Segal A is-segal-A x y f z)
   :=
     \ z →
     ( (if-iso-then-precomp-has-retraction A is-segal-A x y f h hh z) ,
@@ -277,7 +277,7 @@ Some of the definitions in this file rely on extension extensionality:
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
   : is-contr (arrow-Retraction A is-segal-A x y f)
-  := (is-contr-map-is-equiv (hom A y x) (hom A x x) (Segal-precomp A is-segal-A x y f x)
+  := (is-contr-map-is-equiv (hom A y x) (hom A x x) (precomp-Segal A is-segal-A x y f x)
                           (if-iso-then-precomp-is-equiv A is-segal-A x y f g gg h hh x))
       (id-arr A x)
 
@@ -291,7 +291,7 @@ Some of the definitions in this file rely on extension extensionality:
   (h : hom A y x)
   (hh : arrow-has-section A is-segal-A x y f h)
   : is-contr (arrow-Section A is-segal-A x y f)
-  := (is-contr-map-is-equiv (hom A y x) (hom A y y) (Segal-postcomp A is-segal-A x y f y)
+  := (is-contr-map-is-equiv (hom A y x) (hom A y y) (postcomp-Segal A is-segal-A x y f y)
                           (if-iso-then-postcomp-is-equiv A is-segal-A x y f g gg h hh y))
       (id-arr A y)
 
@@ -332,11 +332,11 @@ Some of the definitions in this file rely on extension extensionality:
     (
     (
       (id-arr A x) ,
-      (Segal-id-comp A is-segal-A x x (id-arr A x))
+      (id-comp-Segal A is-segal-A x x (id-arr A x))
     ) ,
     (
       (id-arr A x) ,
-      (Segal-id-comp A is-segal-A x x (id-arr A x))
+      (id-comp-Segal A is-segal-A x x (id-arr A x))
     )
       )
   )
@@ -371,7 +371,7 @@ In a Segal type, initial objects are isomorphic.
           contractible-connecting-htpy
             ( hom A a a)
             ( ainitial a)
-            ( Segal-comp A is-segal-A a b a
+            ( comp-Segal A is-segal-A a b a
               ( first (ainitial b))
               ( first (binitial a)))
             ( id-arr A a)) ,
@@ -379,7 +379,7 @@ In a Segal type, initial objects are isomorphic.
           contractible-connecting-htpy
             ( hom A b b)
             ( binitial b)
-            ( Segal-comp A is-segal-A b a b
+            ( comp-Segal A is-segal-A b a b
               ( first (binitial a))
               ( first (ainitial b)))
             ( id-arr A b))))
@@ -402,7 +402,7 @@ In a Segal type, final objects are isomorphic.
           contractible-connecting-htpy
             ( hom A a a)
             ( afinal a)
-            ( Segal-comp A is-segal-A a b a
+            ( comp-Segal A is-segal-A a b a
               ( first (bfinal a))
               ( first (afinal b)))
             ( id-arr A a)) ,
@@ -410,7 +410,7 @@ In a Segal type, final objects are isomorphic.
           contractible-connecting-htpy
             ( hom A b b)
             ( bfinal b)
-            ( Segal-comp A is-segal-A b a b
+            ( comp-Segal A is-segal-A b a b
               ( first (afinal b))
               ( first (bfinal a)))
             ( id-arr A b))))

--- a/src/simplicial-hott/10-rezk-types.rzk.md
+++ b/src/simplicial-hott/10-rezk-types.rzk.md
@@ -381,7 +381,7 @@ Some of the definitions in this file rely on extension extensionality:
       )
   )
 
-#def iso-id
+#def iso-eq
   ( A : U)
   ( is-segal-A : is-segal A)
   ( x y : A)
@@ -402,7 +402,7 @@ Some of the definitions in this file rely on extension extensionality:
   :=
     Σ ( is-segal-A : is-segal A) ,
       (x : A) → (y : A) →
-        is-equiv (x = y) (Iso A is-segal-A x y) (iso-id A is-segal-A x y)
+        is-equiv (x = y) (Iso A is-segal-A x y) (iso-eq A is-segal-A x y)
 ```
 
 ## Uniqueness of initial and final objects

--- a/src/simplicial-hott/12-cocartesian.rzk.md
+++ b/src/simplicial-hott/12-cocartesian.rzk.md
@@ -21,7 +21,6 @@ This is a literate `rzk` file:
 - `4-extension-types.md` — We use the fubini theorem and extension
   extensionality.
 - `5-segal-types.md` - We make heavy use of the notion of Segal types
-- `8-covariant.md` - We use covariant type families.
 - `10-rezk-types.md`- We use Rezk types.
 
 ## (Iso-)Inner families
@@ -31,23 +30,23 @@ future, hopefully, these can be replaced by instances of orthogonal and LARI
 families.
 
 ```rzk
-#def totalType
-  (B : U)
-  (P : B → U)
+#def is-inner-fam
+  ( B : U)
+  ( P : B → U)
   : U
-  := Σ (b : B) , P b
+  :=
+    product
+    ( product (is-segal B) (is-segal (Σ (b : B) , P b)))
+    ( (b : B) → (is-segal (P b)))
 
-#def isInnerFam
-  (B : U)
-  (P : B → U)
+#def is-isoinner-fam
+  ( B : U)
+  ( P : B → U)
   : U
-  := product (product (is-segal B) (is-segal (totalType B P))) ((b : B) → (is-segal (P b)))
-
-#def is-isoInnerFam
-  (B : U)
-  (P : B → U)
-  : U
-  := product (product (is-rezk B) (is-rezk (totalType B P))) ((b : B) → (is-segal (P b)))
+  :=
+    product
+    ( product (is-rezk B) (is-rezk (Σ (b : B) , P b)))
+    ( (b : B) → (is-segal (P b)))
 ```
 
 ## Cocartesian arrows
@@ -57,23 +56,21 @@ cocartesian. This is an alternative version using unpacked extension types, as
 this is preferred for usage.
 
 ```rzk title="BW23, Definition 5.1.1"
-#def isCocartArr
-  (B : U)
-  (b b' : B)
-  (u : hom B b b')
-  (P : B → U)
-  (e : P b)
-  (e' : P b')
-  (f : dhom B b b' u P e e')
+#def is-cocart-arrow
+  ( B : U)
+  ( b b' : B)
+  ( u : hom B b b')
+  ( P : B → U)
+  ( e : P b)
+  ( e' : P b')
+  ( f : dhom B b b' u P e e')
   : U
-  := (b'' : B)
-  → (v : hom B b' b'')
-  → (w : hom B b b'')
-  → (sigma : hom2 B b b' b'' u v w)
-  → (e'' : P b'')
-  → (h : dhom B b b'' w P e e'')
-  → is-contr
-      ( Σ ( g : dhom B b' b'' v P e' e'') ,
+  :=
+    (b'' : B) → (v : hom B b' b'') → (w : hom B b b'') →
+      (sigma : hom2 B b b' b'' u v w) → (e'' : P b'') →
+      (h : dhom B b b'' w P e e'') →
+      is-contr
+        ( Σ ( g : dhom B b' b'' v P e' e'') ,
           ( dhom2 B b b' b'' u v w sigma P e e' e'' f g h))
 ```
 
@@ -83,22 +80,14 @@ The following is the type of cocartesian lifts of a fixed arrow in the base with
 a given starting point in the fiber.
 
 ```rzk title="BW23, Definition 5.1.2"
-#def CocartLift
-    (B : U)
-    (b b' : B)
-    (u : hom B b b')
-    (P : B → U)
-    (e : P b)
-    : U
-    := Σ (e' : P b') , Σ (f : dhom B b b' u P e e') , isCocartArr B b b' u P e e' f
-```
-
-#def cocart-is-prop (B : U) (Bis-rezk : is-rezk B) (b b' : B) (u : hom B b b')
-(P : B → U) (TPis-rezk : is-rezk (totalType B P)) (PisfibRezk : (b : B) →
-is-rezk (P b)) (e : P b) (e' : P b') (f : dhom B b b' u P e e') (fiscocart :
-isCocartArr B b b' u P e e' f) : is-contr (CocartLift B b b' u P e) := ( (e' , f
-, fiscocart) , \ d → \ g →
-
-```
-
+#def cocart-lift
+  ( B : U)
+  ( b b' : B)
+  ( u : hom B b b')
+  ( P : B → U)
+  ( e : P b)
+  : U
+  :=
+    Σ (e' : P b') ,
+      Σ (f : dhom B b b' u P e e') , is-cocart-arrow B b b' u P e e' f
 ```


### PR DESCRIPTION
Notes:
- `emb-is-equiv` was already proven (with a different name) in `04-half-adjoint-equivalences`, so I removed the proof in `08-families-of-maps`
- The stuff about `pullback-homotopy` in `08-families-of-maps` doesn't seem to be used anywhere, and isn't it just a special case of the fact that `transport` is an equivalence of fibers?

Builds on #39 and #40, progresses #14.