### PR TITLE
Use mkdocs-plugin-rzk to anchor definitions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,3 +87,6 @@ extra_javascript:
 
 plugins:
   - search
+  - rzk:
+      render_svg: false
+      anchor_definitions: true


### PR DESCRIPTION
With [`mkdocs-plugin-rzk` extension](https://github.com/rzk-lang/mkdocs-plugin-rzk), you can now click on the name of a definition to get a link to it (useful to reference specific definitions):

<img width="456" alt="Screenshot 2023-09-06 at 12 10 56" src="https://github.com/emilyriehl/yoneda/assets/686582/30a724f5-d4b3-446c-ada4-a73193f432b1">
