### PR TITLE
Remove malicious polyfill.io dependency in the docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,7 +100,6 @@ theme:
 
 extra_javascript:
   - javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
Removes the `polyfill.io` script from the documentation site. The `cdn.polyfill.io` /
`polyfill.io` service changed ownership in mid-2024 and began serving malicious code to
visitors, so any page loading it is a supply-chain risk. This drops the single reference
from `extra_javascript` in `mkdocs.yml`:

```diff
 extra_javascript:
   - javascript/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
```

The polyfill only backfilled ES6 features for legacy browsers. All browsers MathJax 3
supports already ship ES6 natively, so the polyfill is dead weight and math rendering is
unaffected. The remaining MathJax setup (javascript/mathjax.js + the jsdelivr
tex-mml-chtml.js bundle) is untouched.

The already-published `gh-pages` site — including the historic directories
(`CPP-2024`, `arXiv-v1`, `master`) that a fresh deploy would not regenerate —
has already been scrubbed of the injected `<script src="https://polyfill.io/...">` tags, so the live site is clean. This PR keeps it that way by preventing the line from being
re-injected on the next docs deploy.

This follows the same fix applied across the rzk ecosystem, originally rzk-lang/rzk#231.